### PR TITLE
feat: Broker Ω with guarded Trading 212 execution

### DIFF
--- a/.github/workflows/mobile-ci-eas-apk.yml
+++ b/.github/workflows/mobile-ci-eas-apk.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'mobile/**'
+      - 'api/**'
+      - 'render.yaml'
       - '.github/workflows/mobile-ci-eas-apk.yml'
   pull_request:
     branches:
@@ -17,6 +19,8 @@ on:
       - synchronize
     paths:
       - 'mobile/**'
+      - 'api/**'
+      - 'render.yaml'
       - '.github/workflows/mobile-ci-eas-apk.yml'
   workflow_dispatch:
     inputs:
@@ -31,6 +35,71 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  api-certification:
+    name: API Syntax & Broker Guardrail Verification
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install API dependencies
+        run: pip install -r api/requirements.txt
+
+      - name: Compile API
+        run: python -m compileall -q api
+
+      - name: Verify Broker Ω fail-closed guardrails
+        shell: bash
+        run: |
+          python - <<'PY'
+          from fastapi.testclient import TestClient
+          import api.main as main
+
+          client = TestClient(main.app)
+
+          status = client.get('/v1/broker/status')
+          assert status.status_code == 200, status.text
+          payload = status.json()
+          assert payload['mode'] == 'PAPER', payload
+          assert payload['configured'] is False, payload
+
+          protected = client.get('/v1/broker/account')
+          assert protected.status_code == 503, protected.text
+
+          main.TRADING212_API_KEY = 'ci-key'
+          main.TRADING212_API_SECRET = 'ci-secret'
+          main.ATLAS_BROKER_CONTROL_TOKEN = 'ci-control'
+          main.TRADING212_ENV = 'live'
+          main.TRADING212_LIVE_TRADING_ENABLED = False
+
+          live_locked = client.post(
+              '/v1/broker/orders/market',
+              headers={'X-Atlas-Broker-Token': 'ci-control'},
+              json={'ticker': 'AAPL_US_EQ', 'quantity': 0.01, 'extended_hours': False, 'confirmation': 'EXECUTE_LIVE'},
+          )
+          assert live_locked.status_code == 403, live_locked.text
+
+          main.TRADING212_ENV = 'demo'
+          wrong_confirmation = client.post(
+              '/v1/broker/orders/market',
+              headers={'X-Atlas-Broker-Token': 'ci-control'},
+              json={'ticker': 'AAPL_US_EQ', 'quantity': 0.01, 'extended_hours': False, 'confirmation': 'EXECUTE_LIVE'},
+          )
+          assert wrong_confirmation.status_code == 400, wrong_confirmation.text
+
+          unauthorized = client.get('/v1/broker/positions', headers={'X-Atlas-Broker-Token': 'wrong'})
+          assert unauthorized.status_code == 401, unauthorized.text
+          print('Broker Ω guardrails: PASS')
+          PY
+
   typecheck-and-schema:
     name: TypeScript Check & Schema Verification
     runs-on: ubuntu-latest
@@ -57,7 +126,9 @@ jobs:
 
   build-candidate-apk:
     name: Build Android Candidate APK
-    needs: typecheck-and-schema
+    needs:
+      - api-certification
+      - typecheck-and-schema
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/api/main.py
+++ b/api/main.py
@@ -1,21 +1,42 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import hmac
 import os
+import time
 from datetime import date, timedelta
-from typing import Any
+from typing import Any, Literal
 
 import httpx
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, Header, HTTPException, Query
+from pydantic import BaseModel, Field
 
 FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
 FINNHUB_TOKEN = os.getenv("FINNHUB_TOKEN", "").strip()
 
+TRADING212_ENV = os.getenv("TRADING212_ENV", "demo").strip().lower()
+TRADING212_API_KEY = os.getenv("TRADING212_API_KEY", "").strip()
+TRADING212_API_SECRET = os.getenv("TRADING212_API_SECRET", "").strip()
+TRADING212_LIVE_TRADING_ENABLED = os.getenv("TRADING212_LIVE_TRADING_ENABLED", "false").strip().lower() == "true"
+ATLAS_BROKER_CONTROL_TOKEN = os.getenv("ATLAS_BROKER_CONTROL_TOKEN", "").strip()
+TRADING212_BASE_URL = "https://live.trading212.com/api/v0" if TRADING212_ENV == "live" else "https://demo.trading212.com/api/v0"
+
+_INSTRUMENT_CACHE: tuple[float, list[dict[str, Any]]] = (0.0, [])
+_INSTRUMENT_CACHE_TTL_SECONDS = 900
+
 app = FastAPI(
     title="ATLAS Ω API",
-    version="0.2.0",
-    description="Online ticker-first market and company intelligence bridge for ATLAS Ω Mobile.",
+    version="0.3.0",
+    description="Ticker-first intelligence bridge plus guarded Trading 212 broker adapter for ATLAS Ω Mobile.",
 )
+
+
+class MarketOrderRequest(BaseModel):
+    ticker: str = Field(min_length=1, max_length=64)
+    quantity: float
+    extended_hours: bool = False
+    confirmation: Literal["EXECUTE_DEMO", "EXECUTE_LIVE"]
 
 
 def _require_token() -> str:
@@ -29,6 +50,22 @@ def _symbol(value: str) -> str:
     if not normalized or len(normalized) > 20:
         raise HTTPException(status_code=400, detail="valid symbol is required")
     return normalized
