### PR TITLE
chore: sync main into mobile scanner branch

### DIFF
--- a/docs/canon/AGENTIC_SECURITY_DISCOVERY_OMEGA_v1.md
+++ b/docs/canon/AGENTIC_SECURITY_DISCOVERY_OMEGA_v1.md
@@ -1,0 +1,91 @@
+# AGENTIC SECURITY DISCOVERY Ω v1.0
+
+Status: candidate canonical discovery motor
+Date: 2026-08-09
+Scope: discovery only; it never emits BUY/SELL.
+
+## Mission
+
+Detect listed companies exposed to the emerging security layer created by autonomous/agentic AI before the theme becomes consensus. The motor is independent from portfolio membership, watchlists, preferred sectors and the ATLAS quality score.
+
+## Canonical order
+
+GLOBAL DISCOVERY → AGENTIC SECURITY Ω → MARKET FILTERS → BUSINESS QUALITY Ω → GROWTH Ω → CAPEX PRODUCTIVITY Ω → VALUATION Ω → RISK Ω → CATALYSTS Ω → FINAL SCORE Ω.
+
+Agentic Security Ω can only promote a candidate to the ATLAS full scorer. It cannot bypass valuation, quality or falsifiers.
+
+## Seed profiles
+
+The initial similarity anchors are PANW, NET, CRWD, OKTA and ZS. Seeds are heuristic capability profiles, not certified investments and not automatic BUYs.
+
+## Capability dimensions
+
+1. Direct Agentic Security — 25%
+2. Agent / non-human identity — 15%
+3. Runtime and tool-access control — 15%
+4. Zero Trust / network egress — 10%
+5. Data and model protection — 10%
+6. Secrets / privileged access — 10%
+7. AI gateway / prompt-injection security — 10%
+8. Agent observability — 5%
+
+## Evidence rules
+
+Primary evidence dominates. Repeated marketing language must not manufacture a high score. Candidates without primary evidence receive a penalty and cannot reach DISCOVER. A direct agentic-security claim without breadth across adjacent control planes is insufficient on its own.
+
+Evidence classes:
+- PRIMARY: issuer IR, filings, official product/security documentation.
+- SECONDARY: reputable independent reporting/research.
+- UNVERIFIED: claims not independently established.
+
+## Scoring
+
+Discovery score 0–100:
+- capability score: 55%
+- nearest-seed cosine similarity: 20%
+- evidence quality: 15%
+- commercial traction: 5%
+- enterprise distribution strength: 5%
+
+Penalties:
+- no primary evidence: -15
+- fewer than two meaningful agentic-security dimensions: -15
+- no direct agentic-product evidence: -5
+- not listed: reject
+
+## States
+
+- DISCOVER: score >=70, at least 3 meaningful dimensions and primary evidence. Route to ATLAS_FULL_SCORER.
+- WATCH: score >=50 and at least 2 meaningful dimensions. Route to RESEARCH_QUEUE.
+- REJECT: insufficient structural fit or non-listed.
+- INSUFFICIENT_EVIDENCE: evidence is missing or too weak.
+
+## Anti-bias rules
+
+- Never award points because a ticker is already in Portfolio/Watchlist.
+- Never require membership in cybersecurity sector classifications.
+- Never prefer US companies by construction.
+- Search capability signals first, then identify/normalize ticker.
+- Seed similarity is only 20% of score, preventing clones of the initial five from monopolizing discovery.
+- No BUY/SELL output exists in this engine.
+
+## Falsification / downgrade signals
+
+- Agentic-security product remains marketing-only with no production evidence.
+- Product lacks real enforcement and is limited to dashboards/advisory output.
+- No identity/tool/runtime isolation despite agent claims.
+- Material security incidents contradict claimed control capability.
+- Commercial traction fails to emerge while competitors demonstrate adoption.
+- Acquired capability is not integrated into the platform.
+
+## Implementation
+
+`mobile/domain/agenticSecurityDiscovery.ts`
+
+Exports:
+- `AGENTIC_SECURITY_SEEDS`
+- `evaluateAgenticSecurityCandidate()`
+- `rankAgenticSecurityCandidates()`
+- `agenticSecurityDiscoveryContractCheck()`
+
+The engine consumes evidence bundles from the existing data/evidence pipeline. It extracts capability signals, ranks candidates by structural fit and routes only DISCOVER candidates into the complete ATLAS Ω scoring process.

--- a/docs/rfcs/RFC-EVIDENCE-INGESTION-OMEGA-v1.md
+++ b/docs/rfcs/RFC-EVIDENCE-INGESTION-OMEGA-v1.md
@@ -1,0 +1,121 @@
+# RFC-EVIDENCE-INGESTION-OMEGA-v1
+
+## Estado
+
+ACEPTADO COMO CAPA DE INTEGRACION ATLAS OMEGA.
+
+Fecha: 2026-08-09  
+Ambito: ATLAS Omega Mobile + backend/API futura  
+Objetivo: convertir fuentes publicas, documentos corporativos y contenido web permitido en evidencia estructurada para los motores ATLAS.
+
+## Regla movil-first
+
+El usuario opera desde movil y apps moviles. Toda integracion ATLAS debe funcionar primero como experiencia movil:
+
+- entrada por captura, archivo subido, enlace, texto pegado o fuente sincronizada;
+- salida en tarjetas compactas;
+- evidencia trazable disponible offline cuando sea posible;
+- sincronizacion diferida;
+- cero dependencia obligatoria de escritorio para uso diario.
+
+## Principio rector
+
+La capa de ingesta no existe para saltarse restricciones, huellas anti-bot, muros de pago, logins privados ni terminos de servicio. Existe para transformar fuentes permitidas en evidencia verificable.
+
+Regla canonica:
+
+> No hay decision ATLAS sin fuente, timestamp, tipo de evidencia, nivel de confianza y trazabilidad al dato primario.
+
+## Encaje en arquitectura ATLAS
+
+```text
+Fuente publica / documento / pagina permitida
+  -> Ingestion Adapter
+  -> Normalizacion
+  -> Evidence Omega
+  -> Epistemic Classification
+  -> Motor ATLAS correspondiente
+  -> Decision Log Omega
+```
+
+## Herramientas aprobadas
+
+| Prioridad | Herramienta | Rol ATLAS | Estado |
+|---:|---|---|---|
+| 1 | Microsoft MarkItDown | Conversion de PDFs, Word, Excel, PowerPoint, HTML e imagenes a Markdown para IA | Core adapter |
+| 2 | Firecrawl | Web/public pages a Markdown o JSON estructurado | Core adapter opcional |
+| 3 | Crawl4AI | Web crawler orientado a RAG/agentes, alternativa autoalojada | Core adapter opcional |
+| 4 | Scrapy | Crawler industrial para fuentes repetitivas y estables | Batch adapter |
+| 5 | Playwright / Browser Use | Navegacion controlada en paginas dinamicas permitidas | Controlled adapter |
+| 6 | Crawlee | Alternativa JS/TypeScript para scraping y browser automation | Candidate adapter |
+| 7 | Scrapling | Scraping adaptativo; evaluar antes de core | Experimental |
+| 8 | AutoScraper | Extraccion simple por ejemplos | Utility |
+| 9 | scrcpy | Pruebas Android y QA de app movil | QA only |
+| 10 | curl-impersonate | Cliente HTTP con huella de navegador | Restricted / not core |
+
+## Restricciones de seguridad
+
+Prohibido en ATLAS Core:
+
+- Saltar CAPTCHAs, paywalls, logins privados o bloqueos tecnicos.
+- Usar credenciales personales para extraer datos de terceros sin autorizacion.
+- Ocultar identidad del cliente para eludir controles anti-abuso.
+- Ingerir datos personales innecesarios.
+- Mezclar contenido no verificado con hechos canonicos.
+
+Permitido:
+
+- SEC, EDGAR, investor relations, comunicados de prensa, transcripts publicos.
+- PDFs corporativos publicados por la empresa.
+- Paginas publicas con robots/terminos compatibles.
+- Documentos subidos por el usuario.
+- Fuentes macro, reguladores y organismos oficiales.
+
+## Niveles de fuente
+
+| Nivel | Fuente | Uso |
+|---:|---|---|
+| 1 | SEC, reguladores, investor relations, conference calls oficiales | Puede modificar conviction si valida falsificador o mejora tesis |
+| 2 | Proveedores financieros, comunicados sindicados, bolsas, datos macro oficiales | Puede activar vigilancia |
+| 3 | Medios financieros reputados, analistas, informes secundarios | Contexto, no cambio canonico sin confirmacion |
+| 4 | Redes sociales, newsletters, capturas, rumores | Radar o hipotesis; nunca hecho canonico |
+
+## Integracion en algoritmo
+
+Evidence Ingestion Omega se ejecuta antes de cualquier motor que pueda producir decision:
+
+```text
+Input movil
+  -> Evidence Ingestion Omega
+  -> Validation Harness Omega
+  -> Epistemic Classification
+  -> GLOBAL DISCOVERY
+  -> MARKET FILTERS
+  -> BUSINESS QUALITY OMEGA
+  -> GROWTH OMEGA
+  -> CAPEX PRODUCTIVITY OMEGA
+  -> VALUATION OMEGA
+  -> RISK OMEGA
+  -> CATALYSTS OMEGA
+  -> FINAL SCORE OMEGA
+  -> Decision Log Omega
+```
+
+## Casos de uso
+
+- Vigilancia diaria.
+- CAPEX Productivity Omega.
+- Money Rotation Omega.
+- Historical Dislocation Omega.
+- Futuros Protectores Digitales.
+- Conspiraciones Atlas.
+- ATLAS Mobile Evidence Inbox.
+
+## Criterios de aceptacion
+
+- Toda evidencia tiene fuente, timestamp, adapter y hash.
+- Ninguna salida canonica cambia desde fuente nivel 3 o 4 sin confirmacion primaria.
+- Capturas y redes sociales entran como radar/hipotesis.
+- Documentos subidos se convierten con MarkItDown o parser equivalente.
+- El motor puede explicar de donde sale cada afirmacion.
+- El Decision Log enlaza con evidencia concreta.

