### PR TITLE
docs: preserve GitHub operating context

### DIFF
--- a/docs/context/AUDIT_RECONCILIATION_2026-08-10.md
+++ b/docs/context/AUDIT_RECONCILIATION_2026-08-10.md
@@ -1,0 +1,70 @@
+# ATLAS Ω Enterprise — Reconciliación de auditoría histórica
+
+Fecha de reconciliación: 2026-08-10
+
+## Alcance
+
+Este documento conserva como información la auditoría del 2026-08-04 aportada por el usuario y la contrasta con el estado real observado en `main` el 2026-08-10. No es código ejecutable y no modifica lógica de inversión, Broker Ω ni decisiones BUY/SELL.
+
+## Hallazgos verificados hoy
+
+### EAS / versión móvil
+
+- `mobile/app.json` sigue declarando `version: 0.9.0` y no contiene `extra.eas.projectId`.
+- `mobile/package.json` sigue declarando `version: 0.1.0`.
+- Por tanto, la discrepancia de versión sigue existiendo.
+- No debe aplicarse literalmente el diff histórico de variable de entorno porque el repo actual usa `EXPO_PUBLIC_ATLAS_API_BASE_URL`, no `EXPO_PUBLIC_API_URL`.
+
+### EAS environments
+
+- `mobile/eas.json` mantiene `development` contra `http://localhost:8000`.
+- `preview` y `production` apuntan a `https://atlas-genesis-api.onrender.com`.
+- La clave configurada es `EXPO_PUBLIC_ATLAS_API_BASE_URL`.
+
+### Backend / Render
+
+- `render.yaml` usa `uvicorn api.app:app --host 0.0.0.0 --port $PORT`.
+- `api/app.py` importa `app` desde `api.main` e incluye de forma aditiva los routers `market`, `atlas_core` y `evidence`.
+- La separación `api.main` como base y `api.app` como agregador es real; no debe sustituirse por `api.main:app` en despliegue.
+
+### Trading 212
+
+- `TRADING212_LIVE_TRADING_ENABLED` sigue siendo `false` por defecto en Render.
+- `api/main.py` exige control token para endpoints de broker y exige confirmación explícita `EXECUTE_DEMO` o `EXECUTE_LIVE` según entorno.
+- En entorno live, las órdenes se bloquean si `TRADING212_LIVE_TRADING_ENABLED` no está habilitado servidor-side.
+
+### Mocks
+
+- La búsqueda de `MOCK_` en el índice de código no devolvió resultados.
+- Por tanto, la afirmación histórica «pantallas probablemente consumen mocks» no debe tratarse como hecho sin inspección de cada pantalla concreta.
+
+## Elementos de la auditoría del 04/08 que siguen vigentes
+
+- Mobile-first Android.
+- Expo / React Native modernos; no hay motivo verificado para un downgrade.
+- `api.app:app` es el entrypoint correcto de despliegue.
+- La discrepancia `0.1.0` vs `0.9.0` sigue presente.
+- El dev build con localhost no sirve directamente para un teléfono físico fuera del host, salvo túnel o red accesible.
+- Los guardrails de Trading 212 deben conservarse.
+
+## Elementos que no deben aplicarse literalmente
+
+- Cambiar `EXPO_PUBLIC_API_URL`: la variable real actual es `EXPO_PUBLIC_ATLAS_API_BASE_URL`.
+- Asumir que añadir `extra.eas.projectId` garantiza por sí solo que CI pase: debe verificarse el workflow y la resolución real del proyecto EAS.
+- Afirmar que Drizzle RC rompe con RN 0.86: requiere evidencia reproducible; es riesgo hipotético, no hecho.
+- Afirmar que Portfolio, Watchlist o Business Quality muestran mocks sin inspección de sus implementaciones actuales.
+- Crear endpoints nuevos de CAPEX, Rotation o Evidence solo porque se mencionaron en la auditoría histórica; primero debe comprobarse qué endpoints existen hoy y qué contratos consume la UI.
+
+## Regla operativa
+
+Antes de ejecutar cambios derivados de una auditoría antigua:
+
+1. Leer el archivo actual en `main` o en el PR objetivo.
+2. Separar HECHO, INFERENCIA y SOSPECHA.
+3. No introducir nombres de variables, rutas o endpoints que no coincidan con el código actual.
+4. Validar CI sobre el head real antes de declarar un APK listo.
+5. Mantener la separación entre scanner/discovery, scoring ATLAS, portfolio/watchlist y Broker Ω.
+
+## Estado
+
+Este registro queda archivado como contexto técnico e histórico. Los cambios de código deben ir en PRs separados y basados en evidencia actual del repositorio, no en la fotografía del 2026-08-04.

