### PR TITLE
feat: Evidence Ingestion Ω mobile-first engine

### DIFF
--- a/docs/rfcs/RFC-EVIDENCE-INGESTION-OMEGA-v1.md
+++ b/docs/rfcs/RFC-EVIDENCE-INGESTION-OMEGA-v1.md
@@ -1,0 +1,121 @@
+# RFC-EVIDENCE-INGESTION-OMEGA-v1
+
+## Estado
+
+ACEPTADO COMO CAPA DE INTEGRACION ATLAS OMEGA.
+
+Fecha: 2026-08-09  
+Ambito: ATLAS Omega Mobile + backend/API futura  
+Objetivo: convertir fuentes publicas, documentos corporativos y contenido web permitido en evidencia estructurada para los motores ATLAS.
+
+## Regla movil-first
+
+El usuario opera desde movil y apps moviles. Toda integracion ATLAS debe funcionar primero como experiencia movil:
+
+- entrada por captura, archivo subido, enlace, texto pegado o fuente sincronizada;
+- salida en tarjetas compactas;
+- evidencia trazable disponible offline cuando sea posible;
+- sincronizacion diferida;
+- cero dependencia obligatoria de escritorio para uso diario.
+
+## Principio rector
+
+La capa de ingesta no existe para saltarse restricciones, huellas anti-bot, muros de pago, logins privados ni terminos de servicio. Existe para transformar fuentes permitidas en evidencia verificable.
+
+Regla canonica:
+
+> No hay decision ATLAS sin fuente, timestamp, tipo de evidencia, nivel de confianza y trazabilidad al dato primario.
+
+## Encaje en arquitectura ATLAS
+
+```text
+Fuente publica / documento / pagina permitida
+  -> Ingestion Adapter
+  -> Normalizacion
+  -> Evidence Omega
+  -> Epistemic Classification
+  -> Motor ATLAS correspondiente
+  -> Decision Log Omega
+```
+
+## Herramientas aprobadas
+
+| Prioridad | Herramienta | Rol ATLAS | Estado |
+|---:|---|---|---|
+| 1 | Microsoft MarkItDown | Conversion de PDFs, Word, Excel, PowerPoint, HTML e imagenes a Markdown para IA | Core adapter |
+| 2 | Firecrawl | Web/public pages a Markdown o JSON estructurado | Core adapter opcional |
+| 3 | Crawl4AI | Web crawler orientado a RAG/agentes, alternativa autoalojada | Core adapter opcional |
+| 4 | Scrapy | Crawler industrial para fuentes repetitivas y estables | Batch adapter |
+| 5 | Playwright / Browser Use | Navegacion controlada en paginas dinamicas permitidas | Controlled adapter |
+| 6 | Crawlee | Alternativa JS/TypeScript para scraping y browser automation | Candidate adapter |
+| 7 | Scrapling | Scraping adaptativo; evaluar antes de core | Experimental |
+| 8 | AutoScraper | Extraccion simple por ejemplos | Utility |
+| 9 | scrcpy | Pruebas Android y QA de app movil | QA only |
+| 10 | curl-impersonate | Cliente HTTP con huella de navegador | Restricted / not core |
+
+## Restricciones de seguridad
+
+Prohibido en ATLAS Core:
+
+- Saltar CAPTCHAs, paywalls, logins privados o bloqueos tecnicos.
+- Usar credenciales personales para extraer datos de terceros sin autorizacion.
+- Ocultar identidad del cliente para eludir controles anti-abuso.
+- Ingerir datos personales innecesarios.
+- Mezclar contenido no verificado con hechos canonicos.
+
+Permitido:
+
+- SEC, EDGAR, investor relations, comunicados de prensa, transcripts publicos.
+- PDFs corporativos publicados por la empresa.
+- Paginas publicas con robots/terminos compatibles.
+- Documentos subidos por el usuario.
+- Fuentes macro, reguladores y organismos oficiales.
+
+## Niveles de fuente
+
+| Nivel | Fuente | Uso |
+|---:|---|---|
+| 1 | SEC, reguladores, investor relations, conference calls oficiales | Puede modificar conviction si valida falsificador o mejora tesis |
+| 2 | Proveedores financieros, comunicados sindicados, bolsas, datos macro oficiales | Puede activar vigilancia |
+| 3 | Medios financieros reputados, analistas, informes secundarios | Contexto, no cambio canonico sin confirmacion |
+| 4 | Redes sociales, newsletters, capturas, rumores | Radar o hipotesis; nunca hecho canonico |
+
+## Integracion en algoritmo
+
+Evidence Ingestion Omega se ejecuta antes de cualquier motor que pueda producir decision:
+
+```text
+Input movil
+  -> Evidence Ingestion Omega
+  -> Validation Harness Omega
+  -> Epistemic Classification
+  -> GLOBAL DISCOVERY
+  -> MARKET FILTERS
+  -> BUSINESS QUALITY OMEGA
+  -> GROWTH OMEGA
+  -> CAPEX PRODUCTIVITY OMEGA
+  -> VALUATION OMEGA
+  -> RISK OMEGA
+  -> CATALYSTS OMEGA
+  -> FINAL SCORE OMEGA
+  -> Decision Log Omega
+```
+
+## Casos de uso
+
+- Vigilancia diaria.
+- CAPEX Productivity Omega.
+- Money Rotation Omega.
+- Historical Dislocation Omega.
+- Futuros Protectores Digitales.
+- Conspiraciones Atlas.
+- ATLAS Mobile Evidence Inbox.
+
+## Criterios de aceptacion
+
+- Toda evidencia tiene fuente, timestamp, adapter y hash.
+- Ninguna salida canonica cambia desde fuente nivel 3 o 4 sin confirmacion primaria.
+- Capturas y redes sociales entran como radar/hipotesis.
+- Documentos subidos se convierten con MarkItDown o parser equivalente.
+- El motor puede explicar de donde sale cada afirmacion.
+- El Decision Log enlaza con evidencia concreta.