--- a/docs/rfcs/RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1-CHECKLIST.md
+++ b/docs/rfcs/RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1-CHECKLIST.md
@@ -1,0 +1,8 @@
+# Validation checklist
+
+- [ ] TypeScript typecheck passes
+- [ ] Money Rotation rejects MARKET_CAP_CHANGE as flow
+- [ ] Level 2 maps to WATCH, not canonical
+- [ ] Same eventClusterId deduplicates signals
+- [ ] REDUCE/SELL without confirmed falsifier degrades to WATCH
+- [ ] Conflicting equivalent observations require reconciliation

--- a/docs/rfcs/RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1-IMPLEMENTATION.md
+++ b/docs/rfcs/RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1-IMPLEMENTATION.md
@@ -1,0 +1,3 @@
+# Evidence Integrity Omega v1.1 implementation
+
+Implementation scope: claim-level evidence integrity, quantitative semantics, temporal normalization fields, signal independence, reconciliation and destructive-action safety gating. Mobile-first remains canonical. Validate with project CI/typecheck before merge.

--- a/docs/rfcs/RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1.md
+++ b/docs/rfcs/RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1.md
@@ -1,0 +1,31 @@
+# RFC-EVIDENCE-INTEGRITY-OMEGA-v1.1
+
+## Estado
+CANDIDATO CANONICO. Requiere validacion antes de merge.
+
+## Mision
+Evitar que ATLAS convierta cambios de precio/capitalizacion en flujos, duplique señales causales, trate filings como informacion economica nueva por defecto o ejecute REDUCE/SELL sin falsificador primario confirmado.
+
+## Reglas no negociables
+1. MARKET_CAP_CHANGE != CAPITAL_FLOW.
+2. PRICE_RETURN != CAPITAL_FLOW.
+3. AUM_CHANGE no implica por si solo NET_FLOW.
+4. Toda cifra de Money Rotation debe usar una metrica de flujo explicita y trazable.
+5. Level 1 puede modificar canon; Level 2 solo WATCH; Level 3 WATCH/contexto; Level 4 RADAR/hipotesis.
+6. Claims del mismo eventClusterId cuentan como una sola señal causal.
+7. publishedAt/filedAt/eventAt/effectiveAt son conceptos separados.
+8. isNewInformation debe ser verdadero para contar como señal temprana nueva.
+9. Observaciones equivalentes con valores incompatibles quedan QUARANTINED hasta reconciliacion.
+10. REDUCE/SELL exige falsificador de tesis confirmado y evidencia primaria trazable.
+
+## Flujo
+MOBILE INPUT -> EVIDENCE INGESTION -> SOURCE AUTHENTICITY -> CLAIM EXTRACTION -> QUANTITATIVE SEMANTICS -> TEMPORAL NORMALIZATION -> CROSS-SOURCE VERIFICATION -> EVENT DEDUP/SIGNAL INDEPENDENCE -> VALIDATION HARNESS -> EPISTEMIC CLASSIFICATION -> THESIS/FALSIFIER MAPPING -> ENGINES -> DECISION SAFETY GATE -> FINAL SCORE -> DECISION LOG.
+
+## Caso de prueba obligatorio: Money Rotation
+Un informe que sume perdida de capitalizacion de Magnificent 7 con ETF flows y lo denomine dinero rotado debe ser rechazado. Solo ETF_NET_FLOW, MUTUAL_FUND_NET_FLOW, ETF_CREATION_REDEMPTION, INSTITUTIONAL_POSITION_CHANGE o FUND_ALLOCATION pueden alimentar directamente una cifra de flujo.
+
+## Caso de prueba obligatorio: alertas rojas
+Dos cambios ejecutivos derivados de la misma reorganizacion no cuentan automaticamente como dos señales independientes. Un Form 144 o filing reciente que ejecute un plan preexistente no se considera nueva informacion economica sin comprobar eventAt/effectiveAt.
+
+## Caso de prueba obligatorio: accion
+Insider selling, caida de precio o CAPEX creciente no habilitan por si solos REDUCE/SELL. La accion destructiva queda degradada a WATCH si no existe falsificador confirmado con evidencia primaria.

