### PR TITLE
ci: force dedicated ONLINE Render certification

### DIFF
--- a/.github/workflows/atlas-online-phone-apk.yml
+++ b/.github/workflows/atlas-online-phone-apk.yml
@@ -144,3 +144,5 @@ PY
           path: mobile/android/app/build/outputs/apk/release/*.apk
           if-no-files-found: error
           retention-days: 30
+
+# certification trigger 2026-08-10


### PR DESCRIPTION
Superseded by the consolidated ONLINE production pipeline now merged into main. A fresh certification PR from current main is used instead.