--- a/src/atlas/algorithm/evidence-ingestion-omega.ts
+++ b/src/atlas/algorithm/evidence-ingestion-omega.ts
@@ -1,0 +1,54 @@
+import { EVIDENCE_INGESTION_ENGINE_ID, EVIDENCE_INGESTION_POSITION } from '../evidence-ingestion/engine';
+
+export const ATLAS_MOBILE_FIRST_RULE = {
+  id: 'MOBILE_FIRST_OMEGA',
+  status: 'canonical',
+  statement:
+    'ATLAS Omega is designed for mobile and mobile apps first. Desktop workflows are implementation helpers, not the default user surface.',
+} as const;
+
+export const EVIDENCE_INGESTION_OMEGA_ALGORITHM_NODE = {
+  id: EVIDENCE_INGESTION_ENGINE_ID,
+  name: 'Evidence Ingestion Omega v1.0',
+  status: 'canonical',
+  position: 'before_validation_and_all_investment_engines',
+  mobileFirst: true,
+  purpose:
+    'Transform public sources, uploaded files, mobile screenshots, shared URLs and pasted text into traceable Evidence Omega records before any Atlas decision engine runs.',
+  canonicalPipeline: EVIDENCE_INGESTION_POSITION,
+  allowedCoreAdapters: ['markitdown', 'firecrawl', 'crawl4ai', 'scrapy', 'playwright'] as const,
+  restrictedAdapters: ['curl-impersonate'] as const,
+  requiredOutputs: [
+    'source',
+    'capturedAt',
+    'rawHash',
+    'extractedTextHash',
+    'evidenceLevel',
+    'epistemicClass',
+    'relatedEngines',
+    'mobile.syncStatus',
+  ] as const,
+  canonicalGuardrails: [
+    'No canonical Atlas state changes from level 3 or 4 sources without primary-source confirmation.',
+    'Mobile screenshots and social posts enter Radar or Hypothesis, never Fact by default.',
+    'No CAPTCHA, paywall, login, private account or anti-abuse bypass in Atlas Core.',
+    'Every Decision Log entry must link to at least one EvidenceRecord.',
+  ] as const,
+} as const;
+
+export const ATLAS_CANONICAL_ALGORITHM_WITH_EVIDENCE_INGESTION = [
+  'MOBILE_INPUT',
+  'EVIDENCE_INGESTION_OMEGA_V1',
+  'VALIDATION_HARNESS_OMEGA',
+  'EPISTEMIC_CLASSIFICATION',
+  'GLOBAL_DISCOVERY',
+  'MARKET_FILTERS',
+  'BUSINESS_QUALITY_OMEGA',
+  'GROWTH_OMEGA',
+  'CAPEX_PRODUCTIVITY_OMEGA',
+  'VALUATION_OMEGA',
+  'RISK_OMEGA',
+  'CATALYSTS_OMEGA',
+  'FINAL_SCORE_OMEGA',
+  'DECISION_LOG_OMEGA',
+] as const;