--- a/mobile/domain/agenticSecurityDiscovery.ts
+++ b/mobile/domain/agenticSecurityDiscovery.ts
@@ -1,0 +1,375 @@
+export type AgenticSecurityDimension =
+  | 'DIRECT_AGENTIC_SECURITY'
+  | 'AGENT_IDENTITY'
+  | 'RUNTIME_TOOL_CONTROL'
+  | 'ZERO_TRUST_EGRESS'
+  | 'DATA_MODEL_PROTECTION'
+  | 'SECRETS_PRIVILEGED_ACCESS'
+  | 'AI_GATEWAY_PROMPT_SECURITY'
+  | 'AGENT_OBSERVABILITY';
+
+export type AgenticSecurityStatus = 'DISCOVER' | 'WATCH' | 'REJECT' | 'INSUFFICIENT_EVIDENCE';
+
+export type EvidenceQuality = 'PRIMARY' | 'SECONDARY' | 'UNVERIFIED';
+
+export interface AgenticSecurityEvidence {
+  id: string;
+  text: string;
+  sourceUrl?: string | null;
+  publishedAt?: string | null;
+  quality: EvidenceQuality;
+}
+
+export interface AgenticSecurityCandidate {
+  ticker: string;
+  companyName?: string | null;
+  evidence: AgenticSecurityEvidence[];
+  listed?: boolean | null;
+  commercialTraction?: number | null; // 0..100; ARR/customers/contracts evidence, if available.
+  distributionStrength?: number | null; // 0..100; installed base / enterprise distribution, if available.
+}
+
+export interface AgenticSecuritySeedProfile {
+  ticker: string;
+  label: string;
+  dimensions: Partial<Record<AgenticSecurityDimension, number>>;
+}
+
+export interface AgenticSecurityDiscoveryResult {
+  ticker: string;
+  status: AgenticSecurityStatus;
+  capabilityScore: number;
+  seedSimilarity: number;
+  evidenceScore: number;
+  discoveryScore: number;
+  dimensions: Record<AgenticSecurityDimension, number>;
+  matchedSeeds: Array<{ ticker: string; similarity: number }>;
+  evidenceRefs: string[];
+  flags: string[];
+  nextStep: 'ATLAS_FULL_SCORER' | 'RESEARCH_QUEUE' | 'NONE';
+}
+
+const DIMENSIONS: AgenticSecurityDimension[] = [
+  'DIRECT_AGENTIC_SECURITY',
+  'AGENT_IDENTITY',
+  'RUNTIME_TOOL_CONTROL',
+  'ZERO_TRUST_EGRESS',
+  'DATA_MODEL_PROTECTION',
+  'SECRETS_PRIVILEGED_ACCESS',
+  'AI_GATEWAY_PROMPT_SECURITY',
+  'AGENT_OBSERVABILITY',
+];
+
+// Heuristic discovery priors, not certified company fundamentals. They are seeds used only
+// to identify similar security capability patterns. A seed never receives BUY automatically.
+export const AGENTIC_SECURITY_SEEDS: AgenticSecuritySeedProfile[] = [
+  {
+    ticker: 'PANW',
+    label: 'agentic platform / runtime / network / data security',
+    dimensions: {
+      DIRECT_AGENTIC_SECURITY: 100,
+      AGENT_IDENTITY: 85,
+      RUNTIME_TOOL_CONTROL: 100,
+      ZERO_TRUST_EGRESS: 90,
+      DATA_MODEL_PROTECTION: 90,
+      SECRETS_PRIVILEGED_ACCESS: 80,
+      AI_GATEWAY_PROMPT_SECURITY: 95,
+      AGENT_OBSERVABILITY: 95,
+    },
+  },
+  {
+    ticker: 'NET',
+    label: 'network edge / zero trust / AI gateway / agent identity',
+    dimensions: {
+      DIRECT_AGENTIC_SECURITY: 70,
+      AGENT_IDENTITY: 85,
+      RUNTIME_TOOL_CONTROL: 65,
+      ZERO_TRUST_EGRESS: 100,
+      DATA_MODEL_PROTECTION: 70,
+      SECRETS_PRIVILEGED_ACCESS: 55,
+      AI_GATEWAY_PROMPT_SECURITY: 95,
+      AGENT_OBSERVABILITY: 80,
+    },
+  },
+  {
+    ticker: 'CRWD',
+    label: 'endpoint / identity / behavior / runtime protection',
+    dimensions: {
+      DIRECT_AGENTIC_SECURITY: 70,
+      AGENT_IDENTITY: 90,
+      RUNTIME_TOOL_CONTROL: 90,
+      ZERO_TRUST_EGRESS: 65,
+      DATA_MODEL_PROTECTION: 65,
+      SECRETS_PRIVILEGED_ACCESS: 70,
+      AI_GATEWAY_PROMPT_SECURITY: 55,
+      AGENT_OBSERVABILITY: 95,
+    },
+  },
+  {
+    ticker: 'OKTA',
+    label: 'identity / non-human identity / authorization',
+    dimensions: {
+      DIRECT_AGENTIC_SECURITY: 55,
+      AGENT_IDENTITY: 100,
+      RUNTIME_TOOL_CONTROL: 55,
+      ZERO_TRUST_EGRESS: 65,
+      DATA_MODEL_PROTECTION: 40,
+      SECRETS_PRIVILEGED_ACCESS: 80,
+      AI_GATEWAY_PROMPT_SECURITY: 35,
+      AGENT_OBSERVABILITY: 65,
+    },
+  },
+  {
+    ticker: 'ZS',
+    label: 'zero trust / workload access / egress / data controls',
+    dimensions: {
+      DIRECT_AGENTIC_SECURITY: 65,
+      AGENT_IDENTITY: 75,
+      RUNTIME_TOOL_CONTROL: 70,
+      ZERO_TRUST_EGRESS: 100,
+      DATA_MODEL_PROTECTION: 85,
+      SECRETS_PRIVILEGED_ACCESS: 60,
+      AI_GATEWAY_PROMPT_SECURITY: 75,
+      AGENT_OBSERVABILITY: 85,
+    },
+  },
+];
+
+const KEYWORDS: Record<AgenticSecurityDimension, RegExp[]> = {
+  DIRECT_AGENTIC_SECURITY: [
+    /agentic security/i,
+    /ai agent security/i,
+    /secure ai agents?/i,
+    /agent security platform/i,
+    /agentic runtime security/i,
+  ],
+  AGENT_IDENTITY: [
+    /agent identity/i,
+    /non[- ]human identit/i,
+    /machine identit/i,
+    /workload identit/i,
+    /service account/i,
+    /identity for ai agents?/i,
+  ],
+  RUNTIME_TOOL_CONTROL: [
+    /runtime secur/i,
+    /tool (?:access|control|permission|governance)/i,
+    /agent runtime/i,
+    /sandbox/i,
+    /execution polic/i,
+    /mcp secur/i,
+    /model context protocol/i,
+  ],
+  ZERO_TRUST_EGRESS: [
+    /zero trust/i,
+    /network egress/i,
+    /egress control/i,
+    /secure access service edge|sase/i,
+    /microsegmentation/i,
+    /network polic/i,
+  ],
+  DATA_MODEL_PROTECTION: [
+    /model secur/i,
+    /ai data secur/i,
+    /data loss prevention|\bdlp\b/i,
+    /vector database secur/i,
+    /model theft/i,
+    /training data secur/i,
+    /model artifact/i,
+  ],
+  SECRETS_PRIVILEGED_ACCESS: [
+    /secrets? management/i,
+    /privileged access/i,
+    /credential secur/i,
+    /api key secur/i,
+    /vault/i,
+    /least privilege/i,
+  ],
+  AI_GATEWAY_PROMPT_SECURITY: [
+    /ai gateway/i,
+    /llm gateway/i,
+    /prompt injection/i,
+    /prompt secur/i,
+    /model firewall/i,
+    /ai firewall/i,
+    /guardrails?/i,
+  ],
+  AGENT_OBSERVABILITY: [
+    /agent observability/i,
+    /ai observability/i,
+    /agent monitoring/i,
+    /behavior analytics/i,
+    /agent trace/i,
+    /tool call(?:s)? observ/i,
+    /siem/i,
+  ],
+};
+
+const DIMENSION_WEIGHTS: Record<AgenticSecurityDimension, number> = {
+  DIRECT_AGENTIC_SECURITY: 25,
+  AGENT_IDENTITY: 15,
+  RUNTIME_TOOL_CONTROL: 15,
+  ZERO_TRUST_EGRESS: 10,
+  DATA_MODEL_PROTECTION: 10,
+  SECRETS_PRIVILEGED_ACCESS: 10,
+  AI_GATEWAY_PROMPT_SECURITY: 10,
+  AGENT_OBSERVABILITY: 5,
+};
+
+function clamp(value: number, min = 0, max = 100): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizedTicker(ticker: string): string {
+  return ticker.trim().toUpperCase();
+}
+
+function scoreEvidenceQuality(evidence: AgenticSecurityEvidence[]): number {
+  if (evidence.length === 0) return 0;
+  const points = evidence.map((item) => item.quality === 'PRIMARY' ? 100 : item.quality === 'SECONDARY' ? 55 : 15);
+  const primaryBonus = evidence.some((item) => item.quality === 'PRIMARY') ? 10 : 0;
+  return clamp(points.reduce((a, b) => a + b, 0) / points.length + primaryBonus);
+}
+
+function extractDimensions(evidence: AgenticSecurityEvidence[]): Record<AgenticSecurityDimension, number> {
+  const result = Object.fromEntries(DIMENSIONS.map((dimension) => [dimension, 0])) as Record<AgenticSecurityDimension, number>;
+
+  for (const dimension of DIMENSIONS) {
+    const patterns = KEYWORDS[dimension];
+    let primaryHits = 0;
+    let secondaryHits = 0;
+    let unverifiedHits = 0;
+
+    for (const item of evidence) {
+      if (!patterns.some((pattern) => pattern.test(item.text))) continue;
+      if (item.quality === 'PRIMARY') primaryHits += 1;
+      else if (item.quality === 'SECONDARY') secondaryHits += 1;
+      else unverifiedHits += 1;
+    }
+
+    // Repeated marketing text cannot manufacture a perfect score. Primary evidence dominates.
+    result[dimension] = clamp(
+      Math.min(primaryHits, 2) * 42
+      + Math.min(secondaryHits, 2) * 14
+      + Math.min(unverifiedHits, 1) * 4,
+    );
+  }
+
+  return result;
+}
+
+function weightedCapabilityScore(dimensions: Record<AgenticSecurityDimension, number>): number {
+  const total = DIMENSIONS.reduce((sum, dimension) => sum + dimensions[dimension] * DIMENSION_WEIGHTS[dimension] / 100, 0);
+  return Math.round(total);
+}
+
+function vector(profile: Partial<Record<AgenticSecurityDimension, number>>): number[] {
+  return DIMENSIONS.map((dimension) => profile[dimension] ?? 0);
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, value, index) => sum + value * b[index], 0);
+  const magA = Math.sqrt(a.reduce((sum, value) => sum + value * value, 0));
+  const magB = Math.sqrt(b.reduce((sum, value) => sum + value * value, 0));
+  if (magA === 0 || magB === 0) return 0;
+  return clamp(dot / (magA * magB) * 100);
+}
+
+function activeDimensions(dimensions: Record<AgenticSecurityDimension, number>): number {
+  return DIMENSIONS.filter((dimension) => dimensions[dimension] >= 35).length;
+}
+
+export function evaluateAgenticSecurityCandidate(
+  candidate: AgenticSecurityCandidate,
+  seeds: AgenticSecuritySeedProfile[] = AGENTIC_SECURITY_SEEDS,
+): AgenticSecurityDiscoveryResult {
+  const ticker = normalizedTicker(candidate.ticker);
+  const dimensions = extractDimensions(candidate.evidence);
+  const capabilityScore = weightedCapabilityScore(dimensions);
+  const evidenceScore = Math.round(scoreEvidenceQuality(candidate.evidence));
+  const candidateVector = vector(dimensions);
+  const matchedSeeds = seeds
+    .map((seed) => ({ ticker: seed.ticker, similarity: Math.round(cosineSimilarity(candidateVector, vector(seed.dimensions))) }))
+    .sort((a, b) => b.similarity - a.similarity);
+  const seedSimilarity = matchedSeeds[0]?.similarity ?? 0;
+  const dimensionsCount = activeDimensions(dimensions);
+  const flags: string[] = [];
+
+  if (candidate.listed === false) flags.push('NOT_LISTED');
+  if (!candidate.evidence.some((item) => item.quality === 'PRIMARY')) flags.push('NO_PRIMARY_EVIDENCE');
+  if (dimensionsCount < 2) flags.push('INSUFFICIENT_AGENTIC_BREADTH');
+  if (dimensions.DIRECT_AGENTIC_SECURITY < 35) flags.push('NO_DIRECT_AGENTIC_PRODUCT_EVIDENCE');
+
+  const commercialTraction = clamp(candidate.commercialTraction ?? 50);
+  const distributionStrength = clamp(candidate.distributionStrength ?? 50);
+  const baseScore = capabilityScore * 0.55 + seedSimilarity * 0.20 + evidenceScore * 0.15 + commercialTraction * 0.05 + distributionStrength * 0.05;
+
+  let penalty = 0;
+  if (flags.includes('NO_PRIMARY_EVIDENCE')) penalty += 15;
+  if (flags.includes('INSUFFICIENT_AGENTIC_BREADTH')) penalty += 15;
+  if (flags.includes('NO_DIRECT_AGENTIC_PRODUCT_EVIDENCE')) penalty += 5;
+  if (candidate.listed === false) penalty += 100;
+
+  const discoveryScore = Math.round(clamp(baseScore - penalty));
+
+  let status: AgenticSecurityStatus;
+  if (candidate.evidence.length === 0 || evidenceScore < 25) status = 'INSUFFICIENT_EVIDENCE';
+  else if (candidate.listed === false) status = 'REJECT';
+  else if (discoveryScore >= 70 && dimensionsCount >= 3 && candidate.evidence.some((item) => item.quality === 'PRIMARY')) status = 'DISCOVER';
+  else if (discoveryScore >= 50 && dimensionsCount >= 2) status = 'WATCH';
+  else status = 'REJECT';
+
+  return {
+    ticker,
+    status,
+    capabilityScore,
+    seedSimilarity,
+    evidenceScore,
+    discoveryScore,
+    dimensions,
+    matchedSeeds: matchedSeeds.slice(0, 3),
+    evidenceRefs: candidate.evidence.map((item) => item.id),
+    flags,
+    nextStep: status === 'DISCOVER' ? 'ATLAS_FULL_SCORER' : status === 'WATCH' ? 'RESEARCH_QUEUE' : 'NONE',
+  };
+}
+
+export function rankAgenticSecurityCandidates(
+  candidates: AgenticSecurityCandidate[],
+  seeds: AgenticSecuritySeedProfile[] = AGENTIC_SECURITY_SEEDS,
+): AgenticSecurityDiscoveryResult[] {
+  return candidates
+    .map((candidate) => evaluateAgenticSecurityCandidate(candidate, seeds))
+    .sort((a, b) => b.discoveryScore - a.discoveryScore || a.ticker.localeCompare(b.ticker));
+}
+
+// Fail-fast deterministic contract check usable by CI/runtime self-tests without a test framework.
+export function agenticSecurityDiscoveryContractCheck(): void {
+  const direct = evaluateAgenticSecurityCandidate({
+    ticker: 'TEST',
+    listed: true,
+    commercialTraction: 80,
+    distributionStrength: 80,
+    evidence: [
+      {
+        id: 'primary-1',
+        quality: 'PRIMARY',
+        text: 'Agentic security platform with agent identity, runtime security, tool access control, AI gateway, prompt injection protection, zero trust network egress and agent observability.',
+      },
+      {
+        id: 'primary-2',
+        quality: 'PRIMARY',
+        text: 'Secrets management and least privilege protect API keys and credentials used by AI agents.',
+      },
+    ],
+  });
+  if (direct.status !== 'DISCOVER') throw new Error('Agentic Security Ω contract: direct candidate must DISCOVER');
+  if (direct.nextStep !== 'ATLAS_FULL_SCORER') throw new Error('Agentic Security Ω contract: DISCOVER must route to ATLAS full scorer');
+
+  const generic = evaluateAgenticSecurityCandidate({
+    ticker: 'GENERIC',
+    listed: true,
+    evidence: [{ id: 'generic-1', quality: 'PRIMARY', text: 'Enterprise software company reports quarterly revenue growth.' }],
+  });
+  if (generic.status === 'DISCOVER') throw new Error('Agentic Security Ω contract: generic SaaS cannot DISCOVER');
+}