--- a/docs/context/GITHUB_OPERATING_CONTEXT_2026-08-10.md
+++ b/docs/context/GITHUB_OPERATING_CONTEXT_2026-08-10.md
@@ -1,0 +1,87 @@
+# GitHub Operating Context — 2026-08-10
+
+## Purpose
+
+Information-only operational record for ATLAS Ω development. This document does not alter investment logic, scoring, portfolio rules, Broker Ω guardrails, or production behavior.
+
+## Repository
+
+- Canonical repository: `Vicente24051980/atlas_genesis`
+- Default branch: `main`
+- GitHub connector access is available in the active ChatGPT environment.
+- Verified repository permissions include push/admin access.
+
+## Working rule
+
+For repository work, inspect GitHub directly first. Do not ask the user to paste workflows, source files, PR code, or logs manually when the connected GitHub tools can retrieve the required repository context.
+
+Manual copy/paste should only be requested when a required artifact or log is genuinely unavailable through the connected tooling.
+
+## Mobile-first constraint
+
+ATLAS Ω is intended for mobile use. App, scanner, portfolio, watchlist, Broker Ω, alerts, evidence views, and decision workflows should remain designed and validated with mobile operation as the primary surface.
+
+## Current relevant pull requests observed on 2026-08-10
+
+### PR #19 — Mobile Market Scanner Ω v1
+
+- State: open
+- Draft: yes
+- Mergeable: yes at last check
+- Branch: `feat/mobile-market-scanner-v1`
+- Purpose: scanner-first mobile home, market search, ticker detail, market-data fallback labeling, additive `/v1/market/*` backend routes, and updated functional Android emulator gate.
+- Methodological guardrail: scanner is discovery UI only and must not emit BUY/SELL decisions.
+
+### PR #17 — Agentic Security Ω discovery engine
+
+- State: open
+- Draft: yes
+- Mergeable: yes at last check
+- Branch: `feat/agentic-security-discovery-v1`
+- Purpose: independent Agentic Security Discovery Ω engine with PRIMARY-evidence gating and DISCOVER/WATCH/REJECT/INSUFFICIENT_EVIDENCE states.
+- Guardrail: the engine routes qualified candidates into the full ATLAS scorer and never emits BUY/SELL itself.
+
+### PR #16 — ATLAS Ω Mobile v1.0.0
+
+- State: open
+- Draft: no
+- Branch: `fix/current-ui-emulator-gate`
+- Purpose: decision-first mobile release including ticker-only analysis, portfolio monitoring, Watchlist Ω, Broker Ω separation, and CI/runtime gates.
+
+### PR #10 — automated mobile data pipeline
+
+- State: open
+- Mergeable status was false at last observed listing.
+- Branch: `feat/automated-data-pipeline-v1`
+- Purpose: Trading 212 read-only portfolio integration, market-data automation, discovery-first pipeline, evidence intake, background sync, and removal of manual forms from automated surfaces.
+
+### PR #7 — functional APK checkpoint
+
+- State: open
+- Branch: `ci/mobile-functional-apk-20260808`
+- Purpose: build-only checkpoint for Mobile CI and APK artifact generation.
+
+## CI state observed on 2026-08-10
+
+For PR #19 head `9fbbe64641be4db237a22b4c0346085ed2742b61`:
+
+- Workflow: `Mobile CI & EAS APK Build`
+- Run number: `210`
+- Run id: `31336589608`
+- Status at observation: `in_progress`
+
+This status is time-sensitive and must be rechecked before any conclusion about release readiness or APK availability.
+
+## Release discipline
+
+Do not describe an APK or release as final merely because a PR exists or a build started. Recheck the relevant CI head and required runtime gates first. Preserve separation between:
+
+- discovery/scanner functions;
+- ATLAS Ω investment scoring and decisions;
+- portfolio/watchlist monitoring;
+- Broker Ω execution controls;
+- information-only documentation.
+
+## Provenance
+
+This file records repository state and operating instructions established through direct GitHub connector inspection on 2026-08-10. It is documentation only and should not be treated as canonical market evidence or investment evidence.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,0 +1,9 @@
+# ATLAS Ω Context Records
+
+This directory stores information-only operational/context records used to preserve development continuity across sessions.
+
+These files are not executable configuration and do not override canonical ATLAS Ω investment rules unless a document explicitly states that it is a canonical specification.
+
+Current record:
+
+- `GITHUB_OPERATING_CONTEXT_2026-08-10.md` — verified GitHub connectivity, mobile-first constraint, current PR/CI state snapshot, and repository working rules.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -4,6 +4,7 @@ This directory stores information-only operational/context records used to prese
 
 These files are not executable configuration and do not override canonical ATLAS Ω investment rules unless a document explicitly states that it is a canonical specification.
 