--- a/src/atlas/evidence-ingestion/engine.ts
+++ b/src/atlas/evidence-ingestion/engine.ts
@@ -1,0 +1,163 @@
+import type {
+  AtlasEngineId,
+  EpistemicClass,
+  EvidenceIngestionInput,
+  EvidenceLevel,
+  EvidenceRecord,
+  EvidenceValidationResult,
+} from './types';
+
+const PRIMARY_SOURCE_TYPES = new Set([
+  'sec_filing',
+  'investor_relations',
+  'earnings_transcript',
+  'press_release',
+  'regulatory',
+]);
+
+const SECONDARY_SOURCE_TYPES = new Set(['macro_source', 'news', 'web_page', 'uploaded_document']);
+const RADAR_SOURCE_TYPES = new Set(['mobile_capture', 'social_post']);
+
+export const EVIDENCE_INGESTION_ENGINE_ID = 'EVIDENCE_INGESTION_OMEGA_V1' as const;
+
+export const EVIDENCE_INGESTION_POSITION = [
+  'MOBILE_INPUT',
+  'EVIDENCE_INGESTION_OMEGA_V1',
+  'VALIDATION_HARNESS_OMEGA',
+  'EPISTEMIC_CLASSIFICATION',
+  'GLOBAL_DISCOVERY',
+  'MARKET_FILTERS',
+  'BUSINESS_QUALITY_OMEGA',
+  'GROWTH_OMEGA',
+  'CAPEX_PRODUCTIVITY_OMEGA',
+  'VALUATION_OMEGA',
+  'RISK_OMEGA',
+  'CATALYSTS_OMEGA',
+  'FINAL_SCORE_OMEGA',
+  'DECISION_LOG_OMEGA',
+] as const;
+
+export function validateEvidenceInput(input: EvidenceIngestionInput): EvidenceValidationResult {
+  const reasons: string[] = [];
+
+  if (!input.extractedText.trim()) {
+    reasons.push('empty_extracted_text');
+  }
+
+  if (!input.sourceUrl && !input.sourceFile && input.inputKind !== 'manual_note') {
+    reasons.push('missing_traceable_source');
+  }
+
+  if (input.adapter === 'playwright' && input.sourceType === 'social_post') {
+    reasons.push('browser_adapter_social_post_requires_manual_review');
+  }
+
+  if (input.adapter === 'manual' || RADAR_SOURCE_TYPES.has(input.sourceType)) {
+    return {
+      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
+      reasons,
+      evidenceLevel: 4,
+      epistemicClass: 'hypothesis',
+    };
+  }
+
+  if (PRIMARY_SOURCE_TYPES.has(input.sourceType)) {
+    return {
+      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
+      reasons,
+      evidenceLevel: 1,
+      epistemicClass: 'evidence',
+    };
+  }
+
+  if (SECONDARY_SOURCE_TYPES.has(input.sourceType)) {
+    return {
+      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
+      reasons,
+      evidenceLevel: input.sourceType === 'macro_source' ? 2 : 3,
+      epistemicClass: input.sourceType === 'uploaded_document' ? 'evidence' : 'interpretation',
+    };
+  }
+
+  return {
+    status: 'QUARANTINED',
+    reasons: [...reasons, 'unknown_source_type'],
+    evidenceLevel: 4,
+    epistemicClass: 'noise',
+  };
+}
+
+export function canModifyCanonicalAtlasState(record: EvidenceRecord): boolean {
+  return record.evidenceLevel <= 2 && (record.epistemicClass === 'fact' || record.epistemicClass === 'evidence');
+}
+
+export function routeEvidenceToEngines(record: EvidenceRecord): AtlasEngineId[] {
+  const engines = new Set<AtlasEngineId>(record.relatedEngines);
+  const text = `${record.title ?? ''} ${record.summary} ${record.keyClaims.join(' ')}`.toLowerCase();
+
+  if (text.includes('capex') || text.includes('free cash flow') || text.includes('fcf') || text.includes('roic')) {
+    engines.add('CAPEX_PRODUCTIVITY_OMEGA');
+  }
+
+  if (text.includes('gold') || text.includes('oil') || text.includes('rates') || text.includes('dollar') || text.includes('flows')) {
+    engines.add('MONEY_ROTATION_OMEGA');
+    engines.add('HISTORICAL_DISLOCATION_OMEGA');
+  }
+
+  if (text.includes('security') || text.includes('agent') || text.includes('identity') || text.includes('zero trust')) {
+    engines.add('FUTUROS_PROTECTORES_DIGITALES');
+  }
+
+  if (record.evidenceLevel === 4) {
+    engines.add('CONSPIRACIONES_ATLAS');
+  }
+
+  return Array.from(engines);
+}
+
+export async function buildEvidenceRecord(
+  input: EvidenceIngestionInput,
+  hash: (value: string) => Promise<string>,
+): Promise<EvidenceRecord> {
+  const validation = validateEvidenceInput(input);
+  const rawHash = await hash(`${input.sourceUrl ?? ''}${input.sourceFile ?? ''}${input.extractedText}`);
+  const extractedTextHash = await hash(input.extractedText);
+  const summary = input.extractedText.trim().slice(0, 500);
+
+  const draft: EvidenceRecord = {
+    id: `evidence_${rawHash.slice(0, 16)}`,
+    sourceUrl: input.sourceUrl,
+    sourceFile: input.sourceFile,
+    sourceType: input.sourceType,
+    capturedAt: input.capturedAt,
+    publisher: input.publisher,
+    title: input.title,
+    rawHash,
+    extractedTextHash,
+    extractionAdapter: input.adapter,
+    evidenceLevel: validation.evidenceLevel,
+    epistemicClass: validation.epistemicClass,
+    relatedTickers: input.relatedTickers ?? [],
+    relatedEngines: input.relatedEngines ?? [],
+    summary,
+    keyClaims: [],
+    limitations: validation.reasons,
+    mobile: {
+      inputKind: input.inputKind,
+      offlineReady: true,
+      syncStatus: 'pending_sync',
+    },
+  };
+
+  return {
+    ...draft,
+    relatedEngines: routeEvidenceToEngines(draft),
+  };
+}
+
+export function classifyCanonicalImpact(record: EvidenceRecord): 'canonical' | 'watch' | 'radar' | 'reject' {
+  if (canModifyCanonicalAtlasState(record)) return 'canonical';
+  if (record.evidenceLevel === 3) return 'watch';
+  if (record.evidenceLevel === 4 && record.epistemicClass !== 'noise') return 'radar';
+  return 'reject';
+}