--- a/src/atlas/algorithm/evidence-ingestion-omega.ts
+++ b/src/atlas/algorithm/evidence-ingestion-omega.ts
@@ -1,0 +1,54 @@
+import { EVIDENCE_INGESTION_ENGINE_ID, EVIDENCE_INGESTION_POSITION } from '../evidence-ingestion/engine';
+
+export const ATLAS_MOBILE_FIRST_RULE = {
+  id: 'MOBILE_FIRST_OMEGA',
+  status: 'canonical',
+  statement:
+    'ATLAS Omega is designed for mobile and mobile apps first. Desktop workflows are implementation helpers, not the default user surface.',
+} as const;
+
+export const EVIDENCE_INGESTION_OMEGA_ALGORITHM_NODE = {
+  id: EVIDENCE_INGESTION_ENGINE_ID,
+  name: 'Evidence Ingestion Omega v1.0',
+  status: 'canonical',
+  position: 'before_validation_and_all_investment_engines',
+  mobileFirst: true,
+  purpose:
+    'Transform public sources, uploaded files, mobile screenshots, shared URLs and pasted text into traceable Evidence Omega records before any Atlas decision engine runs.',
+  canonicalPipeline: EVIDENCE_INGESTION_POSITION,
+  allowedCoreAdapters: ['markitdown', 'firecrawl', 'crawl4ai', 'scrapy', 'playwright'] as const,
+  restrictedAdapters: ['curl-impersonate'] as const,
+  requiredOutputs: [
+    'source',
+    'capturedAt',
+    'rawHash',
+    'extractedTextHash',
+    'evidenceLevel',
+    'epistemicClass',
+    'relatedEngines',
+    'mobile.syncStatus',
+  ] as const,
+  canonicalGuardrails: [
+    'No canonical Atlas state changes from level 3 or 4 sources without primary-source confirmation.',
+    'Mobile screenshots and social posts enter Radar or Hypothesis, never Fact by default.',
+    'No CAPTCHA, paywall, login, private account or anti-abuse bypass in Atlas Core.',
+    'Every Decision Log entry must link to at least one EvidenceRecord.',
+  ] as const,
+} as const;
+
+export const ATLAS_CANONICAL_ALGORITHM_WITH_EVIDENCE_INGESTION = [
+  'MOBILE_INPUT',
+  'EVIDENCE_INGESTION_OMEGA_V1',
+  'VALIDATION_HARNESS_OMEGA',
+  'EPISTEMIC_CLASSIFICATION',
+  'GLOBAL_DISCOVERY',
+  'MARKET_FILTERS',
+  'BUSINESS_QUALITY_OMEGA',
+  'GROWTH_OMEGA',
+  'CAPEX_PRODUCTIVITY_OMEGA',
+  'VALUATION_OMEGA',
+  'RISK_OMEGA',
+  'CATALYSTS_OMEGA',
+  'FINAL_SCORE_OMEGA',
+  'DECISION_LOG_OMEGA',
+] as const;