-Current record:
+Current records:
 
 - `GITHUB_OPERATING_CONTEXT_2026-08-10.md` — verified GitHub connectivity, mobile-first constraint, current PR/CI state snapshot, and repository working rules.
+- `AUDIT_RECONCILIATION_2026-08-10.md` — preserves the 2026-08-04 mobile/API audit as historical context and reconciles it against the verified state of `main` on 2026-08-10, separating facts from stale assumptions and unverified suspicions.

--- a/docs/context/SESSION_INFORMATION_2026-08-10.md
+++ b/docs/context/SESSION_INFORMATION_2026-08-10.md
@@ -1,0 +1,24 @@
+# Session Information — 2026-08-10
+
+## User instruction
+
+All relevant information from this GitHub-access discussion should be preserved in GitHub as information.
+
+## Corrected capability state
+
+A prior statement that no GitHub connector was available is obsolete for the current environment. Direct GitHub access is available and has been verified against `Vicente24051980/atlas_genesis`.
+
+Accordingly, repository inspection should be performed directly through the connector whenever possible rather than asking the user to manually paste repository files or errors.
+
+## Verified items
+
+- Repository: `Vicente24051980/atlas_genesis`
+- Default branch: `main`
+- Connected account has push/admin permissions.
+- Open PRs observed include #19, #17, #16, #10, and #7.
+- PR #19 is `feat: Mobile Market Scanner Ω v1`.
+- The latest observed CI run for PR #19 was `Mobile CI & EAS APK Build` run #210 / id `31336589608`, with status `in_progress` at the time of inspection.
+
+## Operating interpretation
+
+This information is a session/repository continuity record. It does not alter ATLAS Ω scoring, investment decisions, evidence hierarchy, portfolio state, or trading controls.


### PR DESCRIPTION
## Qué añade
- Contexto operativo verificado de GitHub para ATLAS Ω.
- Registro de que el conector GitHub está disponible y debe usarse antes de pedir pegado manual de archivos.
- Restricción mobile-first documentada.
- Snapshot informativo de PRs relevantes y del CI observado el 10-ago-2026.
- Índice `docs/context/README.md` para futuros registros de continuidad.

## Alcance
Documentación únicamente. No modifica scoring, decisiones BUY/SELL, cartera, Broker Ω, evidencia canónica ni comportamiento de producción.

## Motivo
Preservar en GitHub la información operativa de esta sesión y evitar perder continuidad entre sesiones.