### PR TITLE
feat: Energy Rotation Ω regime and normalization engine

### DIFF
--- a/docs/canon/ENERGY_ROTATION_OMEGA_CURRENT.md
+++ b/docs/canon/ENERGY_ROTATION_OMEGA_CURRENT.md
@@ -1,0 +1,18 @@
+# ENERGY ROTATION OMEGA — CURRENT
+
+Canonical candidate integrated with ATLAS Omega mobile-first algorithm.
+
+Core rule: do not chase commodity-cycle earnings. Prefer companies that preserve FCF/share, ROIC, balance quality and capital returns through Brent normalization.
+
+Sector phase and company phase are separate. Aggregate reference snapshot dated 2026-08-09 is R5, with some areas approaching R6; this snapshot expires and must be recomputed.
+
+Required links:
+- Evidence Ingestion Omega
+- Evidence Integrity Omega v1.1
+- Money Rotation Omega
+- Capex Productivity Omega
+- Valuation Omega
+- Risk Omega
+- Decision Safety Gate Omega
+
+Initial deep-audit candidates: XOM, CVX, COP, EOG, FANG, OXY. Midstream/LNG is analyzed separately.

--- a/docs/canon/ENERGY_ROTATION_OMEGA_DECISION_RULES.md
+++ b/docs/canon/ENERGY_ROTATION_OMEGA_DECISION_RULES.md
@@ -1,0 +1,11 @@
+# ENERGY ROTATION OMEGA — DECISION RULES
+
+1. Sector phase and company phase are separate.
+2. MARKET_CAP_CHANGE, PRICE_RETURN and COMMODITY_PRICE_CHANGE are never capital-flow metrics.
+3. Promotion requires confirmed multi-window flows plus revisions, breadth and post-earnings reaction.
+4. R5->R6 risk rises when price remains strong while flows deteriorate, EPS revisions fall and breadth narrows.
+5. Upstream/integrated names must pass Brent 65/70/75 stress cases.
+6. BUY requires resilience of FCF/share, ROIC, balance and capital returns through normalization.
+7. Do not chase XLE or any energy ETF solely because of YTD performance.
+8. Midstream/LNG must be evaluated separately from upstream beta.
+9. Decision Safety Gate remains binding for REDUCE/SELL.

--- a/docs/canon/ENERGY_ROTATION_OMEGA_GUARDS.md
+++ b/docs/canon/ENERGY_ROTATION_OMEGA_GUARDS.md
@@ -1,0 +1,9 @@
+# ENERGY ROTATION OMEGA — INTEGRITY GUARDS
+
+- Never infer net flow from market-cap change.
+- Never infer net flow from commodity-price movement.
+- Never infer early rotation from one weekly print.
+- Never inherit sector R-phase directly to a company.
+- Never use peak-cycle earnings without normalization stress.
+- Never merge upstream, services, integrated, and midstream economics into one company score.
+- Never bypass Evidence Integrity Omega or Decision Safety Gate Omega.

--- a/docs/canon/ENERGY_ROTATION_OMEGA_SNAPSHOT_2026-08-09.md
+++ b/docs/canon/ENERGY_ROTATION_OMEGA_SNAPSHOT_2026-08-09.md
@@ -1,0 +1,18 @@
+# ENERGY ROTATION OMEGA — REFERENCE SNAPSHOT
+
+As of: 2026-08-09
+
+Aggregate phase: R5, with some segments approaching R6.
+
+This is a time-bounded reference snapshot, not a permanent truth. Recompute from fresh evidence.
+
+Operational reading:
+- recent flows weakening;
+- price momentum strong YTD but cooling;
+- fundamentals still strong;
+- commodity-normalization risk rising;
+- crowding risk increasing;
+- no sector-level chase;
+- deep audit should favor resilience through Brent 65/70/75.
+
+Initial candidates: XOM, CVX, COP, EOG, FANG, OXY.