--- a/src/atlas/algorithm/evidence-integrity-omega.ts
+++ b/src/atlas/algorithm/evidence-integrity-omega.ts
@@ -1,0 +1,44 @@
+import { decisionSafetyGate, assertMoneyRotationSemantics } from '../evidence-ingestion/integrity';
+
+export const EVIDENCE_INTEGRITY_OMEGA_V1_1 = {
+  id: 'EVIDENCE_INTEGRITY_OMEGA_V1_1',
+  status: 'canonical_candidate',
+  mobileFirst: true,
+  rules: [
+    'MARKET_CAP_CHANGE is never CAPITAL_FLOW.',
+    'Price return, market-cap change and AUM change cannot be published as money inflow/outflow.',
+    'Level 2 evidence may trigger WATCH but cannot modify canonical state without Level 1 confirmation.',
+    'Claims from the same causal event cluster count as one signal.',
+    'A newly filed document is not necessarily new economic information.',
+    'Conflicting equivalent quantitative observations require reconciliation before use.',
+    'REDUCE or SELL requires a confirmed thesis falsifier with traceable primary evidence.',
+  ] as const,
+  gates: { moneyRotation: assertMoneyRotationSemantics, decision: decisionSafetyGate },
+} as const;
+
+export const ATLAS_CANONICAL_PIPELINE_V1_1 = [
+  'MOBILE_INPUT',
+  'EVIDENCE_INGESTION_OMEGA_V1',
+  'SOURCE_AUTHENTICITY_OMEGA',
+  'CLAIM_EXTRACTION_OMEGA',
+  'QUANTITATIVE_SEMANTICS_OMEGA',
+  'TEMPORAL_NORMALIZATION_OMEGA',
+  'CROSS_SOURCE_VERIFICATION_OMEGA',
+  'EVENT_DEDUP_SIGNAL_INDEPENDENCE_OMEGA',
+  'VALIDATION_HARNESS_OMEGA',
+  'EPISTEMIC_CLASSIFICATION',
+  'THESIS_FALSIFIER_MAPPING_OMEGA',
+  'GLOBAL_DISCOVERY',
+  'MARKET_FILTERS',
+  'BUSINESS_QUALITY_OMEGA',
+  'GROWTH_OMEGA',
+  'CAPEX_PRODUCTIVITY_OMEGA',
+  'MONEY_ROTATION_OMEGA',
+  'HISTORICAL_DISLOCATION_OMEGA',
+  'VALUATION_OMEGA',
+  'RISK_OMEGA',
+  'CATALYSTS_OMEGA',
+  'DECISION_SAFETY_GATE_OMEGA',
+  'FINAL_SCORE_OMEGA',
+  'DECISION_LOG_OMEGA',
+] as const;

--- a/src/atlas/evidence-ingestion/engine.ts
+++ b/src/atlas/evidence-ingestion/engine.ts
@@ -1,163 +1,81 @@
 import type {
   AtlasEngineId,
-  EpistemicClass,
   EvidenceIngestionInput,
-  EvidenceLevel,
   EvidenceRecord,
   EvidenceValidationResult,
 } from './types';
 
 const PRIMARY_SOURCE_TYPES = new Set([
-  'sec_filing',
-  'investor_relations',
-  'earnings_transcript',
-  'press_release',
-  'regulatory',
+  'sec_filing', 'investor_relations', 'earnings_transcript', 'press_release', 'regulatory',
 ]);
-
 const SECONDARY_SOURCE_TYPES = new Set(['macro_source', 'news', 'web_page', 'uploaded_document']);
 const RADAR_SOURCE_TYPES = new Set(['mobile_capture', 'social_post']);
 
 export const EVIDENCE_INGESTION_ENGINE_ID = 'EVIDENCE_INGESTION_OMEGA_V1' as const;
-
 export const EVIDENCE_INGESTION_POSITION = [
-  'MOBILE_INPUT',
-  'EVIDENCE_INGESTION_OMEGA_V1',
-  'VALIDATION_HARNESS_OMEGA',
-  'EPISTEMIC_CLASSIFICATION',
-  'GLOBAL_DISCOVERY',
-  'MARKET_FILTERS',
-  'BUSINESS_QUALITY_OMEGA',
-  'GROWTH_OMEGA',
-  'CAPEX_PRODUCTIVITY_OMEGA',
-  'VALUATION_OMEGA',
-  'RISK_OMEGA',
-  'CATALYSTS_OMEGA',
-  'FINAL_SCORE_OMEGA',
-  'DECISION_LOG_OMEGA',
+  'MOBILE_INPUT', 'EVIDENCE_INGESTION_OMEGA_V1', 'VALIDATION_HARNESS_OMEGA',
+  'EPISTEMIC_CLASSIFICATION', 'GLOBAL_DISCOVERY', 'MARKET_FILTERS',
+  'BUSINESS_QUALITY_OMEGA', 'GROWTH_OMEGA', 'CAPEX_PRODUCTIVITY_OMEGA',
+  'VALUATION_OMEGA', 'RISK_OMEGA', 'CATALYSTS_OMEGA', 'FINAL_SCORE_OMEGA', 'DECISION_LOG_OMEGA',
 ] as const;
 
 export function validateEvidenceInput(input: EvidenceIngestionInput): EvidenceValidationResult {
   const reasons: string[] = [];
-
-  if (!input.extractedText.trim()) {
-    reasons.push('empty_extracted_text');
-  }
-
-  if (!input.sourceUrl && !input.sourceFile && input.inputKind !== 'manual_note') {
-    reasons.push('missing_traceable_source');
-  }
-
-  if (input.adapter === 'playwright' && input.sourceType === 'social_post') {
-    reasons.push('browser_adapter_social_post_requires_manual_review');
-  }
+  if (!input.extractedText.trim()) reasons.push('empty_extracted_text');
+  if (!input.sourceUrl && !input.sourceFile && input.inputKind !== 'manual_note') reasons.push('missing_traceable_source');
+  if (input.adapter === 'playwright' && input.sourceType === 'social_post') reasons.push('browser_adapter_social_post_requires_manual_review');
 
   if (input.adapter === 'manual' || RADAR_SOURCE_TYPES.has(input.sourceType)) {
-    return {
-      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
-      reasons,
-      evidenceLevel: 4,
-      epistemicClass: 'hypothesis',
-    };
+    return { status: reasons.length ? 'QUARANTINED' : 'PASS', reasons, evidenceLevel: 4, epistemicClass: 'hypothesis' };
   }
-
   if (PRIMARY_SOURCE_TYPES.has(input.sourceType)) {
-    return {
-      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
-      reasons,
-      evidenceLevel: 1,
-      epistemicClass: 'evidence',
-    };
+    return { status: reasons.length ? 'QUARANTINED' : 'PASS', reasons, evidenceLevel: 1, epistemicClass: 'evidence' };
   }
-
   if (SECONDARY_SOURCE_TYPES.has(input.sourceType)) {
     return {
-      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
-      reasons,
+      status: reasons.length ? 'QUARANTINED' : 'PASS', reasons,
       evidenceLevel: input.sourceType === 'macro_source' ? 2 : 3,
       epistemicClass: input.sourceType === 'uploaded_document' ? 'evidence' : 'interpretation',
     };
   }
-
-  return {
-    status: 'QUARANTINED',
-    reasons: [...reasons, 'unknown_source_type'],
-    evidenceLevel: 4,
-    epistemicClass: 'noise',
-  };
+  return { status: 'QUARANTINED', reasons: [...reasons, 'unknown_source_type'], evidenceLevel: 4, epistemicClass: 'noise' };
 }
 
