### PR TITLE
ci: final ATLAS Ω ONLINE phone certification

### DIFF
--- a/mobile/FINAL_ONLINE_PHONE_CERTIFICATION_20260810.md
+++ b/mobile/FINAL_ONLINE_PHONE_CERTIFICATION_20260810.md
@@ -1,0 +1,11 @@
+# ATLAS Ω final ONLINE phone certification
+
+This checkpoint triggers the consolidated production pipeline from current `main`.
+
+The APK may be delivered only if all of these pass in the same run:
+
+- LIVE Render API contract at `https://atlas-genesis.onrender.com`.
+- Local ATLAS/Broker guardrails.
+- TypeScript.
+- Android release build with the production URL embedded.
+- Android emulator showing `ONLINE` and `ATLAS + FINNHUB + MARKET` against the real deployed backend.


### PR DESCRIPTION
Obsolete CI-only checkpoint. This branch existed only to certify an older Android/Render state and is now superseded by current main and the hardened Mobile + Agentic deployment contracts. No runtime behavior to preserve. Closed without merge.