### PR TITLE
docs: archive full Economist / Phoenix research dossier

### DIFF
--- a/docs/research/CONSPIRACIONES_ATLAS_ECONOMIST_DINERO_PODER_1986_2026_FULL.md
+++ b/docs/research/CONSPIRACIONES_ATLAS_ECONOMIST_DINERO_PODER_1986_2026_FULL.md
@@ -1,0 +1,928 @@
+# CONSPIRACIONES ATLAS Ω — THE ECONOMIST / DINERO / PODER 1986–2026
+
+**Tipo:** archivo de investigación / información de contexto.  
+**Fecha de archivo:** 2026-08-10.  
+**Origen:** investigación desarrollada en conversación ATLAS Ω.  
+**Estado epistemológico:** no sustituye Evidence Integrity Ω ni convierte automáticamente afirmaciones en canon. Las referencias de sesión originales no son portables a GitHub; cualquier dato usado para decisiones futuras debe volver a enlazarse con fuente primaria o secundaria trazable.
+
+---
+
+## Resultado central
+
+La investigación se trató como una **auditoría forense**, no como una colección de coincidencias. Se cruzaron portadas y artículos monetarios verificables con Bretton Woods/SDR, dólar, oro, petróleo, euro, China, BRICS, crisis y cambios de régimen.
+
+Resultado:
+
+1. **No aparece evidencia sólida de un calendario secreto mediante el cual The Economist anuncie acontecimientos concretos de antemano.**
+2. The Economist aparece repetidamente con portadas monetarias muy agresivas en zonas de máxima tensión de régimen.
+3. Algunas portadas se publican tan tarde dentro de una narrativa que funcionan mejor como indicador de saturación/posible giro que como pronóstico.
+4. La portada del **Phoenix de 1988** es excepcional porque contiene una predicción explícita a treinta años. Literalmente falló; estructuralmente anticipó transformaciones monetarias reales.
+5. La portada del **Big Mac de agosto de 2026** debe tratarse prospectivamente: congelar la interpretación previa y comprobar a 6, 12, 24 y 36 meses sin reinterpretación retrospectiva.
+
+Principio metodológico:
+
+> Si el resultado destruye la teoría, se destruye la teoría. Si sobrevive a un test prospectivo, matched-control y anti-lookahead, entonces gana peso.
+
+---
+
+# I. Antes del Phoenix: Bretton Woods y SDR
+
+Bretton Woods creó un sistema con el dólar anclado al oro y otras divisas organizadas alrededor del dólar. En agosto de 1971 se suspendió la convertibilidad oficial del dólar en oro y para marzo de 1973 las principales monedas ya flotaban.
+
+Por tanto, cuando apareció el Phoenix en 1988, el debate sobre qué arquitectura monetaria debía sustituir al Bretton Woods original llevaba más de una década abierto.
+
+El **SDR / Derecho Especial de Giro** fue creado por el FMI en **1969** para complementar los activos de reserva internacionales.
+
+Regla de integridad conceptual:
+
+**SDR no es una moneda de uso cotidiano.** Es un activo de reserva internacional y una posible reclamación sobre monedas de libre uso.
+
+Esto es decisivo para no convertir retrospectivamente al SDR en “el Phoenix”.
+
+---
+
+# II. 1985–1988: el contexto previo serio
+
+Secuencia relevante:
+
+- **Septiembre 1985 — Plaza Accord:** EE.UU., Japón, Alemania Occidental, Francia y Reino Unido coordinan medidas que favorecen una depreciación ordenada del dólar.
+- **Febrero 1987 — Louvre Accord:** intento de estabilización monetaria después del ajuste.
+- **Diciembre 1987 — G7:** reafirmación de coordinación cambiaria.
+- **1986 — petróleo:** Arabia Saudí deja de contener producción, otros miembros OPEP incrementan oferta y aparece un exceso que parte los precios; el crudo saudí llegó a cotizar por debajo de aproximadamente $8/barril en mayo de 1986 según el expediente de investigación.
+- **1986 — Big Mac Index:** The Economist crea su indicador de paridad de poder adquisitivo basado en el precio del Big Mac.
+- **19-oct-1987 — Black Monday:** Dow -22,6% en una sesión, máximo desplome porcentual diario histórico del índice según el expediente.
+
+Apenas tres meses después aparece la portada Phoenix.
+
+---
+
+# III. 9-enero-1988 — EL PHOENIX
+
+Portada:
+
+**GET READY FOR A WORLD CURRENCY**
+
+Artículo asociado:
+
+**“Get Ready for the Phoenix”**, The Economist, 9-ene-1988, vol. 306, pp. 9-10.
+
+El texto plantea que aproximadamente treinta años después personas de numerosos países podrían utilizar una misma moneda para comprar. También desarrolla la idea de que el Phoenix podría comenzar como una **combinación de monedas nacionales, análoga al SDR**, y evolucionar desde allí.
+
+## Lo que realmente predijo
+
+- Unidades monetarias nacionales perdiendo importancia.
+- Mayor integración económica.
+- Un activo monetario internacional inicialmente construido sobre una cesta de monedas.
+- Cesión parcial de soberanía monetaria nacional.
+- Eventualmente, una moneda común utilizada por consumidores.
+
+## ¿Ocurrió en 2018?
+
+**No.**
+
+En 2018:
+
+- no existía una moneda mundial minorista;
+- dólar, euro, yen, libra, yuan, etc. seguían existiendo;
+- los SDR no eran dinero cotidiano;
+- no existía un banco central mundial emisor de un Phoenix.
+
+Conclusión:
+
+**Predicción literal Phoenix = fallida.**
+
+No se debe convertir después de los hechos a Bitcoin, euro, SDR o criptomonedas en “el Phoenix” si eso requiere cambiar el significado original.
+
+## Sin embargo: la predicción estructural fue mejor
+
+Tres décadas después aparecieron:
+
+- **1999:** euro.
+- **2009:** gran expansión de SDR.
+- **2016:** yuan incorporado al SDR.
+- **2021:** mayor asignación de SDR de la historia.
+- Posteriormente: CBDC, stablecoins, sistemas instantáneos de pago, CIPS, pagos transfronterizos alternativos y creciente uso de monedas locales.
+
+No produjo una moneda única mundial, pero sí una arquitectura monetaria mucho más integrada y supranacional.
+
+Primera conclusión de Conspiraciones Atlas:
+
+### Phoenix acertó mejor en la arquitectura que en el objeto.
+
+---
+
+# IV. El detalle que reduce el misterio de 1988
+
+El Phoenix no nació del vacío.
+
+Contexto previo inmediato:
+
+**Plaza 1985 → grandes reajustes del dólar → Louvre 1987 → Black Monday 1987 → nueva coordinación G7.**
+
+El propio artículo de 1988 se apoya en los problemas de 1987 y en intentos de gobiernos por gestionar tipos de cambio.
+
+Interpretación defendible:
+
+No necesariamente “alguien conoce un plan secreto de treinta años”, sino que una publicación muy próxima al debate económico internacional extrapola posibles soluciones para un sistema ya tensionado.
+
+La portada sigue siendo extraordinaria, pero deja de ser necesariamente una profecía.
+
+---
+
+# V. Cronología monetaria 1986–2026
+
+| Fecha | Evidencia | Contexto al publicarse | Qué ocurrió después | Veredicto Ω |
+|---|---|---|---|---|
+| 1986 | Big Mac Index nace | Plaza altera FX; petróleo colapsa | Se convierte en referencia popular de valoración monetaria | Contexto |
+| 1987 | Louvre + Black Monday | Intento de estabilizar FX; Dow -22,6% | Aumenta debate de coordinación internacional | Pre-Phoenix |
+| 9-ene-1988 | PORTADA World Currency / Phoenix | Sistema monetario bajo fuerte tensión | Euro, SDR ampliados, RMB en SDR; no aparece moneda mundial | Estructural sí / literal no |
+| 24-sep-1998 | ARTÍCULO “One world, one money” | Crisis asiática/rusa; euro próximo | Euro arranca 1-ene-1999 | Tema correcto / poco secreto |
+| 5-jun-1999 | PORTADA “Germany stalls, the Euro falls” | Euro ya cae | Diagnóstico contemporáneo | Termómetro |
+| 7-feb-2004 | PORTADA “Let the Dollar Drop” | USD llevaba años depreciándose | USD rebota con fuerza en 2005 | Contrarian |
+| 1-dic-2007 | PORTADA dólar/riesgo | Crisis crediticia ya iniciada | En fase brutal 2008 USD sube como refugio | Contrarian |
+| 2008 | EVENTO crisis global | Acciones/commodities caen | USD broad +~12% H2 según expediente | Cambio de régimen |
+| mar-2009 | ARTÍCULO China propone fin era dólar | Crisis financiera mundial | Gran asignación SDR ese año | Estructural |
+| 20-nov-2010 | PORTADA “Saving the euro” | Crisis de deuda europea | Euro sobrevive | Stress detector |
+| nov-2011 | PORTADA “Is this really the end?” | Eurozona al borde; oro alto | Euro no desaparece | Literal falla / estrés acierta |
+| 27-jul-2012 | PORTADA Spain → Pain | España bono ~7,75% | Draghi/política cambian régimen | Cerca del extremo |
+| H2-2014 | EVENTO dólar/petróleo | USD +~13%; Brent ~-50% | Gran cambio macro | Cross-asset |
+| 1-oct-2016 | EVENTO SDR | RMB entra al SDR | China entra formalmente en cesta de reservas | Phoenix parcial |
+| ago-2020 | ARTÍCULO “Change for the dollar” | pandemia, oro/FX bajo estrés | SDR récord en 2021 | Estructural |
+| 23-ago-2021 | EVENTO SDR | COVID | SDR 456,5bn, mayor asignación histórica | Arquitectura |
+| 2022–2025 | EVENTO oro/geopolítica | sanciones, guerras, fragmentación | compras oficiales de oro muy elevadas | Desdolarización marginal |
+| 2025–2026 | EVENTO pagos BRICS | multipolaridad | monedas locales/payment rails sí; moneda BRICS no | Fragmentación, no Phoenix |
+| 8-ago-2026 | PORTADA “Global Currency Beef / Big Mac 40” | oro elevado, FX fragmentado, shock petrolero | DESCONOCIDO | EXPERIMENTO ABIERTO |
+
+---
+
+# VI. 1998 — “ONE WORLD, ONE MONEY”
+
+The Economist publicó el 24 de septiembre de 1998 el artículo **“One world, one money”**, dedicado a ventajas y problemas de una moneda global.
+
+Contexto crítico: el euro estaba a poco más de tres meses de su lanzamiento.
+
+El 1 de enero de 1999 once países transfirieron una parte crucial de soberanía monetaria a una política común.
+
+Por tanto, usar el artículo de 1998 como prueba de conocimiento secreto futuro es débil.
+
+Lo interesante es la recurrencia editorial:
+
+- 1988 → integración monetaria global.
+- 1998 → integración monetaria global.
+- 1999 → primeras tensiones de la moneda supranacional.
+
+---
+
+# VII. 1999 — portada como termómetro
+
+Portada del 5 de junio de 1999:
+
+**“Germany stalls, the Euro falls.”**
+
+El euro ya estaba cayendo.
+
+Conclusión:
+
+The Economist no predijo esa caída; la llevó a portada porque ya estaba ocurriendo.
+
+Esto es un ejemplo claro de **portada-termómetro**.
+
+---
+
+# VIII. 2004 — prueba contra la teoría profética
+
+Febrero 2004:
+
+**“LET THE DOLLAR DROP.”**
+
+La tesis editorial era que el dólar no había caído demasiado sino que necesitaba caer más. El expediente recogía que desde 2001 había perdido aproximadamente un tercio frente al euro.
+
+Después, en 2005, el dólar se apreció aproximadamente:
+
+- +15% frente al euro.
+- +15% frente al yen.
+- +10% frente a la libra.
+
+Lectura ATLAS:
+
+- Diagnóstico contemporáneo: **9/10**.
+- Capacidad predictiva direccional: **2/10**.
+- Valor como indicador de saturación: **9/10**.
+
+Hipótesis útil: una narrativa extremadamente bajista puede llegar a portada después de años de caída, justo cerca de un cambio de régimen.
+
+---
+
+# IX. 2007 — repetición del patrón
+
+Portada del 1 de diciembre de 2007 sobre el pánico al dólar y el riesgo de colapso.
+
+En la fase más brutal de 2008 el dólar subió.
+
+El expediente recoge un aumento del índice broad de la Fed de alrededor de **12% en H2 2008**, incluyendo aproximadamente:
+
+- +13% contra euro.
+- +20% contra dólar canadiense.
+- +36% contra libra.
+
+Una explicación principal: demanda de activos estadounidenses como refugio.
+
+Simultáneamente, bolsas extranjeras/emergentes y materias primas sufrieron fuertes caídas.
+
+Patrón:
+
+> portada extrema → narrativa extrema ya existente → régimen posterior menos obvio.
+
+Esto no demuestra manipulación; sí apoya una posible señal de saturación narrativa.
+
+---
+
+# X. Evidencia académica sobre “magazine-cover effect”
+
+La investigación localizó literatura sobre BusinessWeek, Fortune y Forbes, no específicamente The Economist.
+
+Patrón encontrado en esa literatura:
+
+- historias positivas tendían a llegar después de rendimientos excepcionalmente buenos;
+- historias negativas después de rendimientos excepcionalmente malos;
+- muchas coincidían estadísticamente con el final de periodos extremos.
+
+Eso no prueba una estrategia contraria infalible.
+
+Hipótesis defendible:
+
+## COVER SATURATION Ω
+
+Cuando un fenómeno llega a ser tan importante como para ocupar la portada de una publicación económica global, puede significar:
+
+- el fenómeno es real;
+- pero una gran cantidad de información y consenso ya está incorporada en precio y positioning.
+
+---
+
+# XI. 2009 — China, dólar y SDR
+
+Marzo 2009, plena crisis mundial.
+
+Zhou Xiaochuan, gobernador del PBoC, propone reformar el sistema internacional de reservas, reduciendo dependencia de una única moneda nacional y dando mayor papel al SDR.
+
+The Economist publica una pieza sobre China sugiriendo el fin de la era del dólar.
+
+En 2009 el FMI realiza:
+
+- asignación general de **SDR 161,2bn**;
+- asignación especial de **SDR 21,5bn**.
+
+No apareció el Phoenix, pero el instrumento tipo cesta mencionado en 1988 ganó mucho peso sistémico.
+
+---
+
+# XII. 2010–2012 — las portadas del fin del euro
+
+## 20-nov-2010 — “Saving the euro”
+
+Portada visual de naufragio/tormenta para la crisis.
+
+## Nov-2011 — “Is this really the end?”
+
+Euro en llamas; crisis existencial real.
+
+Resultado: el euro no terminó.
+
+Lectura:
+
+- detector de crisis: **10/10**;
+- predicción literal: **1/10**.
+
+---
+
+# XIII. España 2012 — saturación cerca del extremo
+
+**26-jul-2012:** discurso de Mario Draghi en Londres; euro considerado irreversible y disposición a hacer lo necesario dentro del mandato.
+
+**27-jul-2012:** portada The Economist **SPAIN → PAIN**. El expediente sitúa el bono español a diez años alrededor de **7,75%**.
+
+Secuencia:
+
+**pánico extremo → portada extrema → intervención institucional decisiva → cambio de régimen.**
+
+Interpretación útil:
+
+La portada parece más un detector del punto donde el sistema ya no puede seguir igual que una predicción de la caída.
+
+---
+
+# XIV. Petróleo y dólar — patrón cross-asset
+
+En H2 2014:
+
+- Brent aproximadamente **-50%**.
+- USD aproximadamente **+13%** entre julio y diciembre según el expediente.
+
+Regla para Conspiraciones Atlas:
+
+Nunca investigar portadas monetarias aislando sólo el dólar.
+
+Cruzar siempre:
+
+**USD ↔ petróleo ↔ oro ↔ tipos ↔ crédito ↔ inflación ↔ acciones ↔ flujos internacionales.**
+
+Cadena causal aproximada:
+
+energía → balanzas comerciales → demanda de divisas → inflación importada → tipos → valoraciones → rotaciones bursátiles.
+
+El petróleo es un engranaje central, no una variable secundaria.
+
+---
+
+# XV. 2016 — RMB entra en SDR
+
+**1-oct-2016:** renminbi entra oficialmente en la cesta SDR.
+
+Pesos iniciales recogidos:
+
+- USD 41,73%.
+- EUR 30,93%.
+- RMB 10,92%.
+- JPY 8,33%.
+- GBP 8,09%.
+
+Esto se parece estructuralmente a la idea de 1988 de cesta multinacional e internacionalización monetaria.
+
+Pero:
+
+- SDR ≠ Phoenix.
+- SDR ≠ moneda minorista.
+- RMB en SDR ≠ sustitución del dólar.
+
+Es evolución gradual, no materialización literal.
+
+---
+
+# XVI. 2021 — mayor asignación SDR
+
+El 23 de agosto de 2021 entra en vigor una asignación de aproximadamente **SDR 456,5bn** (~$650bn entonces), la mayor de la historia del instrumento.
+
+Secuencia de grandes asignaciones recogida:
+
+- 1970–72: 9,3bn.
+- 1979–81: 12,1bn.
+- 2009: 161,2bn.
+- 2021: 456,5bn.
+
+Línea estructural:
+
+**1969 SDR → 1988 Phoenix usa cesta tipo SDR → 2009 China pide más SDR → 2009 gran ampliación → 2016 RMB entra → 2021 asignación récord.**
+
+Lo que todavía no existe:
+
+**SDR → moneda universal para consumidores.**
+
+---
+
+# XVII. 2022–2026 — fragmentación marginal, no colapso del dólar
+
+El expediente de investigación recoge para final de 2025 aproximadamente:
+
+- USD ≈57% de reservas oficiales FX.
+- EUR ≈20%.
+- RMB ≈2%.
+
+Para Q1 2026 se recogió aumento del peso del dólar de aproximadamente **56,42% a 57,13%**, con parte importante explicada por valoración cambiaria.
+
+Conclusión:
+
+## La desdolarización radical NO está ocurriendo.
+
+Pero:
+
+## La fragmentación marginal SÍ.
+
+Ésta es una distinción central.
+
+---
+
+# XVIII. ORO — señal más seria
+
+El expediente recoge que al final de 2025 el oro representaba aproximadamente **27%** del conjunto reservas oficiales mundiales compuesto por oro + FX en valor de mercado.
+
+Pero gran parte del incremento se explica por precio.
+
+Si se valorara el oro a precio de finales de 2023, el expediente aproxima:
+
+- oro 16%.
+- euro 16%.
+- Treasuries 26%.
+
+Por tanto:
+
+- sí aumenta el peso del oro;
+- no todo es compra deliberada;
+- el efecto valoración es muy importante.
+
+Compras físicas recogidas:
+
+- aproximadamente **850 t en 2025**;
+- más de **1.000 t/año entre 2022 y 2024**.
+
+Desde la invasión a gran escala de Ucrania, el expediente recoge aproximadamente:
+
+- China +350 t.
+- Polonia +320 t.
+- Türkiye +220 t.
+- India +130 t.
+
+Lectura defendible:
+
+No “los bancos centrales saben que el dólar va a desaparecer”, sino:
+
+> en un mundo geopolíticamente fragmentado aumenta el atractivo de un activo de reserva sin pasivo soberano de contraparte.
+
+El oro entra así en MONEY ROTATION Ω como señal estructural de reservas y régimen.
+
+---
+
+# XIX. BRICS — separar mito y evidencia
+
+Relato viral: BRICS prepara una moneda que sustituirá al dólar.
+
+Evidencia investigada para 2025:
+
+- una moneda BRICS común no estaba formalmente en discusión según declaraciones oficiales citadas en el expediente;
+- sí estaban en discusión monedas locales;
+- reducción de costes de liquidación;
+- plataformas de pagos transfronterizos;
+- conexión entre bancos centrales;
+- tecnologías digitales de pagos.
+
+La agenda oficial 2025 incorporó monedas locales e instrumentos/plataformas de pago.
+
+Conclusión:
+
+No parece un camino claro a **ONE WORLD, ONE MONEY**.
+
+Puede ser algo distinto:
+
+# ONE WORLD, MANY MONIES, CONNECTED RAILS
+
+Arquitectura posible:
+
+- dólar;
+- euro;
+- RMB;
+- monedas nacionales;
+- oro;
+- stablecoins;
+- CBDC;
+- SDR institucional;
+- redes de liquidación interoperables.
+
+Esto sería multipolaridad e interoperabilidad, no una moneda mundial única.
+
+---
+
+# XX. Petróleo 2026 y nueva portada
+
+El expediente recoge que el conflicto de Oriente Medio iniciado el **28-feb-2026** produjo una disrupción energética excepcional, con caída grave del tráfico energético por Hormuz y alrededor de 20% del suministro mundial de LNG afectado según la investigación.
+
+También se recoge que el **11-mar-2026** miembros de la IEA acordaron liberar **400 millones de barriles**, la mayor acción coordinada de emergencia en ese marco.
+
+Hormuz normalmente mueve aproximadamente **20 millones de barriles diarios**, cerca de 20% del consumo mundial según el expediente.
+
+Por tanto, la portada de 8-ago-2026:
+
+# THE GLOBAL CURRENCY BEEF
+
+aparece después de una secuencia:
+
+**guerra → petróleo → inflación/terms of trade → monedas → reservas → oro → flujos internacionales.**
+
+Eso la hace macroeconómicamente relevante, pero no demuestra un mensaje oculto.
+
+---
+
+# XXI. Decodificación de la hamburguesa 2026
+
+Portada estudiada:
+
+- **The Global Currency Beef**.
+- **Lessons from 40 years of the Big Mac Index**.
+- Big Mac desmontado/flotando.
+
+## Nivel 1 — HECHO
+
+1986 → 2026 = 40 años del Big Mac Index.
+
+Explicación primaria de por qué aparece ahora: **40.º aniversario**.
+
+## Nivel 2 — HECHO
+
+“Currency beef” contiene juego de palabras:
+
+- beef = carne;
+- beef = disputa/conflicto.
+
+## Nivel 3 — INTERPRETACIÓN RAZONABLE
+
+Hamburguesa desmontada = posibles valoraciones monetarias desalineadas / capas que no coinciden.
+
+Compatible con PPP/Big Mac Index, pero sin declaración del diseñador no es un hecho.
+
+## Nivel 4 — ESPECULACIÓN
+
+“Cada ingrediente representa una moneda concreta.”
+
+Sin evidencia.
+
+## Nivel 5 — ESPECULACIÓN FUERTE
+
+“Hay dos niveles monetarios escondidos.”
+
+Sin evidencia documental.
+
+## Nivel 6 — SIN EVIDENCIA
+
+“Anuncia una moneda global.”
+
+La portada no lo dice.
+
+## Nivel 7 — SIN EVIDENCIA
+
+“Anuncia algo para el 12 de agosto.”
+
+No existe soporte en la portada.
+
+---
+
+# XXII. 12-agosto-2026 y eclipse
+
+El eclipse solar total del **12-ago-2026** es un fenómeno astronómico conocido con antelación.
+
+Los hashtags tipo:
+
+- #12deagosto
+- #eclipse
+- #misterio
+
+proceden de contenido social, no de la portada de The Economist.
+
+Regla de falsificación:
+
+**El eclipse no puede contar como hit predictivo.**
+
+Si ocurre el eclipse, no valida ninguna teoría monetaria porque ya era conocido.
+
+Para puntuar una hipótesis de “evento monetario 12 de agosto” tendría que definirse previamente un evento monetario específico y verificable, distinto del eclipse.
+
+Producción editorial: el número es de 8-ago-2026 y el expediente recoge un deadline publicitario el 27-jul-2026. Esto confirma una producción normal previa al número, no cuándo se terminó exactamente la portada.
+
+---
+
+# XXIII. Rothschild y The Economist
+
+Hechos a separar:
+
+- intereses de la familia Rothschild han figurado históricamente entre accionistas de The Economist Group;
+- la frase “The Economist es de los Rothschild” simplifica incorrectamente la estructura accionarial.
+
+El expediente recoge que Exor posee todas las acciones especiales B y aproximadamente **43,4% del capital**.
+
+También recoge que **Stephen Smith / Smith Financial adquirió un 26,9%** previamente en manos de Lady Lynn Forester de Rothschild, su familia y ERANDA Rothschild Foundation.
+
+Clasificación epistemológica:
+
+- **accionista Rothschild = hecho histórico**;
+- **Rothschild ordenó el Phoenix de 1988 = no demostrado**;
+- **Phoenix prueba un plan monetario Rothschild = no demostrado**.
+
+No se localizaron documentos primarios que conectaran editorialmente la portada con una instrucción familiar.
+
+---
+
+# XXIV. Hipótesis fuerte: quizás se miraban las portadas al revés
+
+En vez de:
+
+**PORTADA → EVENTO**
+
+muchas veces aparece:
+
+**TENDENCIA → EXTREMO → PORTADA → CAMBIO DE RÉGIMEN**
+
+Ejemplos:
+
+### 2004
+USD lleva años bajando → “Let the Dollar Drop” → USD rebota en 2005.
+
+### 2007
+miedo extremo al dólar → portada sobre colapso/pánico → crisis 2008 → USD sube como refugio.
+
+### 2011
+eurozona parece romperse → “Is this really the end?” → euro sobrevive.
+
+### 2012
+España al límite → Spain/Pain → Draghi/política cambian régimen.
+
+Esto es coherente con la idea de magazine-cover effect, sin probar una “maldición The Economist”.
+
+---
+
+# XXV. NARRATIVE SATURATION Ω
+
+Indicador propuesto:
+
+Cuando The Economist, Time, Bloomberg Businessweek, Fortune, Barron’s u otra publicación global lleven una narrativa macro extrema a portada, no asumir:
+
+**“va a suceder”.**
+
+Preguntar:
+
+### “¿Cuánto de esto YA ha sucedido?”
+
+Cruzar:
+
+- precio;
+- positioning;
+- flows;
+- breadth;
+- volatilidad;
+- crédito;
+- dólar;
+- oro;
+- petróleo;
+- tipos.
+
+Una portada puede ser más útil como detector de consenso extremo que como predictor.
+
+Este motor conecta especialmente con **HISTORICAL DISLOCATION Ω**.
+
+---
+
+# XXVI. Patrón completo del dinero desde Bretton Woods
+
+Secuencia arquitectónica:
+
+**1944 — Bretton Woods**
+
+↓
+
+**1969 — SDR**
+
+↓
+
+**1971–73 — fin convertibilidad dólar-oro y paridades fijas**
+
+↓
+
+**1985–87 — Plaza/Louvre: coordinación internacional de divisas**
+
+↓
+
+**1988 — Phoenix propone unidad supranacional**
+
+↓
+
+**1999 — euro: moneda supranacional masiva de economías avanzadas**
+
+↓
+
+**2008–09 — crisis mundial, swap lines, expansión SDR**
+
+↓
+
+**2016 — RMB entra en SDR**
+
+↓
+
+**2021 — SDR récord**
+
+↓
+
+**2022–26 — geopolítica → oro + pagos locales + redes digitales**
+
+↓
+
+**2026 — dólar sigue dominante, pero la arquitectura subyacente se diversifica.**
+
+Frase resumen:
+
+> El dólar sigue dominando, pero el sistema que hay debajo del dólar está diversificándose.
+
+---
+
+# XXVII. ¿Se está cumpliendo Phoenix?
+
+Score analítico del expediente, no métrica publicada:
+
+- Predicción literal: **2/10**.
+- Internacionalización monetaria: **9/10**.
+- Cesión de soberanía nacional: **8/10**.
+- Cestas supranacionales: **8/10**.
+- Incorporación de China: **9/10**.
+- Red mundial de pagos: **9/10**.
+- Banco central mundial: **1/10**.
+- Eliminación del dólar: **1/10**.
+- Sistema más multipolar: **7/10 y creciendo**.
+
+Conclusión: Phoenix tiene mejor lectura estructural que literal.
+
+---
+
+# XXVIII. Anomalía 2025–2026 a vigilar
+
+La investigación recoge episodios en 2025 y comienzos de 2026 con una combinación poco habitual en risk-off:
+
+**dólar ↓ + rendimientos Treasury ↑**
+
+Tradicionalmente, una huida a refugio suele fortalecer al dólar y comprimir yields.
+
+Señal especialmente importante:
+
+### USD ↓ + Treasury yields ↑ + gold ↑
+
+Interpretación potencial:
+
+Los inversores no sólo temen riesgo económico, sino que exigen prima relativa a los propios activos de reserva estadounidenses.
+
+Una observación aislada no implica cambio de sistema.
+
+**Repetición persistente** sí sería una señal de regime stress extraordinaria.
+
+---
+
+# XXIX. PROTOCOLO PHOENIX 2026 — congelado
+
+Baseline intelectual fijado el **9-ago-2026** para evitar reinterpretación retrospectiva.
+
+| Señal futura | Si ocurre | Lectura |
+|---|---:|---|
+| USD reservas cae <55% persistentemente por ventas/reasignación real | Confirmación | Fragmentación acelera |
+| RMB supera claramente ~2% de reservas | Confirmación | China gana peso real de reserva |
+| BRICS anuncia formalmente moneda/unidad común | Confirmación fuerte | Cambio enorme |
+| BRICS continúa sólo con pagos locales | Contexto | Fragmentación, no Phoenix |
+| Bancos centrales mantienen compras masivas de oro | Confirmación | Diversificación continúa |
+| USD↓ + UST yield↑ + oro↑ repetidamente | MACRO ROJO | Estrés de arquitectura USA |
+| Grandes contratos de energía migran fuera USD | MACRO ROJO | Cambio petrodólar significativo |
+| Nueva expansión extraordinaria del SDR | Confirmación fuerte | Phoenix estructural |
+| SDR obtiene uso privado/minorista | Cambio histórico | Acercamiento material a Phoenix |
+| Unidad monetaria transnacional de uso comercial | Cambio histórico máximo | Phoenix se acerca |
+| Nada de eso ocurre | Falsificador | Portada = 40.º aniversario + coyuntura FX |
+| “Evento 12 agosto” no ocurre | Falsificador | Prohibido reinterpretar la fecha |
+
+Regla central:
+
+**No mover la portería después.**
+
+---
+
+# XXX. Petróleo como confirmador
+
+Con el shock energético 2026, observar:
+
+**Brent/WTI → inflación → expectativas de tipos → curvas → USD → cuentas corrientes → oro → flujos sectoriales.**
+
+Cuatro regímenes:
+
+1. **USD↑ + petróleo↓** → desinflación / fortaleza estadounidense.
+2. **USD↓ + petróleo↑ + oro↑** → reflación / debilitamiento monetario / commodities.
+3. **USD↑ + oro↑** → miedo sistémico.
+4. **USD↓ + oro↑ + UST yields↑** → potencial pérdida relativa de confianza en activos monetarios estadounidenses.
+
+El cuarto régimen es el más relevante como señal de posible cambio histórico.
+
+---
+
+# XXXI. Conexión con rotaciones bursátiles
+
+Cadena:
+
+**MONEDA → COMMODITIES → INFLACIÓN → TIPOS → MÁRGENES → BENEFICIOS → FLUJOS → SECTORES**
+
+Las portadas deben entrar en **MONEY ROTATION Ω** sólo como señal auxiliar de narrativa/régimen, nunca como orden BUY/SELL.
+
+Ejemplos históricos del expediente:
+
+- 2005, tras giro del dólar: bolsas extranjeras suben con fuerza; energía, minería y tecnología destacan en distintos mercados.
+- 2008: liquidación de riesgo, commodities abajo, dólar refugio arriba.
+- 2014: dólar fuerte + petróleo -50%.
+
+Los cambios de régimen monetario preceden o acompañan redistribuciones enormes de beneficios empresariales.
+
+---
+
+# XXXII. Veredicto congelado
+
+No se encuentra evidencia de:
+
+> “The Economist posee un código secreto que predice acontecimientos concretos.”
+
+Hipótesis más defendible y útil para ATLAS:
+
+> **The Economist es un sensor de debates, temores y proyectos que alcanzan importancia sistémica entre mercados, gobiernos e instituciones.**
+
+La revista muchas veces no llega antes que el mercado; llega cuando el asunto se convierte en régimen.
+
+Resumen por bloque:
+
+### Phoenix 1988
+
+- Acertó tendencia hacia integración y arquitectura supranacional.
+- Falló moneda mundial de consumo hacia ~2018.
+
+### Euro 1998–2012
+
+- Excelente detector de transformación y estrés.
+- Mal profeta literal de la muerte del euro.
+
+### Dollar 2004/2007
+
+- Muy interesante como posible indicador contrario de consenso extremo.
+
+### China/SDR 2009–2016
+
+- Evolución institucional real y considerable.
+
+### Oro 2022–26
+
+- Diversificación geopolítica real, lejos todavía de sustituir al dólar.
+
+### BRICS
+
+- Desdolarización operativa parcial: sí.
+- Moneda común: no demostrada.
+
+### 2026 Big Mac
+
+- No debe descartarse.
+- Tampoco debe convertirse en profecía.
+- Su valor científico es que puede estudiarse prospectivamente.
+
+---
+
+# XXXIII. Prueba definitiva — dataset completo 1986–2026
+
+La investigación verdaderamente científica exige aproximadamente **2.080 ediciones semanales**, no sólo las portadas famosas.
+
+El archivo directo de The Economist y metadata antigua pueden ser incompletos o difíciles de rastrear; por tanto, este expediente constituye la columna vertebral monetaria, no una afirmación falsa de exhaustividad total.
+
+La auditoría completa debe etiquetar cada edición **sin conocer el futuro** con:
+
+1. fecha exacta;
+2. texto de portada;
+3. imagen/símbolos;
+4. dólar;
+5. oro;
+6. petróleo;
+7. tipos 2Y/10Y;
+8. crédito;
+9. inflación;
+10. S&P / World / EM;
+11. sectores;
+12. crisis institucional;
+13. SDR;
+14. euro;
+15. China;
+16. BRICS;
+17. comportamiento -12/-6/-3 meses antes;
+18. comportamiento +1/+3/+6/+12/+36 meses después;
+19. especificidad de la “predicción”;
+20. falsos positivos.
+
+Después comparar portadas monetarias con **semanas equivalentes sin portada monetaria**.
+
+Hipótesis a contrastar:
+
+- **Predictive Economist Effect**.
+- **Contrarian Cover Effect**.
+- **Narrative Saturation Effect**.
+- **Null / sesgo retrospectivo humano**.
+
+La portada del **8-ago-2026** queda como primer caso completamente **out-of-sample** de Conspiraciones Atlas: el resultado posterior no era conocido al congelar el protocolo.
+
+---
+
+# Reglas de integración ATLAS Ω
+
+1. Mantener separación estricta entre:
+   - HECHO;
+   - EVIDENCIA;
+   - HIPÓTESIS;
+   - INTERPRETACIÓN;
+   - ESPECULACIÓN.
+2. Portadas y narrativas nunca generan BUY/SELL directamente.
+3. La señal sólo puede alimentar contexto de régimen, Money Rotation Ω e Historical Dislocation Ω.
+4. Precio o market-cap change nunca deben etiquetarse como capital flow.
+5. Señales causales duplicadas cuentan una vez.
+6. Resultados prospectivos sólo se evalúan después de cerrar su ventana temporal.
+7. Los criterios Phoenix 2026 permanecen congelados; no se añaden confirmadores retrospectivos para salvar la hipótesis.
+8. Eclipse 12-ago-2026 y simbolismo social = peso 0.
+9. Una moneda BRICS formal, SDR minorista o unidad transnacional comercial serían cambios cualitativamente distintos de simples payment rails.
+10. La ausencia persistente de confirmadores debe contar como falsificación, no como “todavía no”.
+
+---
+
+# Estado de investigación
+
+**Información archivada, no canon automático.**
+
+Existe una implementación separada en la rama/PR histórica de Conspiraciones Atlas Ω / Economist / Phoenix; este documento se conserva como **expediente informativo completo**, independiente de que esa implementación de código sea posteriormente rebasada, extraída o reimplementada sobre el `main` vigente.