--- a/src/atlas/evidence-ingestion/types.ts
+++ b/src/atlas/evidence-ingestion/types.ts
@@ -1,0 +1,101 @@
+export type EvidenceSourceType =
+  | 'sec_filing'
+  | 'investor_relations'
+  | 'earnings_transcript'
+  | 'press_release'
+  | 'regulatory'
+  | 'macro_source'
+  | 'news'
+  | 'uploaded_document'
+  | 'web_page'
+  | 'mobile_capture'
+  | 'social_post';
+
+export type IngestionAdapter =
+  | 'markitdown'
+  | 'firecrawl'
+  | 'crawl4ai'
+  | 'scrapy'
+  | 'playwright'
+  | 'crawlee'
+  | 'manual'
+  | 'mobile_capture';
+
+export type EvidenceLevel = 1 | 2 | 3 | 4;
+
+export type EpistemicClass =
+  | 'fact'
+  | 'evidence'
+  | 'hypothesis'
+  | 'interpretation'
+  | 'speculation'
+  | 'noise';
+
+export type AtlasEngineId =
+  | 'GLOBAL_DISCOVERY'
+  | 'MARKET_FILTERS'
+  | 'BUSINESS_QUALITY_OMEGA'
+  | 'GROWTH_OMEGA'
+  | 'CAPEX_PRODUCTIVITY_OMEGA'
+  | 'VALUATION_OMEGA'
+  | 'RISK_OMEGA'
+  | 'CATALYSTS_OMEGA'
+  | 'MONEY_ROTATION_OMEGA'
+  | 'HISTORICAL_DISLOCATION_OMEGA'
+  | 'FUTUROS_PROTECTORES_DIGITALES'
+  | 'CONSPIRACIONES_ATLAS'
+  | 'FINAL_SCORE_OMEGA';
+
+export type MobileInputKind =
+  | 'share_url'
+  | 'upload_file'
+  | 'paste_text'
+  | 'screenshot'
+  | 'manual_note'
+  | 'synced_source';
+
+export type EvidenceRecord = {
+  id: string;
+  sourceUrl?: string;
+  sourceFile?: string;
+  sourceType: EvidenceSourceType;
+  capturedAt: string;
+  publisher?: string;
+  title?: string;
+  rawHash: string;
+  extractedTextHash: string;
+  extractionAdapter: IngestionAdapter;
+  evidenceLevel: EvidenceLevel;
+  epistemicClass: EpistemicClass;
+  relatedTickers: string[];
+  relatedEngines: AtlasEngineId[];
+  summary: string;
+  keyClaims: string[];
+  limitations: string[];
+  mobile: {
+    inputKind: MobileInputKind;
+    offlineReady: boolean;
+    syncStatus: 'local_only' | 'pending_sync' | 'synced' | 'failed';
+  };
+};
+
+export type EvidenceIngestionInput = {
+  inputKind: MobileInputKind;
+  sourceUrl?: string;
+  sourceFile?: string;
+  extractedText: string;
+  sourceType: EvidenceSourceType;
+  adapter: IngestionAdapter;
+  capturedAt: string;
+  publisher?: string;
+  title?: string;
+  relatedTickers?: string[];
+  relatedEngines?: AtlasEngineId[];
+};
+
+export type EvidenceValidationResult = {
+  status: 'PASS' | 'QUARANTINED' | 'REJECT';
+  reasons: string[];
+  evidenceLevel: EvidenceLevel;
+  epistemicClass: EpistemicClass;
+};