+
+
+def _broker_configured() -> bool:
+    return bool(TRADING212_API_KEY and TRADING212_API_SECRET and ATLAS_BROKER_CONTROL_TOKEN)
+
+
+def _require_broker_control(x_atlas_broker_token: str | None) -> None:
+    if not _broker_configured():
+        raise HTTPException(status_code=503, detail="Trading 212 broker is not fully configured")
+    if not x_atlas_broker_token or not hmac.compare_digest(x_atlas_broker_token, ATLAS_BROKER_CONTROL_TOKEN):
+        raise HTTPException(status_code=401, detail="Invalid ATLAS broker control token")
+
+
+def _trading212_auth_header() -> str:
+    raw = f"{TRADING212_API_KEY}:{TRADING212_API_SECRET}".encode("utf-8")
+    return f"Basic {base64.b64encode(raw).decode('ascii')}"
 
 
 async def _finnhub_get(path: str, params: dict[str, Any]) -> Any:
@@ -57,6 +94,40 @@ async def _optional(path: str, params: dict[str, Any]) -> tuple[Any, str]:
         return None, f"UNAVAILABLE:{exc.status_code}"
 
 
+async def _trading212_request(method: str, path: str, *, json: dict[str, Any] | None = None, params: dict[str, Any] | None = None) -> Any:
+    if not TRADING212_API_KEY or not TRADING212_API_SECRET:
+        raise HTTPException(status_code=503, detail="Trading 212 credentials are not configured")
+    headers = {
+        "Authorization": _trading212_auth_header(),
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    timeout = httpx.Timeout(20.0, connect=10.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.request(method, f"{TRADING212_BASE_URL}{path}", headers=headers, json=json, params=params)
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"Trading 212 connection failed: {exc.__class__.__name__}") from exc
+    if response.status_code == 429:
+        reset = response.headers.get("x-ratelimit-reset")
+        detail = "Trading 212 rate limit reached"
+        if reset:
+            detail += f"; reset={reset}"
+        raise HTTPException(status_code=429, detail=detail)
+    if response.status_code >= 400:
+        try:
+            upstream = response.json()
+        except ValueError:
+            upstream = response.text[:300]
+        raise HTTPException(status_code=response.status_code, detail={"provider": "Trading212", "upstream": upstream})
+    if response.status_code == 204 or not response.content:
+        return {"ok": True}
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail="Trading 212 returned a non-JSON response") from exc
+
+
 def _clean_metric(raw: Any) -> dict[str, float | int | str | None]:
     if not isinstance(raw, dict):
         return {}
@@ -68,14 +139,40 @@ def _clean_metric(raw: Any) -> dict[str, float | int | str | None]:
     return result
 
 
+async def _get_instruments_cached() -> list[dict[str, Any]]:
+    global _INSTRUMENT_CACHE
+    cached_at, items = _INSTRUMENT_CACHE
+    if items and time.time() - cached_at < _INSTRUMENT_CACHE_TTL_SECONDS:
+        return items
+    payload = await _trading212_request("GET", "/equity/metadata/instruments")
+    instruments = payload if isinstance(payload, list) else []
+    instruments = [item for item in instruments if isinstance(item, dict)]
+    _INSTRUMENT_CACHE = (time.time(), instruments)
+    return instruments
+
+
 @app.get("/")
 async def root() -> dict[str, Any]:
-    return {"service": "ATLAS Ω API", "status": "online", "version": "0.2.0", "finnhub_configured": bool(FINNHUB_TOKEN)}
+    return {
+        "service": "ATLAS Ω API",
+        "status": "online",
+        "version": "0.3.0",
+        "finnhub_configured": bool(FINNHUB_TOKEN),
+        "broker": {"provider": "Trading212", "environment": TRADING212_ENV, "configured": _broker_configured()},
+    }
 
 
 @app.get("/health")
 async def health() -> dict[str, Any]:
-    return {"ok": True, "service": "atlas-omega-api", "version": "0.2.0", "finnhub_configured": bool(FINNHUB_TOKEN)}
+    return {
+        "ok": True,
+        "service": "atlas-omega-api",
+        "version": "0.3.0",
+        "finnhub_configured": bool(FINNHUB_TOKEN),
+        "broker_configured": _broker_configured(),
+        "broker_environment": TRADING212_ENV,
+        "broker_live_enabled": TRADING212_LIVE_TRADING_ENABLED,
+    }
 
 
 @app.get("/v1/quote/{symbol}")
@@ -132,12 +229,89 @@ async def company(symbol: str) -> dict[str, Any]:
 
 
 @app.get("/v1/discovery")
-async def discovery(
-    q: str = Query(..., min_length=1, max_length=120),
-    exchange: str | None = Query(default=None, max_length=20),
-) -> dict[str, Any]:
+async def discovery(q: str = Query(..., min_length=1, max_length=120), exchange: str | None = Query(default=None, max_length=20)) -> dict[str, Any]:
     params: dict[str, Any] = {"q": q.strip()}
     if exchange:
         params["exchange"] = exchange.strip().upper()
     data = await _finnhub_get("/search", params)
     return {"query": q.strip(), "exchange": exchange, "source": "Finnhub", "data": data}