--- a/docs/research/CONSPIRACIONES_ATLAS_ECONOMIST_IMPLEMENTATION_STATUS_20260810.md
+++ b/docs/research/CONSPIRACIONES_ATLAS_ECONOMIST_IMPLEMENTATION_STATUS_20260810.md
@@ -1,0 +1,109 @@
+# CONSPIRACIONES ATLAS Ω — Economist / Phoenix — estado de implementación
+
+**Fecha:** 2026-08-10  
+**Tipo:** información de repositorio / historial técnico.  
+**Objetivo:** preservar qué se implementó, dónde quedó y qué debe considerarse antes de tocar el código en el futuro.
+
+---
+
+## Implementación original
+
+Rama histórica:
+
+`feat/conspiraciones-atlas-phoenix-2026`
+
+Pull request:
+
+`#25 — feat: Conspiraciones Atlas Ω Economist/Phoenix engine`
+
+La implementación original añadió:
+
+- `Narrative Saturation Ω` determinista 0–100.
+- Clasificación de portadas: `PREDICTIVE / CONTRARIAN / SATURATION / NULL`.
+- Estado `PENDING_OUTCOME` antes del cierre de ventanas prospectivas.
+- Checks anti-lookahead para fechas de portada, métricas y outcomes.
+- Clasificador cross-asset con régimen `RESERVE_ARCHITECTURE_STRESS` para `USD↓ + gold↑ + UST yields↑`.
+- `Phoenix 2026 Ω` con baseline congelado.
+- Pesos explícitos por señal y deduplicación causal.
+- Exclusión explícita del eclipse del 12-ago-2026 con peso cero.
+- Schema de dataset para estudiar aproximadamente 2.080 ediciones 1986–2026.
+- Matched-control event-study primitives.
+- Routing hacia `CONSPIRACIONES_ATLAS`, `NARRATIVE_SATURATION_OMEGA`, `PHOENIX_2026_MONITOR_OMEGA`, `MONEY_ROTATION_OMEGA` y `HISTORICAL_DISLOCATION_OMEGA`.
+- Regla de seguridad: el motor de investigación no emite BUY/SELL.
+
+Archivos históricos principales de esa rama:
+
+- `docs/canon/CONSPIRACIONES_ATLAS_ECONOMIST_PHOENIX_OMEGA_v1.md`
+- `mobile/domain/conspiracionesAtlasEconomist.ts`
+- `src/atlas/algorithm/conspiraciones-atlas-economist-omega.ts`
+- cambios de routing en Evidence Ingestion / tipos / pipeline.
+
+---
+
+## Baseline Phoenix 2026 original
+
+- Portada: `The Global Currency Beef`.
+- Fecha portada: `2026-08-08`.
+- Baseline congelado: `2026-08-09`.
+- Regla: **No moving goalposts / no retrospective reinterpretation.**
+- Sólo observaciones `FACT` con evidencia trazable puntúan.
+- Señales causales duplicadas cuentan una vez.
+- BRICS local rails / monedas locales: contexto de fragmentación, no confirmación Phoenix.
+- Eclipse y simbolismo social 12-ago-2026: excluidos, score 0.
+
+Señales monitorizadas:
+
+1. repetición de `USD↓ + gold↑ + UST yields↑`;
+2. cuota de reservas USD <55% por reasignación real;
+3. aumento material de RMB en reservas;
+4. compras elevadas de oro por bancos centrales;
+5. unidad monetaria común BRICS formal;
+6. migración material de contratos energéticos fuera del USD;
+7. expansión extraordinaria del SDR;
+8. uso privado/minorista del SDR;
+9. unidad monetaria transnacional de uso comercial;
+10. BRICS local rails only = contexto, peso 0;
+11. eclipse 12-ago = excluido, peso 0.
+
+---
+
+## Validación obtenida en la rama histórica
+
+Durante el PR #25 se observó:
+
+- `API Syntax & Broker Guardrail Verification`: PASS.
+- `TypeScript Check & Schema Verification`: PASS.
+- Build Android Candidate APK llegó a ejecutarse después de esos gates.
+
+El PR #25 quedó inicialmente listo para review.
+
+---
+
+## Estado actual respecto a `main`
+
+Desde entonces `main` avanzó mediante múltiples PRs y releases (Mobile v2, Energy Rotation Ω, AI Infrastructure Rotation Ω, nuevas correcciones móviles, etc.).
+
+Por ello, a fecha 2026-08-10:
+
+- PR #25 sigue **abierto**.
+- No está fusionado.
+- Aparece como no mergeable frente al `main` actual debido a divergencia/conflictos posteriores.
+
+### Regla de seguridad de repositorio
+
+**No fusionar PR #25 wholesale sobre el `main` actual sin reconciliación.**
+
+Si se desea activar ese motor en el producto vigente:
+
+1. partir del `main` actual;
+2. extraer sólo los archivos/lógica de Conspiraciones Atlas / Narrative Saturation / Phoenix que sigan siendo necesarios;
+3. reconciliar IDs y routing con los motores actuales;
+4. mantener Evidence Integrity Ω;
+5. ejecutar typecheck, tests, API gates, APK y emulator gate;
+6. abrir un PR limpio y pequeño.
+
+El documento completo de investigación se conserva en:
+
+`docs/research/CONSPIRACIONES_ATLAS_ECONOMIST_DINERO_PODER_1986_2026_FULL.md`
+
+Éste es el archivo informativo persistente y no depende de que la rama histórica permanezca mergeable.


### PR DESCRIPTION
## Scope

Archives the full Conspiraciones Atlas Ω research dossier on The Economist / money / power 1986–2026 as repository information, plus the technical status of the historical Phoenix implementation.

## Added

- Full 1986–2026 research narrative and chronology.
- Phoenix 1988 literal-vs-structural assessment.
- Dollar/euro/SDR/gold/oil/BRICS analysis.
- Narrative Saturation Ω research hypothesis.
- Frozen Phoenix 2026 prospective protocol and falsifiers.
- 2,080-edition dataset/event-study research plan.
- Historical PR #25 implementation map, CI status and current divergence warning.

## Safety

Documentation only. It does not modify canonical investment decisions, portfolio state, broker execution, scoring engines or mobile runtime. Evidence must be re-linked to traceable sources before being promoted from research information into canonical claims.