### PR DESCRIPTION
## Resumen

Integra **Evidence Ingestion Ω v1.0** en ATLAS como capa previa al algoritmo y a los motores de decision.

## Cambios

- Añade RFC canonico `RFC-EVIDENCE-INGESTION-OMEGA-v1`.
- Añade contratos TypeScript para `EvidenceRecord`, niveles de fuente, clases epistemicas y adaptadores de ingesta.
- Añade motor `Evidence Ingestion Omega` con validacion, clasificacion de impacto canonico y routing hacia motores ATLAS.
- Registra la capa en el algoritmo canonico antes de `Validation Harness`, `GLOBAL_DISCOVERY`, `CAPEX_PRODUCTIVITY`, `VALUATION`, `RISK` y `FINAL_SCORE`.
- Fija regla **mobile-first**: ATLAS se usa desde movil y apps moviles; escritorio queda como apoyo tecnico.

## Guardrails

- Capturas/redes sociales entran como radar o hipotesis, nunca como hecho por defecto.
- Fuentes nivel 3/4 no modifican estado canonico sin confirmacion primaria.
- `curl-impersonate` queda restringido y fuera del core.
- No se permite bypass de CAPTCHA, paywall, login privado ni controles anti-abuso.

## Archivos

- `docs/rfcs/RFC-EVIDENCE-INGESTION-OMEGA-v1.md`
- `src/atlas/evidence-ingestion/types.ts`
- `src/atlas/evidence-ingestion/engine.ts`
- `src/atlas/algorithm/evidence-ingestion-omega.ts`

## Estado

Draft: requiere validacion contra la estructura real del proyecto antes de merge.