### PR TITLE
ci: certify ATLAS Ω ONLINE phone APK

### DIFF
--- a/mobile/ONLINE_APK_CERTIFICATION_20260810.md
+++ b/mobile/ONLINE_APK_CERTIFICATION_20260810.md
@@ -1,0 +1,5 @@
+# ATLAS Ω ONLINE APK certification checkpoint
+
+Triggers the production-online APK workflow after restoring the canonical Render endpoint and deployment branch.
+
+The resulting APK is valid for delivery only if the workflow proves the live Render `/health`, `/v1/atlas/universe`, and `/v1/market/snapshot` contracts before compilation and verifies the embedded production URL.

--- a/mobile/core/api/atlasOnlineApi.ts
+++ b/mobile/core/api/atlasOnlineApi.ts
@@ -259,7 +259,7 @@ export type MarketOrderInput = {
 };
 
 const configuredBase = process.env.EXPO_PUBLIC_ATLAS_API_BASE_URL?.replace(/\/$/, '');
-const DEFAULT_PUBLIC_API = 'https://atlas-genesis-api.onrender.com';
+const DEFAULT_PUBLIC_API = 'https://atlas-genesis.onrender.com';
 
 export function atlasApiBaseUrl(): string {
   return configuredBase || DEFAULT_PUBLIC_API;


### PR DESCRIPTION
Build-only certification checkpoint after the Render connectivity repair. The dedicated ONLINE workflow must prove the live backend contract and the correct embedded production URL before publishing `atlas-omega-ONLINE-phone-apk`.