### PR TITLE
feat: AI Infrastructure Rotation Ω v1

### DIFF
--- a/CURRENT_CANON/ATLAS_OMEGA_CURRENT_CANON.md
+++ b/CURRENT_CANON/ATLAS_OMEGA_CURRENT_CANON.md
@@ -42,6 +42,35 @@ Grade F (`Fundamental Deterioration Candidate`) MUST route to `Auditor Ω -> The
 
 Pre-event `pea_manifest_locked.json` is cryptographically sealed using RFC 8785 (JCS) + SHA-256 and is immutable/independent from later `earnings_outcome.json` and `pev_report.json` artifacts.
 
+## Money Rotation Ω
+
+MONEY_ROTATION Ω v1.3 is the canonical candidate layer for early capital rotation and historical dislocation detection.
+
+Rules:
+
+- Flow totals must use comparable, additive and non-overlapping flow metrics.
+- Price-only momentum is a market sensor, never proof of canonical R3/R4.
+- R3 requires multi-signal confirmation; R4 requires persistent comparable flows plus positive reaction to good news after destruction.
+- R5 is the handoff to the main ATLAS discovery/scoring stack; R6 is consensus/crowding and must not be chased mechanically.
+- Rotation evidence never emits a portfolio order by itself.
+
+### AI Infrastructure Rotation Ω
+
+`AI_INFRASTRUCTURE_ROTATION_OMEGA_v1` is registered under MONEY_ROTATION Ω for AI data-center optics, AI power/grid, industrial networking and defense connectivity beneficiaries.
+
+Canonical rule:
+
+`Excellent business != early rotation opportunity`.
+
+The engine ranks companies by business quality, normalized growth, CAPEX productivity, valuation margin of safety, financial inflection, AI infrastructure purity, cash generation and balance-sheet strength, then penalizes narrative crowding and completed price discovery.
+
+Fujikura/Furukawa application:
+
+- Fujikura may remain a high-quality `BUY_REVIEW`, but maps to `R5_DISCOVERED_BY_ATLAS_MAIN` when the market has already discovered the AI optics story.
+- Furukawa Electric can rank higher as `R4_TO_R5_RELATIVE_OPPORTUNITY` when the same AI optics demand is converting losses into profit/guidance acceleration with less mature consensus and better valuation asymmetry.
+
+The engine rejects mixed-thesis rankings and untraceable claims.
+
 ## Epistemic governance
 
 `Information Received != Admissible Evidence`.

--- a/docs/canon/AI_INFRASTRUCTURE_ROTATION_OMEGA_v1.md
+++ b/docs/canon/AI_INFRASTRUCTURE_ROTATION_OMEGA_v1.md
@@ -1,0 +1,96 @@
+# AI INFRASTRUCTURE ROTATION Ω v1.0
+
+Status: canonical candidate
+Date: 2026-08-10
+Scope: MONEY_ROTATION Ω + HISTORICAL_DISLOCATION Ω + Business Quality Ω + Valuation Ω
+
+## Mission
+
+Rank AI infrastructure beneficiaries without confusing a great company with an early rotation opportunity.
+
+The layer exists because the AI infrastructure chain is broader than GPUs. Capital can rotate into optical fiber, data-center connectivity, power, grid, cooling, industrial networking and defense connectivity. The algorithm must separate:
+
+1. Business quality.
+2. Growth durability.
+3. CAPEX productivity.
+4. Valuation margin of safety.
+5. Financial inflection.
+6. AI infrastructure purity.
+7. Narrative crowding.
+8. Price discovery already completed.
+
+## Core Rule
+
+A company can be a `BUY_REVIEW` while no longer being an early `R2/R3` opportunity.
+
+A lower-quality peer can outrank a higher-quality leader when the peer has stronger financial inflection, less narrative crowding and better valuation asymmetry within the same thesis.
+
+## Required Evidence
+
+Every ranked company requires:
+
+- at least two traceable evidence IDs;
+- confirmed structural integrity;
+- a specific thesis bucket;
+- comparable ranking only against companies in the same thesis bucket;
+- explicit valuation and narrative-crowding assessment.
+
+Mixed-thesis rankings are rejected. Optical fiber, power grid, industrial networking and defense connectivity can be discussed together qualitatively, but the relative ranking engine requires one thesis at a time.
+
+## Score Weights
+
+| Factor | Weight |
+| --- | ---: |
+| Business quality | 14% |
+| Normalized growth | 15% |
+| CAPEX productivity | 15% |
+| Valuation margin of safety | 20% |
+| Financial inflection | 18% |
+| AI infrastructure purity | 10% |
+| Cash generation | 5% |
+| Balance-sheet strength | 3% |
+
+Narrative crowding above 65 and price discovery above 75 reduce the opportunity score.
+
+## Phase Mapping
+
+| Phase | Meaning |
+| --- | --- |
+| `R3_CANDIDATE_MONITOR` | Signal exists, but inflection or evidence is still incomplete. |
+| `R4_EARLY_ACCUMULATION` | Financial inflection and CAPEX productivity are visible, but asymmetry is not yet fully confirmed. |
+| `R4_TO_R5_RELATIVE_OPPORTUNITY` | Same structural wave, visible inflection, less mature consensus and better valuation asymmetry. |
+| `R5_DISCOVERED_BY_ATLAS_MAIN` | Strong company and valid thesis, but the market has already discovered the story. |
+| `R6_CONSENSUS_CROWDING` | Consensus or price discovery is extreme; avoid chasing mechanically. |
+| `REJECT_INSUFFICIENT_EVIDENCE` | Evidence, comparability or structural integrity requirements are missing. |
+
+## Fujikura / Furukawa Rule
+
+Fujikura is treated as the better AI optical pure-play when its quality, growth and CAPEX productivity remain superior. However, after major price discovery and visible narrative adoption, it maps to `R5_DISCOVERED_BY_ATLAS_MAIN`, not an early `R3` entry.
+
+Furukawa Electric can rank higher on relative opportunity when the same AI optics demand is converting from communications losses into profit, guidance acceleration and capacity expansion while valuation and narrative crowding remain more favorable. That maps to `R4_TO_R5_RELATIVE_OPPORTUNITY`.
+
+## Safety Rules
+
+AI Infrastructure Rotation Ω must never:
+
+- place orders by itself;
+- convert a qualitative story into a ranked result without traceable evidence;
+- compare unrelated thesis buckets as if they were one opportunity set;
+- treat a large share-price move as proof of future return;
+- treat high quality as equivalent to high margin of safety;
+- ignore multiple compression risk after a story reaches `R5` or `R6`.
+
+## Mobile-First Output
+
+The mobile card should show:
+
+- company;
+- thesis bucket;
+- phase;
+- opportunity score;
+- quality composite;
+- reasons;
+- guardrails;
+- next review trigger.
+
+Recommended review triggers: earnings, guidance, capacity expansion, contract wins, margin inflection, material multiple expansion or compression.

--- a/src/atlas/algorithm/ai-infrastructure-rotation-omega.test.ts
+++ b/src/atlas/algorithm/ai-infrastructure-rotation-omega.test.ts
@@ -1,0 +1,57 @@
+import {
+  FUJIKURA_FURUKAWA_AI_OPTICS_CASES,
+  assessAiInfrastructureRotation,
+  rankAiInfrastructureRotation,
+  type AiInfrastructureCompanyInput,
+} from './ai-infrastructure-rotation-omega';
+
+describe('AI Infrastructure Rotation Omega v1', () => {
+  const [fujikura, furukawa] = FUJIKURA_FURUKAWA_AI_OPTICS_CASES;
+
+  it('classifies Fujikura as discovered R5 instead of an early R3 opportunity', () => {
+    expect(assessAiInfrastructureRotation(fujikura)).toMatchObject({
+      company: 'Fujikura',
+      phase: 'R5_DISCOVERED_BY_ATLAS_MAIN',
+      decision: 'BUY_REVIEW',
+    });
+  });
+
+  it('classifies Furukawa as the relative R4 to R5 opportunity', () => {
+    expect(assessAiInfrastructureRotation(furukawa)).toMatchObject({
+      company: 'Furukawa Electric',
+      phase: 'R4_TO_R5_RELATIVE_OPPORTUNITY',
+      decision: 'BUY_REVIEW',
+    });
+  });
+
+  it('ranks Furukawa above Fujikura on relative opportunity despite lower pure business quality', () => {
+    const ranking = rankAiInfrastructureRotation(FUJIKURA_FURUKAWA_AI_OPTICS_CASES);
+    expect(ranking.map((result) => result.company)).toEqual(['Furukawa Electric', 'Fujikura']);
+    expect(ranking[0].qualityComposite).toBeLessThan(ranking[1].qualityComposite);
+    expect(ranking[0].opportunityScore).toBeGreaterThan(ranking[1].opportunityScore);
+  });
+
+  it('rejects rankings that mix incomparable AI infrastructure theses', () => {
+    const mixed: readonly AiInfrastructureCompanyInput[] = [
+      fujikura,
+      { ...furukawa, id: 'FURUKAWA_GRID_MIXED_CASE', thesis: 'AI_POWER_GRID' },
+    ];
+    expect(() => rankAiInfrastructureRotation(mixed)).toThrow('ai_infra_rotation_ranking_requires_single_thesis');
+  });
+
+  it('rejects untraceable or structurally unconfirmed claims', () => {
+    expect(assessAiInfrastructureRotation({
+      ...furukawa,
+      id: 'VAGUE_AI_WINNER',
+      evidenceIds: ['single-blog-post'],
+      structuralIntegrity: false,
+    })).toMatchObject({
+      phase: 'REJECT_INSUFFICIENT_EVIDENCE',
+      decision: 'REJECT',
+      reasons: expect.arrayContaining([
+        'requires_at_least_two_traceable_evidence_ids',
+        'structural_integrity_not_confirmed',
+      ]),
+    });
+  });
+});

--- a/src/atlas/algorithm/ai-infrastructure-rotation-omega.ts
+++ b/src/atlas/algorithm/ai-infrastructure-rotation-omega.ts
@@ -1,0 +1,247 @@
+export type AiInfrastructureRotationPhase =
+  | 'R3_CANDIDATE_MONITOR'
+  | 'R4_EARLY_ACCUMULATION'
+  | 'R4_TO_R5_RELATIVE_OPPORTUNITY'
+  | 'R5_DISCOVERED_BY_ATLAS_MAIN'
+  | 'R6_CONSENSUS_CROWDING'
+  | 'REJECT_INSUFFICIENT_EVIDENCE';
+
+export type AiInfrastructureDecision =
+  | 'BUY_REVIEW'
+  | 'WATCHLIST_PRIORITY'
+  | 'MONITOR_ONLY'
+  | 'AVOID_CHASING'
+  | 'REJECT';
+
+export type AiInfrastructureCompanyInput = {
+  id: string;
+  company: string;
+  thesis: 'AI_DATA_CENTER_OPTICS' | 'AI_POWER_GRID' | 'INDUSTRIAL_NETWORKING' | 'DEFENSE_CONNECTIVITY';
+  asOf: string;
+  evidenceIds: readonly string[];
+  businessQuality: number;
+  normalizedGrowth: number;
+  capexProductivity: number;
+  valuationMarginOfSafety: number;
+  financialInflection: number;
+  aiInfrastructurePurity: number;
+  cashGeneration: number;
+  balanceSheetStrength: number;
+  narrativeCrowding: number;
+  priceDiscovery: number;
+  structuralIntegrity: boolean;
+  notes?: readonly string[];
+};
+
+export type AiInfrastructureRotationResult = {
+  id: string;
+  company: string;
+  thesis: AiInfrastructureCompanyInput['thesis'];
+  phase: AiInfrastructureRotationPhase;
+  decision: AiInfrastructureDecision;
+  qualityComposite: number;
+  opportunityScore: number;
+  crowdingPenalty: number;
+  reasons: readonly string[];
+  guardrails: readonly string[];
+};
+
+const SCORE_FIELDS = [
+  'businessQuality',
+  'normalizedGrowth',
+  'capexProductivity',
+  'valuationMarginOfSafety',
+  'financialInflection',
+  'aiInfrastructurePurity',
+  'cashGeneration',
+  'balanceSheetStrength',
+  'narrativeCrowding',
+  'priceDiscovery',
+] as const;
+
+function assertScore(name: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new Error(`ai_infra_rotation_score_out_of_range:${name}`);
+  }
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function validateAiInfrastructureInput(input: AiInfrastructureCompanyInput): readonly string[] {
+  const violations: string[] = [];
+  if (!input.id.trim()) violations.push('missing_id');
+  if (!input.company.trim()) violations.push('missing_company');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.asOf)) violations.push('invalid_as_of');
+  if (input.evidenceIds.length < 2) violations.push('requires_at_least_two_traceable_evidence_ids');
+  for (const field of SCORE_FIELDS) {
+    try {
+      assertScore(field, input[field]);
+    } catch (error) {
+      violations.push((error as Error).message);
+    }
+  }
+  if (!input.structuralIntegrity) violations.push('structural_integrity_not_confirmed');
+  return violations;
+}
+
+export function classifyAiInfrastructurePhase(input: AiInfrastructureCompanyInput): AiInfrastructureRotationPhase {
+  if (validateAiInfrastructureInput(input).length > 0) return 'REJECT_INSUFFICIENT_EVIDENCE';
+
+  if (input.narrativeCrowding >= 88 || input.priceDiscovery >= 90) return 'R6_CONSENSUS_CROWDING';
+  if (input.narrativeCrowding >= 72 || input.priceDiscovery >= 75) return 'R5_DISCOVERED_BY_ATLAS_MAIN';
+
+  const hasVisibleFinancialTurn = input.financialInflection >= 72 && input.normalizedGrowth >= 70;
+  const hasRotationAsymmetry = input.valuationMarginOfSafety >= 72 && input.narrativeCrowding <= 65;
+  if (hasVisibleFinancialTurn && hasRotationAsymmetry) return 'R4_TO_R5_RELATIVE_OPPORTUNITY';
+
+  if (input.financialInflection >= 62 && input.capexProductivity >= 70) return 'R4_EARLY_ACCUMULATION';
+  return 'R3_CANDIDATE_MONITOR';
+}
+
+export function scoreAiInfrastructureOpportunity(input: AiInfrastructureCompanyInput): number {
+  const violations = validateAiInfrastructureInput(input);
+  if (violations.length > 0) return 0;
+
+  const gross =
+    input.businessQuality * 0.14 +
+    input.normalizedGrowth * 0.15 +
+    input.capexProductivity * 0.15 +
+    input.valuationMarginOfSafety * 0.20 +
+    input.financialInflection * 0.18 +
+    input.aiInfrastructurePurity * 0.10 +
+    input.cashGeneration * 0.05 +
+    input.balanceSheetStrength * 0.03;
+  const crowdingPenalty = Math.max(0, input.narrativeCrowding - 65) * 0.35 + Math.max(0, input.priceDiscovery - 75) * 0.30;
+  return round(Math.max(0, Math.min(100, gross - crowdingPenalty)));
+}
+
+export function assessAiInfrastructureRotation(input: AiInfrastructureCompanyInput): AiInfrastructureRotationResult {
+  const violations = validateAiInfrastructureInput(input);
+  const qualityComposite = round(
+    input.businessQuality * 0.35 + input.normalizedGrowth * 0.25 + input.capexProductivity * 0.25 + input.cashGeneration * 0.15,
+  );
+
+  if (violations.length > 0) {
+    return {
+      id: input.id,
+      company: input.company,
+      thesis: input.thesis,
+      phase: 'REJECT_INSUFFICIENT_EVIDENCE',
+      decision: 'REJECT',
+      qualityComposite,
+      opportunityScore: 0,
+      crowdingPenalty: 0,
+      reasons: violations,
+      guardrails: ['Do not rank or act until evidence and structural integrity requirements are met.'],
+    };
+  }
+
+  const phase = classifyAiInfrastructurePhase(input);
+  const opportunityScore = scoreAiInfrastructureOpportunity(input);
+  const crowdingPenalty = round(Math.max(0, input.narrativeCrowding - 65) * 0.35 + Math.max(0, input.priceDiscovery - 75) * 0.30);
+  const reasons: string[] = [];
+
+  if (qualityComposite >= 88) reasons.push('elite_or_near_elite_business_quality');
+  if (input.financialInflection >= 72) reasons.push('visible_financial_inflection');
+  if (input.capexProductivity >= 88) reasons.push('capex_follows_demonstrated_demand');
+  if (input.valuationMarginOfSafety >= 80) reasons.push('valuation_asymmetry_vs_quality');
+  if (phase === 'R5_DISCOVERED_BY_ATLAS_MAIN') reasons.push('market_has_already_discovered_the_story');
+  if (phase === 'R6_CONSENSUS_CROWDING') reasons.push('consensus_or_price_discovery_is_extreme');
+
+  let decision: AiInfrastructureDecision = 'MONITOR_ONLY';
+  if (phase === 'R6_CONSENSUS_CROWDING') decision = 'AVOID_CHASING';
+  else if (phase === 'R5_DISCOVERED_BY_ATLAS_MAIN' && opportunityScore >= 70) decision = 'BUY_REVIEW';
+  else if (phase === 'R4_TO_R5_RELATIVE_OPPORTUNITY' && opportunityScore >= 78) decision = 'BUY_REVIEW';
+  else if (phase === 'R4_EARLY_ACCUMULATION' || phase === 'R4_TO_R5_RELATIVE_OPPORTUNITY') decision = 'WATCHLIST_PRIORITY';
+
+  return {
+    id: input.id,
+    company: input.company,
+    thesis: input.thesis,
+    phase,
+    decision,
+    qualityComposite,
+    opportunityScore,
+    crowdingPenalty,
+    reasons,
+    guardrails: [
+      'This engine ranks relative opportunity; it does not place orders.',
+      'R5 quality can be investable but is not an early rotation entry.',
+      'A lower-quality peer can rank higher when financial inflection and valuation asymmetry are stronger.',
+      'Re-score after earnings, guidance, capex updates or material multiple expansion/compression.',
+    ],
+  };
+}
+
+export function rankAiInfrastructureRotation(inputs: readonly AiInfrastructureCompanyInput[]): readonly AiInfrastructureRotationResult[] {
+  const thesisSet = new Set(inputs.map((input) => input.thesis));
+  if (thesisSet.size !== 1) throw new Error('ai_infra_rotation_ranking_requires_single_thesis');
+  return [...inputs]
+    .map(assessAiInfrastructureRotation)
+    .sort((a, b) => b.opportunityScore - a.opportunityScore || b.qualityComposite - a.qualityComposite || a.company.localeCompare(b.company));
+}
+
+export const AI_INFRASTRUCTURE_ROTATION_OMEGA_V1 = {
+  id: 'AI_INFRASTRUCTURE_ROTATION_OMEGA_V1',
+  status: 'canonical_candidate',
+  mission:
+    'Rank AI infrastructure beneficiaries by quality, financial inflection, capex productivity, valuation asymmetry and narrative crowding without confusing discovered winners with early rotation opportunities.',
+  requiredEvidence: ['at_least_two_traceable_evidence_ids', 'structural_integrity_confirmed', 'same_thesis_for_relative_ranking'],
+  scoringWeights: {
+    businessQuality: 0.14,
+    normalizedGrowth: 0.15,
+    capexProductivity: 0.15,
+    valuationMarginOfSafety: 0.20,
+    financialInflection: 0.18,
+    aiInfrastructurePurity: 0.10,
+    cashGeneration: 0.05,
+    balanceSheetStrength: 0.03,
+  } as const,
+  crowdingPenalty: 'Narrative crowding above 65 and price discovery above 75 reduce opportunity score.',
+  classify: classifyAiInfrastructurePhase,
+  assess: assessAiInfrastructureRotation,
+  rank: rankAiInfrastructureRotation,
+} as const;
+
+export const FUJIKURA_FURUKAWA_AI_OPTICS_CASES: readonly AiInfrastructureCompanyInput[] = [
+  {
+    id: 'FUJIKURA_AI_OPTICS_2026_08_10',
+    company: 'Fujikura',
+    thesis: 'AI_DATA_CENTER_OPTICS',
+    asOf: '2026-08-10',
+    evidenceIds: ['reuters-ai-infra-winners-2025', 'marketwatch-ultra-high-density-share'],
+    businessQuality: 91,
+    normalizedGrowth: 95,
+    capexProductivity: 94,
+    valuationMarginOfSafety: 67,
+    financialInflection: 86,
+    aiInfrastructurePurity: 94,
+    cashGeneration: 78,
+    balanceSheetStrength: 78,
+    narrativeCrowding: 78,
+    priceDiscovery: 82,
+    structuralIntegrity: true,
+    notes: ['Best optical pure-play in the comparison, but already discovered by the market.'],
+  },
+  {
+    id: 'FURUKAWA_AI_OPTICS_2026_08_10',
+    company: 'Furukawa Electric',
+    thesis: 'AI_DATA_CENTER_OPTICS',
+    asOf: '2026-08-10',
+    evidenceIds: ['furukawa-fy2025-communications-turnaround', 'furukawa-fy2026-guidance'],
+    businessQuality: 84,
+    normalizedGrowth: 90,
+    capexProductivity: 89,
+    valuationMarginOfSafety: 86,
+    financialInflection: 92,
+    aiInfrastructurePurity: 82,
+    cashGeneration: 73,
+    balanceSheetStrength: 76,
+    narrativeCrowding: 58,
+    priceDiscovery: 66,
+    structuralIntegrity: true,
+    notes: ['Same AI optics wave, stronger relative inflection and less mature consensus.'],
+  },
+] as const;

--- a/src/atlas/algorithm/money-rotation-omega.ts
+++ b/src/atlas/algorithm/money-rotation-omega.ts
@@ -1,5 +1,9 @@
 import { ATLAS_CANONICAL_PIPELINE_V1_1 } from './evidence-integrity-omega';
 import {
+  AI_INFRASTRUCTURE_ROTATION_OMEGA_V1,
+  FUJIKURA_FURUKAWA_AI_OPTICS_CASES,
+} from './ai-infrastructure-rotation-omega';
+import {
   MARKET_REGIME_FAMILIES,
   R3_TO_R4_TRIGGER_OMEGA,
   ROTATION_SCORE_WEIGHTS,
@@ -30,6 +34,7 @@ export const MONEY_ROTATION_OMEGA_V1_3 = {
     'R4 requires persistent positive comparable flows plus a positive reaction to good news after destruction.',
     'R1 and R2 are research states only when the underlying business remains structurally intact.',
     'R5 is the handoff to the main ATLAS discovery/scoring stack; R6 represents consensus/crowding and must not be chased mechanically.',
+    'AI infrastructure beneficiaries must be ranked by quality, financial inflection, valuation asymmetry and crowding; a great R5 company is not automatically an early R3 opportunity.',
     'Gold is split into structural and tactical signals; one cannot substitute for the other.',
     'Oil forecasts remain conditional when primary supply-demand evidence or geopolitical transmission is unresolved.',
     'The gold/oil matrix selects what to investigate; it never emits a mechanical sector trade.',
@@ -46,6 +51,12 @@ export const MONEY_ROTATION_OMEGA_V1_3 = {
     gold: assessGoldRegime,
     oil: assessOilScenario,
     goldOilRegime: inferGoldOilRegime,
+  },
+  sectorEngines: {
+    aiInfrastructure: AI_INFRASTRUCTURE_ROTATION_OMEGA_V1,
+  },
+  canonicalCases: {
+    fujikuraFurukawaAiOptics: FUJIKURA_FURUKAWA_AI_OPTICS_CASES,
   },
   calculateScore: calculateRotationScore,
 } as const;


### PR DESCRIPTION
## Summary

Extracts the Fujikura/Furukawa insight into a clean canonical algorithm on top of current `main`, without carrying the divergent Android/CI changes from PR #24.

## What changed

- Adds `AI_INFRASTRUCTURE_ROTATION_OMEGA_v1` canon.
- Adds a deterministic TypeScript engine for AI infrastructure rotation ranking.
- Registers the engine under `MONEY_ROTATION_OMEGA_V1_3`.
- Updates current canon with the rule: `Excellent business != early rotation opportunity`.
- Adds tests for the Fujikura/Furukawa case:
  - Fujikura => `R5_DISCOVERED_BY_ATLAS_MAIN`, still `BUY_REVIEW` but not early R3.
  - Furukawa Electric => `R4_TO_R5_RELATIVE_OPPORTUNITY` and ranks higher on relative opportunity.
  - Mixed-thesis rankings are rejected.
  - Untraceable or structurally unconfirmed claims are rejected.

## Safety

The engine ranks relative opportunity and review priority only. It does not place orders or emit mechanical portfolio actions.

## Validation

Connector-level diff verified against `main`: 5 files changed, 441 additions, 1 deletion. Local `npm`/`tsc` could not be run because this execution context does not have a local checkout of the repository.