--- a/docs/rfcs/RFC-ENERGY-ROTATION-OMEGA-v1.md
+++ b/docs/rfcs/RFC-ENERGY-ROTATION-OMEGA-v1.md
@@ -1,0 +1,136 @@
+# RFC-ENERGY-ROTATION-OMEGA-v1
+
+## Estado
+
+CANDIDATO CANONICO ATLAS OMEGA.
+
+Fecha: 2026-08-10
+Ambito: ATLAS Omega / Money Rotation / Capex Productivity / Historical Dislocation
+
+## Mision
+
+ENERGY ROTATION OMEGA identifica si el capital, los fundamentales y el regimen del commodity justifican una oportunidad temprana, madura o tardia dentro de energia. No persigue el ETF sectorial por rendimiento pasado; busca empresas capaces de seguir creando FCF por accion y ROIC cuando el commodity se normaliza.
+
+## Regla constitucional
+
+> En commodities, ATLAS Omega no debe buscar la empresa que mas gana con el precio actual, sino la que continua creando valor por accion cuando el commodity se normaliza.
+
+## Separacion semantica obligatoria
+
+Nunca mezclar ni sumar como si fueran equivalentes:
+
+- precio del petroleo;
+- rendimiento de acciones/ETF;
+- variacion de market cap;
+- ETF/fund flows;
+- CAPEX del sector;
+- beneficios empresariales;
+- gasto publico;
+- AUM.
+
+MARKET_CAP_CHANGE != CAPITAL_FLOW.
+PRICE_RETURN != CAPITAL_FLOW.
+COMMODITY_PRICE_CHANGE != CAPITAL_FLOW.
+
+## Fases R1-R6
+
+R1 abandonado
+R2 capitulacion
+R3 suelo
+R4 primeras entradas
+R5 detectado por algoritmo principal / liderazgo visible
+R6 consenso, crowded o madurez
+
+La fase se asigna al sector y tambien por subsector/empresa. Una fase sectorial nunca se hereda automaticamente a una compania concreta.
+
+## Estado base de referencia 2026-08-09
+
+ENERGIA agregado: R5, con segmentos aproximandose a R6.
+
+Lectura operativa:
+- flujos recientes debilitandose;
+- momentum de precio fuerte YTD pero enfriandose;
+- fundamentales todavia fuertes;
+- riesgo de normalizacion del crudo;
+- crowding creciente;
+- no perseguir XLE por momentum;
+- buscar ganadores idiosincraticos.
+
+Este snapshot caduca y debe recalcularse con datos nuevos.
+
+## Subcapas
+
+1. Integrated majors: XOM, CVX
+2. E&P shale: COP, EOG, FANG, OXY
+3. Oil services: SLB, HAL
+4. Midstream / LNG / transporte: analizar por separado
+
+## Stress test obligatorio
+
+Para upstream e integrated majors, calcular al menos escenarios Brent:
+
+- 65 USD/bbl
+- 70 USD/bbl
+- 75 USD/bbl
+
+En cada escenario evaluar:
+- FCF/share;
+- ROIC;
+- breakeven;
+- CAPEX requerido;
+- deuda/net debt;
+- dividendos;
+- recompras;
+- inventario Tier-1;
+- productividad por pozo o activos;
+- margen de seguridad de valoracion.
+
+## Drivers de score
+
+- Flow Score
+- Price Momentum
+- Fundamental Momentum
+- Earnings Revisions
+- Commodity Regime
+- Crowding Risk
+- Balance Quality
+- Breakeven Quality
+- CAPEX Productivity
+- FCF/share Resilience
+- ROIC Resilience
+- Capital Returns
+- Valuation
+
+## Triggers
+
+### R5 -> R6
+Precio fuerte + deterioro persistente de flujos + revisiones EPS descendentes + perdida de breadth.
+
+### Reentrada R4/R5
+Estabilizacion del crudo + reanudacion de flujos 4w/13w + revisiones EPS positivas + reaccion favorable a resultados.
+
+## Decision rules
+
+- No BUY sectorial solo por subida del crudo.
+- No BUY solo por beneficios extraordinarios de un trimestre.
+- No considerar CAPEX alto como falsificador sin deterioro de retorno incremental.
+- No elevar energia a top rotation si flujos no estan confirmados multiventana.
+- Priorizar calidad del negocio + disciplina de capital sobre beta al barril.
+
+## Integracion ATLAS
+
+Evidence Ingestion Omega
+-> Evidence Integrity Omega
+-> Money Rotation Omega
+-> ENERGY ROTATION OMEGA
+-> CAPEX PRODUCTIVITY OMEGA
+-> VALUATION OMEGA
+-> RISK OMEGA
+-> DECISION SAFETY GATE OMEGA
+-> FINAL SCORE OMEGA
+
+## Candidatos iniciales para auditoria
+
+XOM, CVX, COP, EOG, FANG, OXY.
+
+Midstream/LNG se analiza en un bloque separado para evitar mezclar perfiles economicos distintos.