+// Canonical state changes require Level 1 primary evidence. Level 2 may trigger WATCH only.
 export function canModifyCanonicalAtlasState(record: EvidenceRecord): boolean {
-  return record.evidenceLevel <= 2 && (record.epistemicClass === 'fact' || record.epistemicClass === 'evidence');
+  return record.evidenceLevel === 1 && (record.epistemicClass === 'fact' || record.epistemicClass === 'evidence');
 }
 
 export function routeEvidenceToEngines(record: EvidenceRecord): AtlasEngineId[] {
   const engines = new Set<AtlasEngineId>(record.relatedEngines);
   const text = `${record.title ?? ''} ${record.summary} ${record.keyClaims.join(' ')}`.toLowerCase();
-
-  if (text.includes('capex') || text.includes('free cash flow') || text.includes('fcf') || text.includes('roic')) {
-    engines.add('CAPEX_PRODUCTIVITY_OMEGA');
-  }
-
+  if (text.includes('capex') || text.includes('free cash flow') || text.includes('fcf') || text.includes('roic')) engines.add('CAPEX_PRODUCTIVITY_OMEGA');
   if (text.includes('gold') || text.includes('oil') || text.includes('rates') || text.includes('dollar') || text.includes('flows')) {
-    engines.add('MONEY_ROTATION_OMEGA');
-    engines.add('HISTORICAL_DISLOCATION_OMEGA');
+    engines.add('MONEY_ROTATION_OMEGA'); engines.add('HISTORICAL_DISLOCATION_OMEGA');
   }
-
-  if (text.includes('security') || text.includes('agent') || text.includes('identity') || text.includes('zero trust')) {
-    engines.add('FUTUROS_PROTECTORES_DIGITALES');
-  }
-
-  if (record.evidenceLevel === 4) {
-    engines.add('CONSPIRACIONES_ATLAS');
-  }
-
+  if (text.includes('security') || text.includes('agent') || text.includes('identity') || text.includes('zero trust')) engines.add('FUTUROS_PROTECTORES_DIGITALES');
+  if (record.evidenceLevel === 4) engines.add('CONSPIRACIONES_ATLAS');
   return Array.from(engines);
 }
 
