### PR TITLE
ci: fresh ATLAS Ω APK delivery build

### DIFF
--- a/mobile/APK_DELIVERY_CHECKPOINT_20260810.md
+++ b/mobile/APK_DELIVERY_CHECKPOINT_20260810.md
@@ -1,0 +1,5 @@
+# ATLAS Ω APK delivery checkpoint
+
+Trigger a fresh PR-scoped Mobile CI / APK build from current main so the resulting workflow run and APK artifact can be retrieved and delivered.
+
+No runtime behavior changes.


### PR DESCRIPTION
Obsolete CI-only APK checkpoint. It contains no runtime behavior and targeted an older main/Android certification state. Current main and the current mobile workflow supersede it. Closed without merge.