--- a/src/atlas/algorithm/energy-rotation-omega.pipeline.ts
+++ b/src/atlas/algorithm/energy-rotation-omega.pipeline.ts
@@ -1,0 +1,15 @@
+import { ENERGY_ROTATION_OMEGA } from './energy-rotation-omega';
+
+export const ENERGY_ROTATION_OMEGA_PIPELINE_NODE = {
+  id: ENERGY_ROTATION_OMEGA.id,
+  position: 'after_money_rotation_before_capex_productivity',
+  upstream: ['EVIDENCE_INGESTION_OMEGA_V1', 'EVIDENCE_INTEGRITY_OMEGA_V1_1', 'MONEY_ROTATION_OMEGA'],
+  downstream: [
+    'CAPEX_PRODUCTIVITY_OMEGA',
+    'VALUATION_OMEGA',
+    'RISK_OMEGA',
+    'DECISION_SAFETY_GATE_OMEGA',
+    'FINAL_SCORE_OMEGA',
+  ],
+  mobileFirst: true,
+} as const;

--- a/src/atlas/algorithm/energy-rotation-omega.test.ts
+++ b/src/atlas/algorithm/energy-rotation-omega.test.ts
@@ -1,0 +1,32 @@
+import { canPromoteEnergyRotation, isCapitalFlowMetric } from './energy-rotation-omega';
+
+describe('Energy Rotation Omega', () => {
+  it('does not treat market cap or price return as capital flow', () => {
+    expect(isCapitalFlowMetric('MARKET_CAP_CHANGE')).toBe(false);
+    expect(isCapitalFlowMetric('PRICE_RETURN')).toBe(false);
+    expect(isCapitalFlowMetric('COMMODITY_PRICE_CHANGE')).toBe(false);
+    expect(isCapitalFlowMetric('ETF_NET_FLOW')).toBe(true);
+  });
+
+  it('requires multi-window and fundamental confirmation before promotion', () => {
+    expect(
+      canPromoteEnergyRotation({
+        positive4wFlows: true,
+        positive13wFlows: false,
+        positiveEpsRevisions: true,
+        positiveBreadth: true,
+        positivePostEarningsReaction: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      canPromoteEnergyRotation({
+        positive4wFlows: true,
+        positive13wFlows: true,
+        positiveEpsRevisions: true,
+        positiveBreadth: true,
+        positivePostEarningsReaction: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/atlas/algorithm/energy-rotation-omega.ts
+++ b/src/atlas/algorithm/energy-rotation-omega.ts
@@ -1,0 +1,111 @@
+export type EnergyRotationPhase = 'R1' | 'R2' | 'R3' | 'R4' | 'R5' | 'R6';
+
+export type EnergyCandidate = {
+  ticker: string;
+  subsector: 'integrated_major' | 'ep_shale' | 'oil_services' | 'midstream_lng';
+};
+
+export const ENERGY_ROTATION_OMEGA = {
+  id: 'ENERGY_ROTATION_OMEGA_V1',
+  name: 'Energy Rotation Omega v1.0',
+  status: 'canonical_candidate',
+  mission:
+    'Find energy companies that can keep creating FCF per share and ROIC when the commodity normalizes; do not chase sector ETF momentum.',
+  constitutionalRule:
+    'In commodities, Atlas must prefer value creation through normalization over peak-cycle earnings.',
+  semanticGuards: [
+    'MARKET_CAP_CHANGE != CAPITAL_FLOW',
+    'PRICE_RETURN != CAPITAL_FLOW',
+    'COMMODITY_PRICE_CHANGE != CAPITAL_FLOW',
+    'AUM_CHANGE != NET_FLOW unless explicitly decomposed',
+  ] as const,
+  aggregateReferenceSnapshot: {
+    asOf: '2026-08-09',
+    phase: 'R5' as EnergyRotationPhase,
+    note: 'Sector-level snapshot only; must not be inherited automatically by each company and must be recalculated with fresh evidence.',
+  },
+  stressBrentUsdPerBarrel: [65, 70, 75] as const,
+  requiredStressOutputs: [
+    'fcf_per_share',
+    'roic',
+    'breakeven',
+    'required_capex',
+    'net_debt',
+    'dividend_sustainability',
+    'buyback_capacity',
+    'tier1_inventory',
+    'asset_or_well_productivity',
+    'valuation_margin_of_safety',
+  ] as const,
+  scoreInputs: [
+    'flow_score',
+    'price_momentum',
+    'fundamental_momentum',
+    'earnings_revisions',
+    'commodity_regime',
+    'crowding_risk',
+    'balance_quality',
+    'breakeven_quality',
+    'capex_productivity',
+    'fcf_per_share_resilience',
+    'roic_resilience',
+    'capital_returns',
+    'valuation',
+  ] as const,
+  r5ToR6Trigger: [
+    'strong_price',
+    'persistent_flow_deterioration',
+    'falling_eps_revisions',
+    'breadth_loss',
+  ] as const,
+  reentryTrigger: [
+    'commodity_stabilization',
+    'positive_4w_and_13w_flows',
+    'positive_eps_revisions',
+    'positive_post_earnings_reaction',
+  ] as const,
+  initialCandidates: [
+    { ticker: 'XOM', subsector: 'integrated_major' },
+    { ticker: 'CVX', subsector: 'integrated_major' },
+    { ticker: 'COP', subsector: 'ep_shale' },
+    { ticker: 'EOG', subsector: 'ep_shale' },
+    { ticker: 'FANG', subsector: 'ep_shale' },
+    { ticker: 'OXY', subsector: 'ep_shale' },
+  ] satisfies EnergyCandidate[],
+  pipeline: [
+    'EVIDENCE_INGESTION_OMEGA_V1',
+    'EVIDENCE_INTEGRITY_OMEGA_V1_1',
+    'MONEY_ROTATION_OMEGA',
+    'ENERGY_ROTATION_OMEGA_V1',
+    'CAPEX_PRODUCTIVITY_OMEGA',
+    'VALUATION_OMEGA',
+    'RISK_OMEGA',
+    'DECISION_SAFETY_GATE_OMEGA',
+    'FINAL_SCORE_OMEGA',
+  ] as const,
+} as const;
+
+export function isCapitalFlowMetric(metric: string): boolean {
+  return [
+    'ETF_NET_FLOW',
+    'MUTUAL_FUND_NET_FLOW',
+    'ETF_CREATION_REDEMPTION',
+    'INSTITUTIONAL_ALLOCATION_FLOW',
+  ].includes(metric);
+}
+
+export function canPromoteEnergyRotation(input: {
+  positive4wFlows: boolean;
+  positive13wFlows: boolean;
+  positiveEpsRevisions: boolean;
+  positiveBreadth: boolean;
+  positivePostEarningsReaction: boolean;
+}): boolean {
+  return (
+    input.positive4wFlows &&
+    input.positive13wFlows &&
+    input.positiveEpsRevisions &&
+    input.positiveBreadth &&
+    input.positivePostEarningsReaction
+  );
+}


### PR DESCRIPTION
## Resumen

Integra **ENERGY ROTATION Ω v1.0** en ATLAS para analizar energía por fase de rotación, resiliencia a normalización del crudo y disciplina de capital, sin confundir precio, market cap o commodity moves con flujos.

## Cambios

- Nuevo RFC canónico de Energy Rotation Ω.
- Nuevo nodo TypeScript conectado tras Money Rotation y antes de CAPEX Productivity.
- Stress tests Brent 65/70/75 para FCF/share, ROIC, balance, CAPEX y retornos de capital.
- Separación sector/subsector/empresa y prohibición de heredar fase R automáticamente.
- Triggers R5→R6 y reentrada R4/R5.
- Guardrails de Evidence Integrity Ω para flow semantics.
- Candidatos iniciales: XOM, CVX, COP, EOG, FANG, OXY; midstream/LNG separado.
- Tests para impedir MARKET_CAP_CHANGE/PRICE_RETURN como capital flow y exigir confirmación multiventana.

## Nota

El snapshot R5 de energía es referencia fechada 2026-08-09 y debe recalcularse con evidencia nueva.