### PR TITLE
fix: definitive mobile route gate

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -68,6 +68,17 @@ export default function RootLayout() {
         <Stack.Screen name="ticker" />
         <Stack.Screen name="market" />
         <Stack.Screen name="broker" />
+        <Stack.Screen name="overview" />
+        <Stack.Screen name="growth" />
+        <Stack.Screen name="quality" />
+        <Stack.Screen name="capex-productivity" />
+        <Stack.Screen name="valuation" />
+        <Stack.Screen name="risk" />
+        <Stack.Screen name="catalysts" />
+        <Stack.Screen name="news" />
+        <Stack.Screen name="audit" />
+        <Stack.Screen name="daily-intelligence" />
+        <Stack.Screen name="digital-twin" />
       </Stack>
     </>
   );

--- a/mobile/app/more.tsx
+++ b/mobile/app/more.tsx
@@ -11,7 +11,7 @@ const ITEMS = [
   { code: 'EVD', title: 'Evidence Ω', subtitle: 'Ticker → SEC / fuentes primarias → prioridad de revisión', route: '/evidence' },
   { code: 'LOG', title: 'Decision Log Ω', subtitle: 'Historial de cambios en Cartera y Watchlist', route: '/decisions' },
   { code: 'MKT', title: 'Mercados Ω', subtitle: 'Índices, sectores, oro, petróleo, dólar, duración y crédito', route: '/market' },
-  { code: 'NWS', title: 'News Ω', subtitle: 'Noticias por ticker y catalizadores', route: '/engine-detail?engine=news' },
+  { code: 'NWS', title: 'News Ω', subtitle: 'Noticias por ticker y catalizadores', route: '/news' },
   { code: 'BRK', title: 'Broker Ω', subtitle: 'Trading 212 · estado seguro y guardrails', route: '/broker' },
 ] as const;
 

--- a/tmp-trigger.txt
+++ b/tmp-trigger.txt
@@ -1,0 +1,1 @@
+trigger

--- a/tmp-trigger.txt
+++ b/tmp-trigger.txt
@@ -1,1 +1,0 @@
-trigger


### PR DESCRIPTION
Corrige la navegación móvil definitiva para que las pantallas reales del APK estén registradas en el stack.

- Registra overview, growth, quality, capex-productivity, valuation, risk, catalysts, news, audit, daily-intelligence y digital-twin.
- Cambia News Ω para abrir la pantalla `/news` directamente.
- Verificado localmente con `npx tsc --noEmit` antes de limpiar dependencias temporales.

Nota: el build local no pudo completarse en el sandbox porque Gradle necesitaba descargar desde services.gradle.org y la red del entorno lo bloquea. GitHub Actions debe generar el APK.