+
+
+@app.get("/v1/broker/status")
+async def broker_status() -> dict[str, Any]:
+    return {
+        "provider": "Trading212",
+        "environment": TRADING212_ENV,
+        "configured": _broker_configured(),
+        "liveTradingEnabled": TRADING212_LIVE_TRADING_ENABLED,
+        "mode": "LIVE" if TRADING212_ENV == "live" else "PAPER",
+        "guardrail": "Live orders require server-side enablement plus an explicit EXECUTE_LIVE confirmation on every order.",
+    }
+
+
+@app.get("/v1/broker/account")
+async def broker_account(x_atlas_broker_token: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_broker_control(x_atlas_broker_token)
+    data = await _trading212_request("GET", "/equity/account/summary")
+    return {"provider": "Trading212", "environment": TRADING212_ENV, "data": data}
+
+
+@app.get("/v1/broker/positions")
+async def broker_positions(x_atlas_broker_token: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_broker_control(x_atlas_broker_token)
+    data = await _trading212_request("GET", "/equity/positions")
+    return {"provider": "Trading212", "environment": TRADING212_ENV, "data": data}
+
+
+@app.get("/v1/broker/orders")
+async def broker_orders(x_atlas_broker_token: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_broker_control(x_atlas_broker_token)
+    data = await _trading212_request("GET", "/equity/orders")
+    return {"provider": "Trading212", "environment": TRADING212_ENV, "data": data}
+
+
+@app.get("/v1/broker/instruments/search")
+async def broker_instruments_search(q: str = Query(..., min_length=1, max_length=80), x_atlas_broker_token: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_broker_control(x_atlas_broker_token)
+    needle = q.strip().upper()
+    instruments = await _get_instruments_cached()
+    matches: list[dict[str, Any]] = []
+    for item in instruments:
+        haystack = " ".join(str(item.get(key, "")) for key in ("ticker", "name", "shortName", "isin", "currencyCode")).upper()
+        if needle in haystack:
+            matches.append(item)
+        if len(matches) >= 25:
+            break
+    return {"query": q.strip(), "count": len(matches), "items": matches}
+
+
+@app.post("/v1/broker/orders/market")
+async def broker_market_order(order: MarketOrderRequest, x_atlas_broker_token: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_broker_control(x_atlas_broker_token)
+    ticker = order.ticker.strip()
+    if not ticker or order.quantity == 0:
+        raise HTTPException(status_code=400, detail="ticker and non-zero quantity are required")
+    expected = "EXECUTE_LIVE" if TRADING212_ENV == "live" else "EXECUTE_DEMO"
+    if order.confirmation != expected:
+        raise HTTPException(status_code=400, detail=f"confirmation must be {expected} for this environment")
+    if TRADING212_ENV == "live" and not TRADING212_LIVE_TRADING_ENABLED:
+        raise HTTPException(status_code=403, detail="Live trading is locked. Set TRADING212_LIVE_TRADING_ENABLED=true server-side only after paper validation.")
+    data = await _trading212_request(
+        "POST",
+        "/equity/orders/market",
+        json={"ticker": ticker, "quantity": order.quantity, "extendedHours": order.extended_hours},
+    )
+    return {
+        "provider": "Trading212",
+        "environment": TRADING212_ENV,
+        "mode": "LIVE" if TRADING212_ENV == "live" else "PAPER",
+        "order": data,
+        "audit": {"requestedTicker": ticker, "requestedQuantity": order.quantity, "extendedHours": order.extended_hours},
+    }
+
+
+@app.delete("/v1/broker/orders/{order_id}")
+async def broker_cancel_order(order_id: int, x_atlas_broker_token: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_broker_control(x_atlas_broker_token)
+    data = await _trading212_request("DELETE", f"/equity/orders/{order_id}")
+    return {"provider": "Trading212", "environment": TRADING212_ENV, "orderId": order_id, "result": data}

--- a/docs/BROKER_OMEGA_TRADING212.md
+++ b/docs/BROKER_OMEGA_TRADING212.md
@@ -1,0 +1,70 @@
+# Broker Ω — Trading 212
+
+ATLAS Ω keeps broker credentials server-side. The Android APK never contains the Trading 212 API key or secret.
+
+## Default mode
+
+The repository defaults to Trading 212 **demo/paper**:
+
+- `TRADING212_ENV=demo`
+- `TRADING212_LIVE_TRADING_ENABLED=false`
+
+Live execution is therefore fail-closed.
+
+## Required Render secrets
+
+Configure these as server-side secrets in Render:
+
+- `TRADING212_API_KEY` — Trading 212 API key.
+- `TRADING212_API_SECRET` — Trading 212 API secret.
+- `ATLAS_BROKER_CONTROL_TOKEN` — a long random token used by the mobile Broker Ω screen to authorize private broker calls.
+
+Do not put any of these values in Git, Expo public environment variables, screenshots, logs, or the APK.
+
+## Paper activation
+
+1. Create Trading 212 demo API credentials with the minimum permissions needed.
+2. Set `TRADING212_API_KEY`, `TRADING212_API_SECRET`, and `ATLAS_BROKER_CONTROL_TOKEN` in Render.
+3. Keep `TRADING212_ENV=demo` and `TRADING212_LIVE_TRADING_ENABLED=false`.
+4. Deploy the API.
+5. Open Broker Ω in the Android app.
+6. Enter the control token and sync account/positions/orders.
+7. Search the Trading 212 instrument metadata and select its exact T212 ticker, e.g. `AAPL_US_EQ`.
+8. Test small paper orders only.
+
+## Live activation
+
+Do this only after paper validation:
+
+1. Replace the server credentials with live Trading 212 credentials.
+2. Set `TRADING212_ENV=live`.
+3. Verify account and positions while `TRADING212_LIVE_TRADING_ENABLED=false`.
+4. When deliberately ready to permit real execution, set `TRADING212_LIVE_TRADING_ENABLED=true` server-side.
+5. The API still requires `EXECUTE_LIVE` confirmation on every market-order request.
+
+## API endpoints
+
+Public status only:
+
+- `GET /v1/broker/status`
+
+Control-token protected:
+
+- `GET /v1/broker/account`
+- `GET /v1/broker/positions`
+- `GET /v1/broker/orders`
+- `GET /v1/broker/instruments/search?q=...`
+- `POST /v1/broker/orders/market`
+- `DELETE /v1/broker/orders/{order_id}`
+
+Protected calls require the `X-Atlas-Broker-Token` header.
+
+## Guardrails
+
+- Trading 212 credentials never travel to the mobile client.
+- Demo is the repository default.
+- Live is disabled independently of environment selection.
+- A live market order is rejected unless both the server flag is enabled and the request confirms `EXECUTE_LIVE`.
+- Zero-quantity orders are rejected.
+- Trading 212 upstream errors and rate limits are surfaced rather than silently retried, reducing duplicate-order risk.
+- Market orders are not idempotent in the Trading 212 beta API; callers must not blindly retry a failed POST.

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -65,6 +65,7 @@ export default function RootLayout() {
         <Stack.Screen name="risk" />
         <Stack.Screen name="catalysts" />
         <Stack.Screen name="news" />
+        <Stack.Screen name="broker" />
       </Stack>
     </>
   );

--- a/mobile/app/broker.tsx
+++ b/mobile/app/broker.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { AtlasOnlineApi, BrokerStatus } from '../core/api/atlasOnlineApi';
+
+function pretty(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export default function BrokerScreen() {
+  const router = useRouter();
+  const [status, setStatus] = useState<BrokerStatus | null>(null);
+  const [controlToken, setControlToken] = useState('');
+  const [account, setAccount] = useState<unknown>(null);
+  const [positions, setPositions] = useState<unknown>(null);
+  const [orders, setOrders] = useState<unknown>(null);
+  const [query, setQuery] = useState('AAPL');
+  const [instruments, setInstruments] = useState<Array<Record<string, unknown>>>([]);
+  const [ticker, setTicker] = useState('');
+  const [quantity, setQuantity] = useState('0.01');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    void AtlasOnlineApi.brokerStatus().then(setStatus).catch((error) => setMessage(error instanceof Error ? error.message : String(error)));
+  }, []);
+
+  const confirmation = status?.mode === 'LIVE' ? 'EXECUTE_LIVE' : 'EXECUTE_DEMO';
+  const liveLocked = status?.mode === 'LIVE' && !status.liveTradingEnabled;
+  const canUsePrivate = Boolean(controlToken.trim() && status?.configured);
+  const parsedQuantity = useMemo(() => Number(quantity.replace(',', '.')), [quantity]);
+
+  async function refreshPrivate() {
+    if (!canUsePrivate) return;
+    setBusy(true);
+    setMessage('');
+    try {
+      const [accountResult, positionResult, orderResult] = await Promise.all([
+        AtlasOnlineApi.brokerAccount(controlToken),
+        AtlasOnlineApi.brokerPositions(controlToken),
+        AtlasOnlineApi.brokerOrders(controlToken),
+      ]);
+      setAccount(accountResult.data);
+      setPositions(positionResult.data);
+      setOrders(orderResult.data);
+      setMessage('Cuenta Trading 212 sincronizada.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function searchInstrument() {
+    if (!canUsePrivate || !query.trim()) return;
+    setBusy(true);
+    setMessage('');
+    try {
+      const result = await AtlasOnlineApi.brokerInstrumentSearch(query, controlToken);
+      setInstruments(result.items);
+      setMessage(`${result.count} instrumentos encontrados.`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function placeOrder() {
+    if (!canUsePrivate || !ticker.trim() || !Number.isFinite(parsedQuantity) || parsedQuantity === 0 || !status) return;
+    setBusy(true);
+    setMessage('');
+    try {
+      const result = await AtlasOnlineApi.brokerMarketOrder({
+        ticker: ticker.trim(),
+        quantity: parsedQuantity,
+        extended_hours: false,
+        confirmation,
+      }, controlToken);
+      setMessage(`${status.mode} order accepted: ${pretty(result)}`);
+      await refreshPrivate();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} style={styles.back}><Text style={styles.backText}>‹</Text></Pressable>
+        <View><Text style={styles.brand}>BROKER Ω</Text><Text style={styles.subbrand}>TRADING 212</Text></View>
+      </View>
+
+      <View style={[styles.card, status?.mode === 'LIVE' ? styles.liveCard : styles.paperCard]}>
+        <Text style={styles.label}>ESTADO</Text>
+        <Text style={styles.big}>{status ? `${status.mode} · ${status.environment.toUpperCase()}` : 'CARGANDO…'}</Text>
+        <Text style={styles.muted}>{status?.configured ? 'Backend configurado' : 'Faltan credenciales/seguridad en el backend'}</Text>
+        {liveLocked ? <Text style={styles.warning}>LIVE bloqueado por servidor. No puede enviar órdenes reales.</Text> : null}
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.label}>CONTROL TOKEN</Text>
+        <TextInput
+          value={controlToken}
+          onChangeText={setControlToken}
+          placeholder="Token privado del Broker Ω"
+          placeholderTextColor="#526170"
+          secureTextEntry
+          autoCapitalize="none"
+          style={styles.input}
+        />
+        <Text style={styles.small}>El token no está incluido en el APK. Debe coincidir con ATLAS_BROKER_CONTROL_TOKEN del servidor.</Text>
+        <Pressable disabled={!canUsePrivate || busy} onPress={refreshPrivate} style={[styles.button, (!canUsePrivate || busy) && styles.disabled]}>
+          <Text style={styles.buttonText}>SINCRONIZAR CUENTA</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.label}>BUSCAR INSTRUMENTO T212</Text>
+        <TextInput value={query} onChangeText={setQuery} autoCapitalize="characters" style={styles.input} />
+        <Pressable disabled={!canUsePrivate || busy} onPress={searchInstrument} style={[styles.button, (!canUsePrivate || busy) && styles.disabled]}>
+          <Text style={styles.buttonText}>BUSCAR</Text>
+        </Pressable>
+        {instruments.map((item, index) => {
+          const itemTicker = String(item.ticker || '');
+          return (
+            <Pressable key={`${itemTicker}-${index}`} onPress={() => setTicker(itemTicker)} style={styles.instrument}>
+              <Text style={styles.instrumentTicker}>{itemTicker || '—'}</Text>
+              <Text style={styles.instrumentName}>{String(item.name || item.shortName || '')}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View style={[styles.card, styles.orderCard]}>
+        <Text style={styles.label}>ORDEN MARKET</Text>
+        <TextInput value={ticker} onChangeText={setTicker} placeholder="AAPL_US_EQ" placeholderTextColor="#526170" autoCapitalize="characters" style={styles.input} />
+        <TextInput value={quantity} onChangeText={setQuantity} placeholder="0.01" placeholderTextColor="#526170" keyboardType="decimal-pad" style={styles.input} />
+        <Text style={styles.small}>Cantidad positiva = compra. Cantidad negativa = venta. La API de Trading 212 usa cantidad de acciones, no importe monetario.</Text>
+        <Text style={styles.confirm}>Confirmación automática del entorno: {confirmation}</Text>
+        <Pressable disabled={!canUsePrivate || busy || liveLocked || !ticker.trim() || !Number.isFinite(parsedQuantity) || parsedQuantity === 0} onPress={placeOrder} style={[styles.execute, (!canUsePrivate || busy || liveLocked) && styles.disabled]}>
+          <Text style={styles.executeText}>{status?.mode === 'LIVE' ? 'EJECUTAR ORDEN REAL' : 'EJECUTAR PAPER ORDER'}</Text>
+        </Pressable>
+      </View>
+
+      {message ? <View style={styles.message}><Text style={styles.messageText}>{message}</Text></View> : null}
+
+      <View style={styles.card}><Text style={styles.label}>CUENTA</Text><Text style={styles.json}>{account ? pretty(account) : 'Sin sincronizar'}</Text></View>
+      <View style={styles.card}><Text style={styles.label}>POSICIONES</Text><Text style={styles.json}>{positions ? pretty(positions) : 'Sin sincronizar'}</Text></View>
+      <View style={styles.card}><Text style={styles.label}>ÓRDENES PENDIENTES</Text><Text style={styles.json}>{orders ? pretty(orders) : 'Sin sincronizar'}</Text></View>
+
+      <View style={styles.guardrail}>
+        <Text style={styles.guardrailTitle}>GUARDRAIL Ω</Text>
+        <Text style={styles.guardrailText}>La app no contiene las claves de Trading 212. Las credenciales viven en el backend. LIVE requiere una activación explícita del servidor y una confirmación específica en cada orden.</Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#070b10' },
+  content: { padding: 18, paddingBottom: 70, gap: 14 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 4 },
+  back: { width: 42, height: 42, borderRadius: 12, backgroundColor: '#111922', alignItems: 'center', justifyContent: 'center' },
+  backText: { color: '#b8cad9', fontSize: 30, lineHeight: 32 },
+  brand: { color: '#fff', fontSize: 24, fontWeight: '900', letterSpacing: 1.2 },
+  subbrand: { color: '#60778c', fontSize: 9, fontWeight: '900', letterSpacing: 1.5 },
+  card: { backgroundColor: '#0e151d', borderWidth: 1, borderColor: '#20303f', borderRadius: 16, padding: 15, gap: 9 },
+  paperCard: { borderColor: '#24513f', backgroundColor: '#0b1814' },
+  liveCard: { borderColor: '#63313b', backgroundColor: '#1a1014' },
+  orderCard: { borderColor: '#33475b' },
+  label: { color: '#68c9ff', fontSize: 9, fontWeight: '900', letterSpacing: 1.4 },
+  big: { color: '#f8fafc', fontSize: 25, fontWeight: '900' },
+  muted: { color: '#8b9aaa', fontSize: 12 },
+  warning: { color: '#ff9ca9', fontSize: 12, lineHeight: 18, fontWeight: '700' },
+  input: { backgroundColor: '#080d13', color: '#eef5fb', borderWidth: 1, borderColor: '#263848', borderRadius: 11, paddingHorizontal: 12, paddingVertical: 12, fontSize: 14 },
+  small: { color: '#718293', fontSize: 10, lineHeight: 15 },
+  confirm: { color: '#b6cde0', fontSize: 11, fontWeight: '800' },
+  button: { backgroundColor: '#17344a', borderWidth: 1, borderColor: '#2b6288', borderRadius: 11, padding: 13, alignItems: 'center' },
+  buttonText: { color: '#bce6ff', fontSize: 11, fontWeight: '900', letterSpacing: 0.8 },
+  execute: { backgroundColor: '#1b4a34', borderWidth: 1, borderColor: '#34765a', borderRadius: 11, padding: 14, alignItems: 'center' },
+  executeText: { color: '#c7f9df', fontSize: 11, fontWeight: '900', letterSpacing: 0.8 },
+  disabled: { opacity: 0.35 },
+  instrument: { backgroundColor: '#0a1016', borderWidth: 1, borderColor: '#1b2b39', borderRadius: 10, padding: 10 },
+  instrumentTicker: { color: '#d9eefc', fontWeight: '900', fontSize: 12 },
+  instrumentName: { color: '#74879a', fontSize: 10, marginTop: 3 },
+  message: { backgroundColor: '#101b25', borderWidth: 1, borderColor: '#29465d', borderRadius: 12, padding: 12 },
+  messageText: { color: '#b8d6e9', fontSize: 11, lineHeight: 17 },
+  json: { color: '#9eb0c0', fontFamily: 'monospace', fontSize: 10, lineHeight: 15 },
+  guardrail: { backgroundColor: '#17170c', borderWidth: 1, borderColor: '#49451f', borderRadius: 14, padding: 14 },
+  guardrailTitle: { color: '#d2c86d', fontSize: 9, fontWeight: '900', letterSpacing: 1.3 },
+  guardrailText: { color: '#9b9564', fontSize: 11, lineHeight: 17, marginTop: 6 },
+});

--- a/mobile/app/broker.tsx
+++ b/mobile/app/broker.tsx
@@ -3,12 +3,48 @@ import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-
 import { useRouter } from 'expo-router';
 
 import { AtlasOnlineApi, BrokerStatus } from '../core/api/atlasOnlineApi';
+import { db } from '../db/client';
+import { auditLog, decisionLog } from '../db/schema';
 
 function pretty(value: unknown): string {
   try {
     return JSON.stringify(value, null, 2);
   } catch {
     return String(value);
+  }
+}
+
+function eventId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`.toUpperCase();
+}
+
+async function writeDecision(subjectId: string, decisionType: string, rationale: unknown): Promise<void> {
+  await db.insert(decisionLog).values({
+    id: eventId('BRK-DEC'),
+    subjectId,
+    decisionType,
+    rationale: pretty(rationale),
+    evidenceRefsJson: '[]',
+    createdAt: new Date(),
+  });
+}
+
+async function writeAudit(action: string, target: string): Promise<void> {
+  await db.insert(auditLog).values({
+    id: eventId('BRK-AUD'),
+    action,
+    actor: 'ATLAS_MOBILE_USER',
+    target,
+    payloadHash: null,
+    createdAt: new Date(),
+  });
+}
+
+async function safeLog(operation: () => Promise<void>): Promise<void> {
+  try {
+    await operation();
+  } catch {
+    // Broker execution must not be retried merely because local audit persistence failed.
   }
 }
 
@@ -73,19 +109,38 @@ export default function BrokerScreen() {
 
   async function placeOrder() {
     if (!canUsePrivate || !ticker.trim() || !Number.isFinite(parsedQuantity) || parsedQuantity === 0 || !status) return;
+    const normalizedTicker = ticker.trim();
+    const intent = {
+      provider: 'Trading212',
+      environment: status.environment,
+      mode: status.mode,
+      ticker: normalizedTicker,
+      quantity: parsedQuantity,
+      extendedHours: false,
+      confirmation,
+    };
+
     setBusy(true);
     setMessage('');
+    await safeLog(() => writeDecision(normalizedTicker, 'BROKER_ORDER_INTENT', intent));
+    await safeLog(() => writeAudit('BROKER_ORDER_INTENT', `${status.mode}:${normalizedTicker}`));
+
     try {
       const result = await AtlasOnlineApi.brokerMarketOrder({
-        ticker: ticker.trim(),
+        ticker: normalizedTicker,
         quantity: parsedQuantity,
         extended_hours: false,
         confirmation,
       }, controlToken);
+      await safeLog(() => writeDecision(normalizedTicker, 'BROKER_ORDER_ACCEPTED', { intent, result }));
+      await safeLog(() => writeAudit('BROKER_ORDER_ACCEPTED', `${status.mode}:${normalizedTicker}`));
       setMessage(`${status.mode} order accepted: ${pretty(result)}`);
       await refreshPrivate();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : String(error));
+      const detail = error instanceof Error ? error.message : String(error);
+      await safeLog(() => writeDecision(normalizedTicker, 'BROKER_ORDER_FAILED', { intent, error: detail }));
+      await safeLog(() => writeAudit('BROKER_ORDER_FAILED', `${status.mode}:${normalizedTicker}`));
+      setMessage(detail);
     } finally {
       setBusy(false);
     }
@@ -158,7 +213,7 @@ export default function BrokerScreen() {
 
       <View style={styles.guardrail}>
         <Text style={styles.guardrailTitle}>GUARDRAIL Ω</Text>
-        <Text style={styles.guardrailText}>La app no contiene las claves de Trading 212. Las credenciales viven en el backend. LIVE requiere una activación explícita del servidor y una confirmación específica en cada orden.</Text>
+        <Text style={styles.guardrailText}>La app no contiene las claves de Trading 212. Las credenciales viven en el backend. LIVE requiere una activación explícita del servidor y una confirmación específica en cada orden. Cada intento de orden queda registrado localmente en Decision Log Ω y Audit Log Ω sin guardar el control token.</Text>
       </View>
     </ScrollView>
   );

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -14,12 +14,14 @@ const modules = [
   { code: 'RSK', title: 'Risk Ω', subtitle: 'Beta · deuda · liquidez · volatilidad', route: '/risk' },
   { code: 'CAT', title: 'Catalysts Ω', subtitle: 'Noticias · consenso · cambios', route: '/catalysts' },
   { code: 'NWS', title: 'News Ω', subtitle: 'Noticias recientes del ticker', route: '/news' },
+  { code: 'BRK', title: 'Broker Ω', subtitle: 'Trading 212 · paper/live · posiciones · órdenes', route: '/broker' },
 ] as const;
 
 export default function HomeScreen() {
   const router = useRouter();
   const [apiState, setApiState] = useState<'CHECKING' | 'ONLINE' | 'OFFLINE'>('CHECKING');
   const [apiVersion, setApiVersion] = useState('');
+  const [brokerState, setBrokerState] = useState('BROKER CHECKING');
 
   useEffect(() => {
     let active = true;
@@ -28,9 +30,13 @@ export default function HomeScreen() {
         if (!active) return;
         setApiState(health.ok && health.finnhub_configured ? 'ONLINE' : 'OFFLINE');
         setApiVersion(health.version || '');
+        setBrokerState(health.broker_configured ? `BROKER ${(health.broker_environment || 'demo').toUpperCase()}` : 'BROKER UNCONFIGURED');
       })
       .catch(() => {
-        if (active) setApiState('OFFLINE');
+        if (active) {
+          setApiState('OFFLINE');
+          setBrokerState('BROKER OFFLINE');
+        }
       });
     return () => { active = false; };
   }, []);
@@ -49,13 +55,13 @@ export default function HomeScreen() {
       </View>
 
       <View style={styles.hero}>
-        <Text style={styles.eyebrow}>NUEVA INTERFAZ</Text>
-        <Text style={styles.title}>Elige pantalla. Pon ticker. Recibe datos.</Text>
-        <Text style={styles.subtitle}>Sin formularios manuales. Sin escribir razones, señales ni evidencias a mano. Cada módulo consulta ATLAS online.</Text>
+        <Text style={styles.eyebrow}>ATLAS Ω MOBILE</Text>
+        <Text style={styles.title}>Analiza. Decide. Ejecuta con guardrails.</Text>
+        <Text style={styles.subtitle}>Los módulos de análisis consultan ATLAS online. Broker Ω añade Trading 212 con paper trading por defecto y LIVE bloqueado hasta activación explícita del servidor.</Text>
         <View style={styles.apiBox}>
           <Text style={styles.apiLabel}>BACKEND</Text>
           <Text style={styles.apiValue} numberOfLines={1}>{atlasApiBaseUrl()}</Text>
-          <Text style={styles.apiMeta}>{apiVersion ? `API ${apiVersion}` : 'Render + Finnhub'}</Text>
+          <Text style={styles.apiMeta}>{apiVersion ? `API ${apiVersion}` : 'Render + Finnhub'} · {brokerState}</Text>
         </View>
       </View>
 
@@ -67,7 +73,7 @@ export default function HomeScreen() {
             accessibilityRole="button"
             accessibilityLabel={`Abrir ${module.title}`}
             onPress={() => router.push(module.route)}
-            style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+            style={({ pressed }) => [styles.card, pressed && styles.cardPressed, module.code === 'BRK' && styles.brokerCard]}
           >
             <Text style={styles.code}>{module.code}</Text>
             <Text style={styles.cardTitle}>{module.title}</Text>
@@ -79,7 +85,7 @@ export default function HomeScreen() {
 
       <View style={styles.ruleCard}>
         <Text style={styles.ruleTitle}>REGLA DE USO</Text>
-        <Text style={styles.ruleText}>1 ticker → datos automáticos. Si un dato no existe o el proveedor no lo entrega, ATLAS muestra “no disponible”; no te obliga a rellenarlo manualmente.</Text>
+        <Text style={styles.ruleText}>1 ticker → datos automáticos. Broker Ω mantiene las claves de Trading 212 fuera del APK. Las órdenes reales permanecen bloqueadas si el servidor no habilita LIVE explícitamente.</Text>
       </View>
     </ScrollView>
   );
@@ -111,6 +117,7 @@ const styles = StyleSheet.create({
   section: { color: '#65798d', fontSize: 10, fontWeight: '900', letterSpacing: 1.4 },
   grid: { gap: 10 },
   card: { minHeight: 104, backgroundColor: '#0e151d', borderWidth: 1, borderColor: '#1f3040', borderRadius: 16, padding: 15, position: 'relative' },
+  brokerCard: { borderColor: '#2a5c4b', backgroundColor: '#0c1714' },
   cardPressed: { opacity: 0.65, transform: [{ scale: 0.99 }] },
   code: { color: '#63caff', fontSize: 9, fontWeight: '900', letterSpacing: 1.3 },
   cardTitle: { color: '#f1f5f9', fontSize: 19, fontWeight: '900', marginTop: 8 },

--- a/mobile/core/api/atlasOnlineApi.ts
+++ b/mobile/core/api/atlasOnlineApi.ts
@@ -3,6 +3,9 @@ export type AtlasHealth = {
   service: string;
   version?: string;
   finnhub_configured: boolean;
+  broker_configured?: boolean;
+  broker_environment?: 'demo' | 'live';
+  broker_live_enabled?: boolean;
 };
 
 export type CompanyBundle = {
@@ -18,6 +21,34 @@ export type CompanyBundle = {
   guardrail: string;
 };
 
+export type BrokerStatus = {
+  provider: 'Trading212';
+  environment: 'demo' | 'live';
+  configured: boolean;
+  liveTradingEnabled: boolean;
+  mode: 'PAPER' | 'LIVE';
+  guardrail: string;
+};
+
+export type BrokerEnvelope = {
+  provider: 'Trading212';
+  environment: 'demo' | 'live';
+  data: unknown;
+};
+
+export type BrokerInstrumentSearch = {
+  query: string;
+  count: number;
+  items: Array<Record<string, unknown>>;
+};
+
+export type MarketOrderInput = {
+  ticker: string;
+  quantity: number;
+  extended_hours?: boolean;
+  confirmation: 'EXECUTE_DEMO' | 'EXECUTE_LIVE';
+};
+
 const configuredBase = process.env.EXPO_PUBLIC_ATLAS_API_BASE_URL?.replace(/\/$/, '');
 const DEFAULT_PUBLIC_API = 'https://atlas-genesis.onrender.com';
 
@@ -25,17 +56,26 @@ export function atlasApiBaseUrl(): string {
   return configuredBase || DEFAULT_PUBLIC_API;
 }
 
-async function request<T>(path: string): Promise<T> {
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 25000);
   try {
     const response = await fetch(`${atlasApiBaseUrl()}${path}`, {
-      headers: { accept: 'application/json' },
+      ...init,
+      headers: {
+        accept: 'application/json',
+        ...(init?.body ? { 'content-type': 'application/json' } : {}),
+        ...(init?.headers || {}),
+      },
       signal: controller.signal,
     });
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) {
-      const detail = typeof payload?.detail === 'string' ? payload.detail : `ATLAS API HTTP ${response.status}`;
+      const detail = typeof payload?.detail === 'string'
+        ? payload.detail
+        : payload?.detail
+          ? JSON.stringify(payload.detail)
+          : `ATLAS API HTTP ${response.status}`;
       throw new Error(detail);
     }
     return payload as T;
@@ -49,7 +89,25 @@ async function request<T>(path: string): Promise<T> {
   }
 }
 
+function brokerHeaders(controlToken: string): Record<string, string> {
+  return { 'x-atlas-broker-token': controlToken.trim() };
+}
+
 export const AtlasOnlineApi = {
   health: () => request<AtlasHealth>('/health'),
   company: (ticker: string) => request<CompanyBundle>(`/v1/company/${encodeURIComponent(ticker.trim().toUpperCase())}`),
+  brokerStatus: () => request<BrokerStatus>('/v1/broker/status'),
+  brokerAccount: (controlToken: string) => request<BrokerEnvelope>('/v1/broker/account', { headers: brokerHeaders(controlToken) }),
+  brokerPositions: (controlToken: string) => request<BrokerEnvelope>('/v1/broker/positions', { headers: brokerHeaders(controlToken) }),
+  brokerOrders: (controlToken: string) => request<BrokerEnvelope>('/v1/broker/orders', { headers: brokerHeaders(controlToken) }),
+  brokerInstrumentSearch: (query: string, controlToken: string) => request<BrokerInstrumentSearch>(`/v1/broker/instruments/search?q=${encodeURIComponent(query.trim())}`, { headers: brokerHeaders(controlToken) }),
+  brokerMarketOrder: (input: MarketOrderInput, controlToken: string) => request<Record<string, unknown>>('/v1/broker/orders/market', {
+    method: 'POST',
+    headers: brokerHeaders(controlToken),
+    body: JSON.stringify(input),
+  }),
+  brokerCancelOrder: (orderId: number, controlToken: string) => request<Record<string, unknown>>(`/v1/broker/orders/${orderId}`, {
+    method: 'DELETE',
+    headers: brokerHeaders(controlToken),
+  }),
 };

--- a/render.yaml
+++ b/render.yaml
@@ -9,3 +9,13 @@ services:
     envVars:
       - key: FINNHUB_TOKEN
         sync: false
+      - key: TRADING212_ENV
+        value: demo
+      - key: TRADING212_API_KEY
+        sync: false
+      - key: TRADING212_API_SECRET
+        sync: false
+      - key: ATLAS_BROKER_CONTROL_TOKEN
+        sync: false
+      - key: TRADING212_LIVE_TRADING_ENABLED
+        value: "false"


### PR DESCRIPTION
Implements the missing broker execution layer for ATLAS Ω Mobile.

What is included:
- Trading 212 demo/live adapter in FastAPI.
- Server-side Basic auth; Trading 212 API key/secret never ship in the APK.
- Separate ATLAS broker control token for all private broker endpoints.
- Account, positions, pending orders and instrument search.
- Market order placement and pending-order cancellation.
- Demo/paper as the repository default.
- LIVE fail-closed behind `TRADING212_LIVE_TRADING_ENABLED=false` plus per-order `EXECUTE_LIVE` confirmation.
- Trading 212 rate-limit/upstream errors surfaced without blind POST retries.
- Broker Ω Android screen and home/menu route.
- Render environment-variable blueprint and activation runbook.

Activation still requires the user's own Trading 212 API key/secret and a private ATLAS control token to be set in Render; no credentials are committed.