-export async function buildEvidenceRecord(
-  input: EvidenceIngestionInput,
-  hash: (value: string) => Promise<string>,
-): Promise<EvidenceRecord> {
+export async function buildEvidenceRecord(input: EvidenceIngestionInput, hash: (value: string) => Promise<string>): Promise<EvidenceRecord> {
   const validation = validateEvidenceInput(input);
   const rawHash = await hash(`${input.sourceUrl ?? ''}${input.sourceFile ?? ''}${input.extractedText}`);
   const extractedTextHash = await hash(input.extractedText);
-  const summary = input.extractedText.trim().slice(0, 500);
-
   const draft: EvidenceRecord = {
-    id: `evidence_${rawHash.slice(0, 16)}`,
-    sourceUrl: input.sourceUrl,
-    sourceFile: input.sourceFile,
-    sourceType: input.sourceType,
-    capturedAt: input.capturedAt,
-    publisher: input.publisher,
-    title: input.title,
-    rawHash,
-    extractedTextHash,
-    extractionAdapter: input.adapter,
-    evidenceLevel: validation.evidenceLevel,
-    epistemicClass: validation.epistemicClass,
-    relatedTickers: input.relatedTickers ?? [],
-    relatedEngines: input.relatedEngines ?? [],
-    summary,
-    keyClaims: [],
-    limitations: validation.reasons,
-    mobile: {
-      inputKind: input.inputKind,
-      offlineReady: true,
-      syncStatus: 'pending_sync',
-    },
+    id: `evidence_${rawHash.slice(0, 16)}`, sourceUrl: input.sourceUrl, sourceFile: input.sourceFile,
+    sourceType: input.sourceType, capturedAt: input.capturedAt, publisher: input.publisher, title: input.title,
+    rawHash, extractedTextHash, extractionAdapter: input.adapter, evidenceLevel: validation.evidenceLevel,
+    epistemicClass: validation.epistemicClass, relatedTickers: input.relatedTickers ?? [], relatedEngines: input.relatedEngines ?? [],
+    summary: input.extractedText.trim().slice(0, 500), keyClaims: [], limitations: validation.reasons,
+    mobile: { inputKind: input.inputKind, offlineReady: true, syncStatus: 'pending_sync' },
   };
-
-  return {
-    ...draft,
-    relatedEngines: routeEvidenceToEngines(draft),
-  };
+  return { ...draft, relatedEngines: routeEvidenceToEngines(draft) };
 }
 
 export function classifyCanonicalImpact(record: EvidenceRecord): 'canonical' | 'watch' | 'radar' | 'reject' {
   if (canModifyCanonicalAtlasState(record)) return 'canonical';
-  if (record.evidenceLevel === 3) return 'watch';
+  if (record.evidenceLevel === 2 || record.evidenceLevel === 3) return 'watch';
   if (record.evidenceLevel === 4 && record.epistemicClass !== 'noise') return 'radar';
   return 'reject';
 }

--- a/src/atlas/evidence-ingestion/engine.ts
+++ b/src/atlas/evidence-ingestion/engine.ts
@@ -1,0 +1,163 @@
+import type {
+  AtlasEngineId,
+  EpistemicClass,
+  EvidenceIngestionInput,
+  EvidenceLevel,
+  EvidenceRecord,
+  EvidenceValidationResult,
+} from './types';
+
+const PRIMARY_SOURCE_TYPES = new Set([
+  'sec_filing',
+  'investor_relations',
+  'earnings_transcript',
+  'press_release',
+  'regulatory',
+]);
+
+const SECONDARY_SOURCE_TYPES = new Set(['macro_source', 'news', 'web_page', 'uploaded_document']);
+const RADAR_SOURCE_TYPES = new Set(['mobile_capture', 'social_post']);
+
+export const EVIDENCE_INGESTION_ENGINE_ID = 'EVIDENCE_INGESTION_OMEGA_V1' as const;
+
+export const EVIDENCE_INGESTION_POSITION = [
+  'MOBILE_INPUT',
+  'EVIDENCE_INGESTION_OMEGA_V1',
+  'VALIDATION_HARNESS_OMEGA',
+  'EPISTEMIC_CLASSIFICATION',
+  'GLOBAL_DISCOVERY',
+  'MARKET_FILTERS',
+  'BUSINESS_QUALITY_OMEGA',
+  'GROWTH_OMEGA',
+  'CAPEX_PRODUCTIVITY_OMEGA',
+  'VALUATION_OMEGA',
+  'RISK_OMEGA',
+  'CATALYSTS_OMEGA',
+  'FINAL_SCORE_OMEGA',
+  'DECISION_LOG_OMEGA',
+] as const;
+
+export function validateEvidenceInput(input: EvidenceIngestionInput): EvidenceValidationResult {
+  const reasons: string[] = [];
+
+  if (!input.extractedText.trim()) {
+    reasons.push('empty_extracted_text');
+  }
+
+  if (!input.sourceUrl && !input.sourceFile && input.inputKind !== 'manual_note') {
+    reasons.push('missing_traceable_source');
+  }
+
+  if (input.adapter === 'playwright' && input.sourceType === 'social_post') {
+    reasons.push('browser_adapter_social_post_requires_manual_review');
+  }
+
+  if (input.adapter === 'manual' || RADAR_SOURCE_TYPES.has(input.sourceType)) {
+    return {
+      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
+      reasons,
+      evidenceLevel: 4,
+      epistemicClass: 'hypothesis',
+    };
+  }
+
+  if (PRIMARY_SOURCE_TYPES.has(input.sourceType)) {
+    return {
+      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
+      reasons,
+      evidenceLevel: 1,
+      epistemicClass: 'evidence',
+    };
+  }
+
+  if (SECONDARY_SOURCE_TYPES.has(input.sourceType)) {
+    return {
+      status: reasons.length > 0 ? 'QUARANTINED' : 'PASS',
+      reasons,
+      evidenceLevel: input.sourceType === 'macro_source' ? 2 : 3,
+      epistemicClass: input.sourceType === 'uploaded_document' ? 'evidence' : 'interpretation',
+    };
+  }
+
+  return {
+    status: 'QUARANTINED',
+    reasons: [...reasons, 'unknown_source_type'],
+    evidenceLevel: 4,
+    epistemicClass: 'noise',
+  };
+}
+
+export function canModifyCanonicalAtlasState(record: EvidenceRecord): boolean {
+  return record.evidenceLevel <= 2 && (record.epistemicClass === 'fact' || record.epistemicClass === 'evidence');
+}
+
+export function routeEvidenceToEngines(record: EvidenceRecord): AtlasEngineId[] {
+  const engines = new Set<AtlasEngineId>(record.relatedEngines);
+  const text = `${record.title ?? ''} ${record.summary} ${record.keyClaims.join(' ')}`.toLowerCase();
+
+  if (text.includes('capex') || text.includes('free cash flow') || text.includes('fcf') || text.includes('roic')) {
+    engines.add('CAPEX_PRODUCTIVITY_OMEGA');
+  }
+
+  if (text.includes('gold') || text.includes('oil') || text.includes('rates') || text.includes('dollar') || text.includes('flows')) {
+    engines.add('MONEY_ROTATION_OMEGA');
+    engines.add('HISTORICAL_DISLOCATION_OMEGA');
+  }
+
+  if (text.includes('security') || text.includes('agent') || text.includes('identity') || text.includes('zero trust')) {
+    engines.add('FUTUROS_PROTECTORES_DIGITALES');
+  }
+
+  if (record.evidenceLevel === 4) {
+    engines.add('CONSPIRACIONES_ATLAS');
+  }
+
+  return Array.from(engines);
+}
+
+export async function buildEvidenceRecord(
+  input: EvidenceIngestionInput,
+  hash: (value: string) => Promise<string>,
+): Promise<EvidenceRecord> {
+  const validation = validateEvidenceInput(input);
+  const rawHash = await hash(`${input.sourceUrl ?? ''}${input.sourceFile ?? ''}${input.extractedText}`);
+  const extractedTextHash = await hash(input.extractedText);
+  const summary = input.extractedText.trim().slice(0, 500);
+
+  const draft: EvidenceRecord = {
+    id: `evidence_${rawHash.slice(0, 16)}`,
+    sourceUrl: input.sourceUrl,
+    sourceFile: input.sourceFile,
+    sourceType: input.sourceType,
+    capturedAt: input.capturedAt,
+    publisher: input.publisher,
+    title: input.title,
+    rawHash,
+    extractedTextHash,
+    extractionAdapter: input.adapter,
+    evidenceLevel: validation.evidenceLevel,
+    epistemicClass: validation.epistemicClass,
+    relatedTickers: input.relatedTickers ?? [],
+    relatedEngines: input.relatedEngines ?? [],
+    summary,
+    keyClaims: [],
+    limitations: validation.reasons,
+    mobile: {
+      inputKind: input.inputKind,
+      offlineReady: true,
+      syncStatus: 'pending_sync',
+    },
+  };
+
+  return {
+    ...draft,
+    relatedEngines: routeEvidenceToEngines(draft),
+  };
+}
+
+export function classifyCanonicalImpact(record: EvidenceRecord): 'canonical' | 'watch' | 'radar' | 'reject' {
+  if (canModifyCanonicalAtlasState(record)) return 'canonical';
+  if (record.evidenceLevel === 3) return 'watch';
+  if (record.evidenceLevel === 4 && record.epistemicClass !== 'noise') return 'radar';
+  return 'reject';
+}

--- a/src/atlas/evidence-ingestion/integrity.test.ts
+++ b/src/atlas/evidence-ingestion/integrity.test.ts
@@ -1,0 +1,43 @@
+import {
+  assertMoneyRotationSemantics,
+  decisionSafetyGate,
+  independentSignalCount,
+  requiresReconciliation,
+  type ClaimRecord,
+} from './integrity';
+
+const baseClaim: ClaimRecord = {
+  id: 'c1', evidenceId: 'e1', text: 'primary claim', claimClass: 'fact', sourceLevel: 1,
+  independenceScore: 1, isNewInformation: true, confirmedByPrimaryEvidenceIds: ['e1'],
+};
+
+describe('Evidence Integrity Omega v1.1', () => {
+  it('rejects market-cap change as money flow', () => {
+    expect(() => assertMoneyRotationSemantics({
+      metric: 'MARKET_CAP_CHANGE', value: -1.5e12, unit: 'USD', currency: 'USD', asOf: '2026-08-09', sourceEvidenceId: 'e1',
+    })).toThrow('money_rotation_non_flow_metric:MARKET_CAP_CHANGE');
+  });
+
+  it('accepts explicit ETF net flow', () => {
+    expect(() => assertMoneyRotationSemantics({
+      metric: 'ETF_NET_FLOW', value: 1.44e9, unit: 'USD', currency: 'USD', asOf: '2026-08-05', sourceEvidenceId: 'e2',
+    })).not.toThrow();
+  });
+
+  it('deduplicates claims in the same causal cluster', () => {
+    expect(independentSignalCount([
+      { ...baseClaim, id: 'c1', eventClusterId: 'google-ai-reorg' },
+      { ...baseClaim, id: 'c2', eventClusterId: 'google-ai-reorg' },
+    ])).toBe(1);
+  });
+
+  it('degrades REDUCE to WATCH without confirmed falsifier', () => {
+    expect(decisionSafetyGate({ requestedAction: 'REDUCE', claims: [baseClaim], confirmedThesisFalsifier: false, falsifierEvidenceIds: [] }).action).toBe('WATCH');
+  });
+
+  it('quarantines conflicting equivalent quantitative observations for reconciliation', () => {
+    const a = { metric: 'ETF_NET_FLOW' as const, value: 10, unit: 'USD', currency: 'USD', asOf: '2026-08-09', universe: 'XLV', sourceEvidenceId: 'e1' };
+    const b = { ...a, value: 20, sourceEvidenceId: 'e2' };
+    expect(requiresReconciliation(a, b)).toBe(true);
+  });
+});

--- a/src/atlas/evidence-ingestion/integrity.ts
+++ b/src/atlas/evidence-ingestion/integrity.ts
@@ -1,0 +1,117 @@
+export type QuantMetricType =
+  | 'MARKET_CAP_CHANGE'
+  | 'ETF_NET_FLOW'
+  | 'MUTUAL_FUND_NET_FLOW'
+  | 'ETF_CREATION_REDEMPTION'
+  | 'AUM_CHANGE'
+  | 'PRICE_RETURN'
+  | 'VOLUME'
+  | 'INSTITUTIONAL_POSITION_CHANGE'
+  | 'FUND_ALLOCATION'
+  | 'CAPEX'
+  | 'FCF'
+  | 'ROIC';
+
+export type ClaimClass = 'fact' | 'evidence' | 'interpretation' | 'hypothesis' | 'speculation';
+
+export type QuantitativeObservation = {
+  metric: QuantMetricType;
+  value: number;
+  unit: string;
+  currency?: string;
+  periodStart?: string;
+  periodEnd?: string;
+  asOf: string;
+  universe?: string;
+  measurementMethod?: string;
+  sourceEvidenceId: string;
+};
+
+export type ClaimRecord = {
+  id: string;
+  evidenceId: string;
+  text: string;
+  claimClass: ClaimClass;
+  sourceLevel: 1 | 2 | 3 | 4;
+  eventClusterId?: string;
+  independenceScore: number;
+  publishedAt?: string;
+  filedAt?: string;
+  eventAt?: string;
+  effectiveAt?: string;
+  isNewInformation: boolean;
+  quantitative?: QuantitativeObservation;
+  confirmedByPrimaryEvidenceIds: string[];
+};
+
+export type AtlasAction = 'HOLD' | 'WATCH' | 'BUY' | 'REDUCE' | 'SELL';
+
+export function isCapitalFlowMetric(metric: QuantMetricType): boolean {
+  return metric === 'ETF_NET_FLOW' ||
+    metric === 'MUTUAL_FUND_NET_FLOW' ||
+    metric === 'ETF_CREATION_REDEMPTION' ||
+    metric === 'INSTITUTIONAL_POSITION_CHANGE' ||
+    metric === 'FUND_ALLOCATION';
+}
+
+export function assertMoneyRotationSemantics(observation: QuantitativeObservation): void {
+  if (!isCapitalFlowMetric(observation.metric)) {
+    throw new Error(`money_rotation_non_flow_metric:${observation.metric}`);
+  }
+}
+
+export function canClaimCanonicalFact(claim: ClaimRecord): boolean {
+  if (claim.sourceLevel === 1 && (claim.claimClass === 'fact' || claim.claimClass === 'evidence')) return true;
+  return claim.confirmedByPrimaryEvidenceIds.length > 0 &&
+    (claim.claimClass === 'fact' || claim.claimClass === 'evidence');
+}
+
+export function independentSignalCount(claims: ClaimRecord[], minimumIndependence = 0.7): number {
+  const clusters = new Set<string>();
+  let independent = 0;
+  for (const claim of claims) {
+    if (!claim.isNewInformation || claim.independenceScore < minimumIndependence) continue;
+    if (claim.eventClusterId) {
+      if (clusters.has(claim.eventClusterId)) continue;
+      clusters.add(claim.eventClusterId);
+    }
+    independent += 1;
+  }
+  return independent;
+}
+
+export type DecisionGateInput = {
+  requestedAction: AtlasAction;
+  claims: ClaimRecord[];
+  confirmedThesisFalsifier: boolean;
+  falsifierEvidenceIds: string[];
+};
+
+export type DecisionGateResult = {
+  allowed: boolean;
+  action: AtlasAction;
+  reasons: string[];
+};
+
+export function decisionSafetyGate(input: DecisionGateInput): DecisionGateResult {
+  const reasons: string[] = [];
+  const destructive = input.requestedAction === 'REDUCE' || input.requestedAction === 'SELL';
+
+  if (destructive && !input.confirmedThesisFalsifier) reasons.push('destructive_action_requires_confirmed_thesis_falsifier');
+  if (destructive && input.falsifierEvidenceIds.length === 0) reasons.push('destructive_action_requires_traceable_primary_evidence');
+  if (destructive && independentSignalCount(input.claims) < 1) reasons.push('destructive_action_requires_independent_new_signal');
+
+  return {
+    allowed: reasons.length === 0,
+    action: reasons.length === 0 ? input.requestedAction : 'WATCH',
+    reasons,
+  };
+}
+
+export function reconciliationKey(observation: QuantitativeObservation): string {
+  return [observation.metric, observation.unit, observation.currency ?? '', observation.periodStart ?? '', observation.periodEnd ?? '', observation.asOf, observation.universe ?? ''].join('|');
+}
+
+export function requiresReconciliation(a: QuantitativeObservation, b: QuantitativeObservation): boolean {
+  return reconciliationKey(a) === reconciliationKey(b) && a.value !== b.value;
+}

--- a/src/atlas/evidence-ingestion/types.ts
+++ b/src/atlas/evidence-ingestion/types.ts
@@ -1,0 +1,101 @@
+export type EvidenceSourceType =
+  | 'sec_filing'
+  | 'investor_relations'
+  | 'earnings_transcript'
+  | 'press_release'
+  | 'regulatory'
+  | 'macro_source'
+  | 'news'
+  | 'uploaded_document'
+  | 'web_page'
+  | 'mobile_capture'
+  | 'social_post';
+
+export type IngestionAdapter =
+  | 'markitdown'
+  | 'firecrawl'
+  | 'crawl4ai'
+  | 'scrapy'
+  | 'playwright'
+  | 'crawlee'
+  | 'manual'
+  | 'mobile_capture';
+
+export type EvidenceLevel = 1 | 2 | 3 | 4;
+
+export type EpistemicClass =
+  | 'fact'
+  | 'evidence'
+  | 'hypothesis'
+  | 'interpretation'
+  | 'speculation'
+  | 'noise';
+
+export type AtlasEngineId =
+  | 'GLOBAL_DISCOVERY'
+  | 'MARKET_FILTERS'
+  | 'BUSINESS_QUALITY_OMEGA'
+  | 'GROWTH_OMEGA'
+  | 'CAPEX_PRODUCTIVITY_OMEGA'
+  | 'VALUATION_OMEGA'
+  | 'RISK_OMEGA'
+  | 'CATALYSTS_OMEGA'
+  | 'MONEY_ROTATION_OMEGA'
+  | 'HISTORICAL_DISLOCATION_OMEGA'
+  | 'FUTUROS_PROTECTORES_DIGITALES'
+  | 'CONSPIRACIONES_ATLAS'
+  | 'FINAL_SCORE_OMEGA';
+
+export type MobileInputKind =
+  | 'share_url'
+  | 'upload_file'
+  | 'paste_text'
+  | 'screenshot'
+  | 'manual_note'
+  | 'synced_source';
+
+export type EvidenceRecord = {
+  id: string;
+  sourceUrl?: string;
+  sourceFile?: string;
+  sourceType: EvidenceSourceType;
+  capturedAt: string;
+  publisher?: string;
+  title?: string;
+  rawHash: string;
+  extractedTextHash: string;
+  extractionAdapter: IngestionAdapter;
+  evidenceLevel: EvidenceLevel;
+  epistemicClass: EpistemicClass;
+  relatedTickers: string[];
+  relatedEngines: AtlasEngineId[];
+  summary: string;
+  keyClaims: string[];
+  limitations: string[];
+  mobile: {
+    inputKind: MobileInputKind;
+    offlineReady: boolean;
+    syncStatus: 'local_only' | 'pending_sync' | 'synced' | 'failed';
+  };
+};
+
+export type EvidenceIngestionInput = {
+  inputKind: MobileInputKind;
+  sourceUrl?: string;
+  sourceFile?: string;
+  extractedText: string;
+  sourceType: EvidenceSourceType;
+  adapter: IngestionAdapter;
+  capturedAt: string;
+  publisher?: string;
+  title?: string;
+  relatedTickers?: string[];
+  relatedEngines?: AtlasEngineId[];
+};
+
+export type EvidenceValidationResult = {
+  status: 'PASS' | 'QUARANTINED' | 'REJECT';
+  reasons: string[];
+  evidenceLevel: EvidenceLevel;
+  epistemicClass: EpistemicClass;
+};


### PR DESCRIPTION
Temporary integration PR to bring current `main` (including Evidence Integrity Ω v1.1) into `feat/mobile-market-scanner-v1` before consolidating the definitive mobile release.