### PR TITLE
prep: premium Finnhub resilience + Trading 212 read-only portfolio

### DIFF
--- a/.github/workflows/premium-data-t212-ci.yml
+++ b/.github/workflows/premium-data-t212-ci.yml
@@ -1,0 +1,72 @@
+name: ATLAS Ω Premium Data + T212 Preparation
+
+on:
+  push:
+    branches:
+      - feat/premium-data-t212-live-20260811
+    paths:
+      - 'api/**'
+      - 'mobile/**'
+      - 'docs/2026-08-11-premium-data-t212-plan.md'
+      - '.github/workflows/premium-data-t212-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'api/**'
+      - 'mobile/**'
+      - 'docs/2026-08-11-premium-data-t212-plan.md'
+      - '.github/workflows/premium-data-t212-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: premium-data-t212-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  api-safety:
+    name: Provider safety + Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install API dependencies
+        run: pip install -r api/requirements.txt
+      - name: Compile API
+        run: python -m compileall -q api
+      - name: Run provider preparation tests
+        run: pytest -q api/tests/test_provider_preparation.py
+      - name: Assert no secrets are hard-coded in preparation files
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! grep -RIE '(TRADING212_API_KEY|TRADING212_API_SECRET|FINNHUB_TOKEN)\s*=\s*["'"'][^"'"']+["'"']' api/providers api/tests || {
+            echo '::error::Potential hard-coded provider secret detected'
+            exit 1
+          }
+
+  mobile-regression:
+    name: Existing mobile TypeScript regression gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+      - run: npm install
+      - run: npx tsc --noEmit
+
+  no-apk-on-prep:
+    name: Confirm preparation does not replace working APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guardrail
+        run: |
+          echo 'Preparation branch only: no APK build, no Render deploy, no main merge.'

--- a/.github/workflows/premium-data-t212-ci.yml
+++ b/.github/workflows/premium-data-t212-ci.yml
@@ -29,6 +29,8 @@ jobs:
   api-safety:
     name: Provider safety + Python tests
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: .
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -39,15 +41,15 @@ jobs:
       - name: Compile API
         run: python -m compileall -q api
       - name: Run provider preparation tests
-        run: pytest -q api/tests/test_provider_preparation.py
+        run: python -m pytest -q api/tests/test_provider_preparation.py
       - name: Assert no secrets are hard-coded in preparation files
         shell: bash
         run: |
           set -euo pipefail
-          ! grep -RIE '(TRADING212_API_KEY|TRADING212_API_SECRET|FINNHUB_TOKEN)\s*=\s*["'"'][^"'"']+["'"']' api/providers api/tests || {
+          if grep -RIE '(TRADING212_API_KEY|TRADING212_API_SECRET|FINNHUB_TOKEN)[[:space:]]*=[[:space:]]*["'"'][A-Za-z0-9_-]{12,}["'"']' api/providers api/tests; then
             echo '::error::Potential hard-coded provider secret detected'
             exit 1
-          }
+          fi
 
   mobile-regression:
     name: Existing mobile TypeScript regression gate

--- a/.github/workflows/premium-data-t212-ci.yml
+++ b/.github/workflows/premium-data-t212-ci.yml
@@ -1,33 +1,15 @@
 name: ATLAS Ω Premium Data + T212 Preparation
 
 on:
-  push:
-    branches:
-      - feat/premium-data-t212-live-20260811
-    paths:
-      - 'api/**'
-      - 'mobile/**'
-      - 'docs/2026-08-11-premium-data-t212-plan.md'
-      - '.github/workflows/premium-data-t212-ci.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'api/**'
-      - 'mobile/**'
-      - 'docs/2026-08-11-premium-data-t212-plan.md'
-      - '.github/workflows/premium-data-t212-ci.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: premium-data-t212-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   api-safety:
-    name: Provider safety + Python tests
     runs-on: ubuntu-latest
     env:
       PYTHONPATH: .
@@ -36,23 +18,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install API dependencies
-        run: pip install -r api/requirements.txt
-      - name: Compile API
-        run: python -m compileall -q api
-      - name: Run provider preparation tests
-        run: python -m pytest -q api/tests/test_provider_preparation.py
-      - name: Assert no secrets are hard-coded in preparation files
-        shell: bash
-        run: |
-          set -euo pipefail
-          if grep -RIE '(TRADING212_API_KEY|TRADING212_API_SECRET|FINNHUB_TOKEN)[[:space:]]*=[[:space:]]*["'"'][A-Za-z0-9_-]{12,}["'"']' api/providers api/tests; then
-            echo '::error::Potential hard-coded provider secret detected'
-            exit 1
-          fi
+      - run: pip install -r api/requirements.txt
+      - run: python -m compileall -q api
+      - run: python -m pytest -q api/tests/test_provider_preparation.py
 
   mobile-regression:
-    name: Existing mobile TypeScript regression gate
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -64,11 +34,3 @@ jobs:
           node-version: '22.13.0'
       - run: npm install
       - run: npx tsc --noEmit
-
-  no-apk-on-prep:
-    name: Confirm preparation does not replace working APK
-    runs-on: ubuntu-latest
-    steps:
-      - name: Guardrail
-        run: |
-          echo 'Preparation branch only: no APK build, no Render deploy, no main merge.'

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,14 @@
+# ATLAS Ω server-side provider configuration example.
+# Never put real values in GitHub or in the mobile application.
+
+FINNHUB_TOKEN=
+FINNHUB_MAX_CALLS_PER_SECOND=20
+
+# For the next phase use a Trading 212 LIVE key created with read-only
+# account/portfolio permissions. Do not grant order permissions.
+TRADING212_ENV=live
+TRADING212_API_KEY=
+TRADING212_API_SECRET=
+
+# Must remain false for the read-only portfolio phase.
+TRADING212_LIVE_TRADING_ENABLED=false

--- a/api/app.py
+++ b/api/app.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
+import api.atlas_core as atlas_core_module
+import api.main as base_api_module
 from api.atlas_core import router as atlas_router
 from api.evidence import router as evidence_router
 from api.main import app
 from api.market import router as market_router
+from api.providers.finnhub_resilient import finnhub_get, finnhub_optional
 from api.providers.trading212_readonly import router as trading212_readonly_router
+
+# Preparation branch provider bridge.
+# Existing route implementations remain intact, but every Finnhub call made by
+# api.main/api.atlas_core is redirected through one resilient server-side
+# adapter. This avoids editing the proven route/engine logic before the paid
+# provider credentials are installed and keeps rollback trivial.
+base_api_module._finnhub_get = finnhub_get
+base_api_module._optional = finnhub_optional
+atlas_core_module._finnhub = finnhub_get
+atlas_core_module._optional = finnhub_optional
 
 # Deployment entrypoint. Routers are additive: Broker Ω guardrails in api.main
 # remain authoritative while market/ATLAS/evidence intelligence stay read-only.

--- a/api/app.py
+++ b/api/app.py
@@ -4,9 +4,12 @@ from api.atlas_core import router as atlas_router
 from api.evidence import router as evidence_router
 from api.main import app
 from api.market import router as market_router
+from api.providers.trading212_readonly import router as trading212_readonly_router
 
 # Deployment entrypoint. Routers are additive: Broker Ω guardrails in api.main
 # remain authoritative while market/ATLAS/evidence intelligence stay read-only.
+# The portfolio router is intentionally read-only and contains no order method.
 app.include_router(market_router)
 app.include_router(atlas_router)
 app.include_router(evidence_router)
+app.include_router(trading212_readonly_router)

--- a/api/app.py
+++ b/api/app.py
@@ -6,6 +6,7 @@ from api.atlas_core import router as atlas_router
 from api.evidence import router as evidence_router
 from api.main import app
 from api.market import router as market_router
+from api.mobile_sync import router as mobile_sync_router
 from api.providers.finnhub_resilient import finnhub_get, finnhub_optional
 from api.providers.trading212_readonly import router as trading212_readonly_router
 
@@ -26,3 +27,4 @@ app.include_router(market_router)
 app.include_router(atlas_router)
 app.include_router(evidence_router)
 app.include_router(trading212_readonly_router)
+app.include_router(mobile_sync_router)

--- a/api/mobile_sync.py
+++ b/api/mobile_sync.py
@@ -23,11 +23,12 @@ def _watchlist() -> list[dict[str, Any]]:
 
 def _portfolio_item(position: dict[str, Any]) -> dict[str, Any]:
     symbol = str(position.get("analysisSymbol") or "").strip().upper()
-    broker_ticker = str(position.get("brokerTicker") or "").strip()
+    broker_ticker = str(position.get("brokerTicker") or "").strip().upper()
     name = str(position.get("name") or symbol or broker_ticker)
     return {
-        "ticker": symbol or broker_ticker,
-        "symbol": symbol or broker_ticker,
+        "ticker": broker_ticker or symbol,
+        "symbol": symbol or None,
+        "analysisSymbolStatus": position.get("analysisSymbolStatus") or ("RESOLVED" if symbol else "NEEDS_VERIFIED_MAPPING"),
         "name": name,
         "sector": "Trading 212 LIVE",
         "brokerTicker": broker_ticker,
@@ -65,6 +66,7 @@ async def resolved_portfolio() -> tuple[list[dict[str, Any]], dict[str, Any]]:
                 "sourceStatus": payload.get("sourceStatus"),
                 "generatedAt": payload.get("generatedAt"),
                 "rateLimit": payload.get("rateLimit") or {},
+                "unresolvedAnalysisSymbols": payload.get("unresolvedAnalysisSymbols", 0),
                 "readOnly": True,
             }
     except HTTPException as exc:
@@ -106,6 +108,35 @@ async def mobile_universe() -> dict[str, Any]:
     }
 
 
+async def _analyze_items(items: list[dict[str, Any]], context: Literal["portfolio", "watchlist"]) -> list[dict[str, Any]]:
+    async def one(item: dict[str, Any]) -> dict[str, Any]:
+        symbol = str(item.get("symbol") or "").strip().upper()
+        if not symbol and item.get("portfolioSource") != "Trading212":
+            symbol = str(item.get("ticker") or "").strip().upper()
+        if not symbol:
+            return {
+                "item": item,
+                "ok": False,
+                "error": "UNRESOLVED_SYMBOL_NEEDS_VERIFIED_MAPPING",
+                "statusCode": 422,
+            }
+        try:
+            result = await analyze_symbol(symbol, context)
+            return {"item": item, "ok": True, **result}
+        except HTTPException as exc:
+            return {
+                "item": item,
+                "ok": False,
+                "symbol": symbol,
+                "error": str(exc.detail),
+                "statusCode": exc.status_code,
+            }
+        except Exception as exc:
+            return {"item": item, "ok": False, "symbol": symbol, "error": exc.__class__.__name__}
+
+    return await asyncio.gather(*(one(item) for item in items))
+
+
 @router.get("/monitor/{kind}")
 async def mobile_monitor(
     kind: Literal["portfolio", "watchlist"],
@@ -121,26 +152,7 @@ async def mobile_monitor(
         context = "watchlist"
 
     page = source[offset: offset + limit]
-
-    async def one(item: dict[str, Any]) -> dict[str, Any]:
-        symbol = str(item.get("symbol") or item.get("ticker") or "").strip().upper()
-        if not symbol:
-            return {"item": item, "ok": False, "error": "UNRESOLVED_SYMBOL"}
-        try:
-            result = await analyze_symbol(symbol, context)
-            return {"item": item, "ok": True, **result}
-        except HTTPException as exc:
-            return {
-                "item": item,
-                "ok": False,
-                "symbol": symbol,
-                "error": str(exc.detail),
-                "statusCode": exc.status_code,
-            }
-        except Exception as exc:
-            return {"item": item, "ok": False, "symbol": symbol, "error": exc.__class__.__name__}
-
-    rows = await asyncio.gather(*(one(item) for item in page))
+    rows = await _analyze_items(page, context)
     next_offset = offset + len(page) if offset + len(page) < len(source) else None
     return {
         "kind": kind,
@@ -151,5 +163,39 @@ async def mobile_monitor(
         "nextOffset": next_offset,
         "items": rows,
         "portfolioMeta": portfolio_meta,
-        "guardrail": "Monitoring is paginated and provider-resilient. A provider limit never changes portfolio identity and never fabricates missing analysis.",
+        "guardrail": "Monitoring is paginated and provider-resilient. A provider limit never changes portfolio identity and unresolved international broker symbols are never guessed.",
+    }
+
+
+@router.get("/analyze-symbols")
+async def analyze_symbols(
+    symbols: str = Query(..., min_length=1, max_length=500),
+    context: Literal["portfolio", "watchlist"] = Query(default="watchlist"),
+) -> dict[str, Any]:
+    """Analyze an app-owned editable list through the paid/resilient provider.
+
+    This is intentionally GET/read-only. It lets the SQLite watchlist remain
+    user-editable on the phone while all analytical data comes from ATLAS.
+    Requests are capped at eight symbols so the caller paginates rather than
+    generating an upstream burst.
+    """
+    raw = [part.strip().upper() for part in symbols.replace(" ", ",").split(",")]
+    unique: list[str] = []
+    for symbol in raw:
+        if not symbol or symbol in unique:
+            continue
+        if len(symbol) > 24 or not all(ch.isalnum() or ch in ".-" for ch in symbol):
+            raise HTTPException(status_code=400, detail=f"Invalid analysis symbol: {symbol[:24]}")
+        unique.append(symbol)
+        if len(unique) >= 8:
+            break
+    if not unique:
+        raise HTTPException(status_code=400, detail="At least one valid symbol is required")
+    items = [{"ticker": symbol, "symbol": symbol, "name": symbol, "sector": "Editable watchlist"} for symbol in unique]
+    rows = await _analyze_items(items, context)
+    return {
+        "context": context,
+        "count": len(rows),
+        "items": rows,
+        "guardrail": "Editable watchlist symbols are analyzed read-only. This endpoint does not mutate broker positions or place orders.",
     }

--- a/api/mobile_sync.py
+++ b/api/mobile_sync.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, Query
+
+from api.atlas_core import analyze_symbol
+from api.providers.trading212_readonly import configured as trading212_configured
+from api.providers.trading212_readonly import live_portfolio
+from api.tracked_universe import PORTFOLIO, PORTFOLIO_PENDING, SNAPSHOT_ID, WATCHLIST
+
+router = APIRouter(prefix="/v1/mobile", tags=["mobile-sync"])
+
+
+def _fallback_portfolio() -> list[dict[str, Any]]:
+    return [dict(item) for item in PORTFOLIO]
+
+
+def _watchlist() -> list[dict[str, Any]]:
+    return [dict(item) for item in WATCHLIST]
+
+
+def _portfolio_item(position: dict[str, Any]) -> dict[str, Any]:
+    symbol = str(position.get("analysisSymbol") or "").strip().upper()
+    broker_ticker = str(position.get("brokerTicker") or "").strip()
+    name = str(position.get("name") or symbol or broker_ticker)
+    return {
+        "ticker": symbol or broker_ticker,
+        "symbol": symbol or broker_ticker,
+        "name": name,
+        "sector": "Trading 212 LIVE",
+        "brokerTicker": broker_ticker,
+        "isin": position.get("isin"),
+        "currency": position.get("currency"),
+        "quantity": position.get("quantity"),
+        "quantityAvailableForTrading": position.get("quantityAvailableForTrading"),
+        "quantityInPies": position.get("quantityInPies"),
+        "averagePricePaid": position.get("averagePricePaid"),
+        "currentPrice": position.get("currentPrice"),
+        "walletImpact": position.get("walletImpact"),
+        "brokerCreatedAt": position.get("createdAt"),
+        "portfolioSource": "Trading212",
+    }
+
+
+async def resolved_portfolio() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not trading212_configured():
+        return _fallback_portfolio(), {
+            "provider": "ATLAS_BOOTSTRAP",
+            "configured": False,
+            "sourceStatus": "FALLBACK",
+            "readOnly": True,
+        }
+
+    try:
+        payload = await live_portfolio()
+        rows = payload.get("positions") if isinstance(payload, dict) else []
+        positions = [_portfolio_item(item) for item in rows if isinstance(item, dict)]
+        if positions:
+            return positions, {
+                "provider": "Trading212",
+                "configured": True,
+                "environment": payload.get("environment"),
+                "sourceStatus": payload.get("sourceStatus"),
+                "generatedAt": payload.get("generatedAt"),
+                "rateLimit": payload.get("rateLimit") or {},
+                "readOnly": True,
+            }
+    except HTTPException as exc:
+        return _fallback_portfolio(), {
+            "provider": "ATLAS_BOOTSTRAP",
+            "configured": True,
+            "sourceStatus": f"BROKER_UNAVAILABLE:{exc.status_code}",
+            "readOnly": True,
+        }
+
+    return _fallback_portfolio(), {
+        "provider": "ATLAS_BOOTSTRAP",
+        "configured": True,
+        "sourceStatus": "BROKER_EMPTY_FALLBACK",
+        "readOnly": True,
+    }
+
+
+@router.get("/universe")
+async def mobile_universe() -> dict[str, Any]:
+    portfolio, portfolio_meta = await resolved_portfolio()
+    watchlist = _watchlist()
+    return {
+        "snapshotId": SNAPSHOT_ID,
+        "portfolio": portfolio,
+        "portfolioPending": [dict(item) for item in PORTFOLIO_PENDING],
+        "watchlist": watchlist,
+        "counts": {
+            "portfolio": len(portfolio),
+            "pending": len(PORTFOLIO_PENDING),
+            "watchlist": len(watchlist),
+        },
+        "portfolioMeta": portfolio_meta,
+        "watchlistMeta": {
+            "provider": "ATLAS_EDITABLE_WATCHLIST",
+            "analysisProvider": "Finnhub via resilient ATLAS backend",
+        },
+        "guardrail": "Trading 212 is authoritative for held positions when read-only credentials are configured. Watchlist identity remains user-editable; analysis is fetched separately from the configured market/fundamental provider.",
+    }
+
+
+@router.get("/monitor/{kind}")
+async def mobile_monitor(
+    kind: Literal["portfolio", "watchlist"],
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=6, ge=1, le=8),
+) -> dict[str, Any]:
+    if kind == "portfolio":
+        source, portfolio_meta = await resolved_portfolio()
+        context: Literal["portfolio", "watchlist"] = "portfolio"
+    else:
+        source = _watchlist()
+        portfolio_meta = None
+        context = "watchlist"
+
+    page = source[offset: offset + limit]
+
+    async def one(item: dict[str, Any]) -> dict[str, Any]:
+        symbol = str(item.get("symbol") or item.get("ticker") or "").strip().upper()
+        if not symbol:
+            return {"item": item, "ok": False, "error": "UNRESOLVED_SYMBOL"}
+        try:
+            result = await analyze_symbol(symbol, context)
+            return {"item": item, "ok": True, **result}
+        except HTTPException as exc:
+            return {
+                "item": item,
+                "ok": False,
+                "symbol": symbol,
+                "error": str(exc.detail),
+                "statusCode": exc.status_code,
+            }
+        except Exception as exc:
+            return {"item": item, "ok": False, "symbol": symbol, "error": exc.__class__.__name__}
+
+    rows = await asyncio.gather(*(one(item) for item in page))
+    next_offset = offset + len(page) if offset + len(page) < len(source) else None
+    return {
+        "kind": kind,
+        "snapshotId": SNAPSHOT_ID,
+        "offset": offset,
+        "limit": limit,
+        "total": len(source),
+        "nextOffset": next_offset,
+        "items": rows,
+        "portfolioMeta": portfolio_meta,
+        "guardrail": "Monitoring is paginated and provider-resilient. A provider limit never changes portfolio identity and never fabricates missing analysis.",
+    }

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -1,0 +1,5 @@
+"""External market/broker provider adapters for ATLAS Ω.
+
+Provider modules keep credentials and upstream rate-limit handling on the server.
+The mobile application must never contain provider secrets.
+"""

--- a/api/providers/finnhub_resilient.py
+++ b/api/providers/finnhub_resilient.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import HTTPException
+
+FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    stored_at: float
+    value: Any
+
+
+@dataclass(frozen=True, slots=True)
+class FinnhubPolicy:
+    ttl_seconds: float
+    stale_seconds: float
+
+
+_POLICIES: tuple[tuple[str, FinnhubPolicy], ...] = (
+    ("/quote", FinnhubPolicy(8.0, 300.0)),
+    ("/stock/profile2", FinnhubPolicy(86_400.0, 7 * 86_400.0)),
+    ("/stock/metric", FinnhubPolicy(21_600.0, 3 * 86_400.0)),
+    ("/stock/recommendation", FinnhubPolicy(3_600.0, 86_400.0)),
+    ("/company-news", FinnhubPolicy(900.0, 21_600.0)),
+    ("/search", FinnhubPolicy(300.0, 3_600.0)),
+)
+_DEFAULT_POLICY = FinnhubPolicy(60.0, 900.0)
+
+
+def policy_for(path: str) -> FinnhubPolicy:
+    for prefix, policy in _POLICIES:
+        if path.startswith(prefix):
+            return policy
+    return _DEFAULT_POLICY
+
+
+class FinnhubResilientClient:
+    """Server-side Finnhub adapter designed for ATLAS Ω fan-out workloads.
+
+    Guarantees:
+    - one in-flight upstream request per unique endpoint/parameter key;
+    - short/long TTLs according to data volatility;
+    - conservative calls-per-second throttle below Finnhub's global ceiling;
+    - temporary cooldown after HTTP 429;
+    - stale-last-good fallback when an upstream limit/outage occurs.
+
+    No provider token is ever returned to clients.
+    """
+
+    def __init__(self, *, max_calls_per_second: int | None = None) -> None:
+        configured = max_calls_per_second or int(os.getenv("FINNHUB_MAX_CALLS_PER_SECOND", "20"))
+        self.max_calls_per_second = max(1, min(configured, 29))
+        self._cache: dict[str, _CacheEntry] = {}
+        self._key_locks: dict[str, asyncio.Lock] = {}
+        self._rate_lock = asyncio.Lock()
+        self._recent_calls: deque[float] = deque()
+        self._cooldown_until = 0.0
+
+    @staticmethod
+    def _token() -> str:
+        token = os.getenv("FINNHUB_TOKEN", "").strip()
+        if not token:
+            raise HTTPException(status_code=503, detail="FINNHUB_TOKEN is not configured")
+        return token
+
+    @staticmethod
+    def _key(path: str, params: dict[str, Any]) -> str:
+        normalized = urlencode(sorted((str(k), str(v)) for k, v in params.items()))
+        return f"{path}?{normalized}"
+
+    async def _throttle(self) -> None:
+        while True:
+            wait = 0.0
+            async with self._rate_lock:
+                now = time.monotonic()
+                while self._recent_calls and now - self._recent_calls[0] >= 1.0:
+                    self._recent_calls.popleft()
+                if len(self._recent_calls) < self.max_calls_per_second:
+                    self._recent_calls.append(now)
+                    return
+                wait = max(0.01, 1.0 - (now - self._recent_calls[0]))
+            await asyncio.sleep(wait)
+
+    @staticmethod
+    def _age(entry: _CacheEntry | None, now: float) -> float | None:
+        return None if entry is None else now - entry.stored_at
+
+    async def fetch(
+        self,
+        path: str,
+        params: dict[str, Any],
+        *,
+        policy: FinnhubPolicy | None = None,
+    ) -> tuple[Any, str]:
+        selected = policy or policy_for(path)
+        key = self._key(path, params)
+        now = time.monotonic()
+        cached = self._cache.get(key)
+        age = self._age(cached, now)
+        if cached is not None and age is not None and age <= selected.ttl_seconds:
+            return cached.value, "CACHE:FRESH"
+
+        lock = self._key_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            now = time.monotonic()
+            cached = self._cache.get(key)
+            age = self._age(cached, now)
+            if cached is not None and age is not None and age <= selected.ttl_seconds:
+                return cached.value, "CACHE:FRESH"
+
+            if now < self._cooldown_until:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, "CACHE:STALE:RATE_LIMIT"
+                retry_after = max(1, int(self._cooldown_until - now))
+                raise HTTPException(status_code=429, detail=f"Finnhub cooling down; retry in ~{retry_after}s")
+
+            await self._throttle()
+            headers = {"X-Finnhub-Token": self._token(), "Accept": "application/json"}
+            timeout = httpx.Timeout(20.0, connect=10.0)
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    response = await client.get(f"{FINNHUB_BASE_URL}{path}", params=params, headers=headers)
+            except httpx.RequestError as exc:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, f"CACHE:STALE:{exc.__class__.__name__}"
+                raise HTTPException(status_code=502, detail=f"Finnhub connection failed: {exc.__class__.__name__}") from exc
+
+            if response.status_code == 429:
+                retry_header = response.headers.get("retry-after")
+                try:
+                    retry_seconds = max(2.0, float(retry_header)) if retry_header else 5.0
+                except ValueError:
+                    retry_seconds = 5.0
+                self._cooldown_until = time.monotonic() + min(retry_seconds, 60.0)
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, "CACHE:STALE:429"
+                raise HTTPException(status_code=429, detail="Finnhub rate limit reached")
+
+            if response.status_code >= 500:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, f"CACHE:STALE:HTTP_{response.status_code}"
+                raise HTTPException(status_code=502, detail=f"Finnhub upstream HTTP {response.status_code}")
+            if response.status_code >= 400:
+                raise HTTPException(status_code=502, detail=f"Finnhub upstream HTTP {response.status_code}")
+
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, "CACHE:STALE:NON_JSON"
+                raise HTTPException(status_code=502, detail="Finnhub returned non-JSON data") from exc
+
+            self._cache[key] = _CacheEntry(stored_at=time.monotonic(), value=payload)
+            return payload, "LIVE"
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._cooldown_until = 0.0
+
+
+finnhub_client = FinnhubResilientClient()
+
+
+async def finnhub_get(path: str, params: dict[str, Any]) -> Any:
+    payload, _ = await finnhub_client.fetch(path, params)
+    return payload
+
+
+async def finnhub_optional(path: str, params: dict[str, Any]) -> tuple[Any, str]:
+    try:
+        return await finnhub_client.fetch(path, params)
+    except HTTPException as exc:
+        return None, f"UNAVAILABLE:{exc.status_code}"

--- a/api/providers/trading212_readonly.py
+++ b/api/providers/trading212_readonly.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import os
 import time
 from dataclasses import dataclass
@@ -52,19 +53,49 @@ def _auth_header() -> str:
     return "Basic " + base64.b64encode(raw).decode("ascii")
 
 
-def _symbol_from_broker_ticker(ticker: str) -> str:
-    """Best-effort ATLAS symbol from a T212 ticker.
+def _symbol_overrides() -> dict[str, str]:
+    """Optional verified T212 ticker -> analysis symbol mappings.
 
-    T212's full instrument object remains attached to every position. This
-    helper only supplies a convenient analysis candidate; international symbol
-    resolution can later use the cached instrument metadata/ISIN map.
+    The value is non-secret configuration, supplied server-side as a JSON
+    object. International symbols are deliberately not guessed. Example:
+    {"VERIFIED_BROKER_TICKER": "VERIFIED.PROVIDER_SYMBOL"}
+    """
+    raw = os.getenv("ATLAS_T212_SYMBOL_OVERRIDES", "{}").strip() or "{}"
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key, value in payload.items():
+        broker = str(key).strip().upper()
+        symbol = str(value).strip().upper()
+        if broker and symbol and len(symbol) <= 24 and all(ch.isalnum() or ch in ".-" for ch in symbol):
+            result[broker] = symbol
+    return result
+
+
+def _symbol_from_broker_ticker(ticker: str) -> str:
+    """Return a safe analysis symbol or an empty string when unresolved.
+
+    Trading 212 uses unique broker tickers such as AAPL_US_EQ. US equity
+    tickers can be normalized deterministically. International instruments are
+    not stripped blindly because the resulting bare symbol can identify a
+    completely different company on another exchange. They require a verified
+    override after inspecting the real instrument metadata/ISIN.
     """
     value = ticker.strip().upper()
     if not value:
+        return ""
+    override = _symbol_overrides().get(value)
+    if override:
+        return override
+    if value.endswith("_US_EQ"):
+        return value[: -len("_US_EQ")]
+    if "_" not in value and len(value) <= 20 and all(ch.isalnum() or ch in ".-" for ch in value):
         return value
-    if "_" in value:
-        return value.split("_", 1)[0]
-    return value
+    return ""
 
 
 def _cache_ttl(path: str) -> float:
@@ -91,7 +122,13 @@ def _cache_key(path: str, params: dict[str, Any] | None) -> str:
 
 
 def _capture_rate_headers(headers: httpx.Headers) -> None:
-    for key in ("x-ratelimit-limit", "x-ratelimit-period", "x-ratelimit-remaining", "x-ratelimit-reset"):
+    for key in (
+        "x-ratelimit-limit",
+        "x-ratelimit-period",
+        "x-ratelimit-remaining",
+        "x-ratelimit-reset",
+        "x-ratelimit-used",
+    ):
         value = headers.get(key)
         if value is not None:
             _LAST_RATE_HEADERS[key] = value
@@ -151,10 +188,12 @@ async def _request(path: str, *, params: dict[str, Any] | None = None) -> tuple[
 
 def _position_row(raw: dict[str, Any]) -> dict[str, Any]:
     instrument = raw.get("instrument") if isinstance(raw.get("instrument"), dict) else {}
-    broker_ticker = str(instrument.get("ticker") or raw.get("ticker") or "").strip()
+    broker_ticker = str(instrument.get("ticker") or raw.get("ticker") or "").strip().upper()
+    analysis_symbol = _symbol_from_broker_ticker(broker_ticker)
     return {
         "brokerTicker": broker_ticker,
-        "analysisSymbol": _symbol_from_broker_ticker(broker_ticker),
+        "analysisSymbol": analysis_symbol or None,
+        "analysisSymbolStatus": "RESOLVED" if analysis_symbol else "NEEDS_VERIFIED_MAPPING",
         "name": instrument.get("name") or instrument.get("shortName") or broker_ticker,
         "isin": instrument.get("isin"),
         "currency": instrument.get("currencyCode"),
@@ -186,6 +225,7 @@ async def live_portfolio() -> dict[str, Any]:
     payload, source_status = await _request("/equity/positions")
     rows = payload if isinstance(payload, list) else []
     positions = [_position_row(item) for item in rows if isinstance(item, dict)]
+    unresolved = sum(1 for item in positions if not item.get("analysisSymbol"))
     return {
         "provider": "Trading212",
         "environment": _env(),
@@ -193,9 +233,10 @@ async def live_portfolio() -> dict[str, Any]:
         "generatedAt": datetime.now(timezone.utc).isoformat(),
         "sourceStatus": source_status,
         "count": len(positions),
+        "unresolvedAnalysisSymbols": unresolved,
         "positions": positions,
         "rateLimit": dict(_LAST_RATE_HEADERS),
-        "guardrail": "Portfolio state is read from Trading 212. ATLAS analysis is separate; broker data never fabricates an investment decision.",
+        "guardrail": "Portfolio state is read from Trading 212. International analysis symbols are never guessed; unresolved instruments stay visible until an exchange/ISIN mapping is verified.",
     }
 
 

--- a/api/providers/trading212_readonly.py
+++ b/api/providers/trading212_readonly.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+router = APIRouter(prefix="/v1/portfolio", tags=["portfolio"])
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    stored_at: float
+    value: Any
+
+
+_CACHE: dict[str, _CacheEntry] = {}
+_LOCKS: dict[str, asyncio.Lock] = {}
+_LAST_RATE_HEADERS: dict[str, str] = {}
+
+
+def _env() -> str:
+    value = os.getenv("TRADING212_ENV", "demo").strip().lower()
+    return "live" if value == "live" else "demo"
+
+
+def _base_url() -> str:
+    return "https://live.trading212.com/api/v0" if _env() == "live" else "https://demo.trading212.com/api/v0"
+
+
+def _credentials() -> tuple[str, str]:
+    key = os.getenv("TRADING212_API_KEY", "").strip()
+    secret = os.getenv("TRADING212_API_SECRET", "").strip()
+    if not key or not secret:
+        raise HTTPException(status_code=503, detail="Trading 212 read-only credentials are not configured")
+    return key, secret
+
+
+def configured() -> bool:
+    return bool(os.getenv("TRADING212_API_KEY", "").strip() and os.getenv("TRADING212_API_SECRET", "").strip())
+
+
+def _auth_header() -> str:
+    key, secret = _credentials()
+    raw = f"{key}:{secret}".encode("utf-8")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def _symbol_from_broker_ticker(ticker: str) -> str:
+    """Best-effort ATLAS symbol from a T212 ticker.
+
+    T212's full instrument object remains attached to every position. This
+    helper only supplies a convenient analysis candidate; international symbol
+    resolution can later use the cached instrument metadata/ISIN map.
+    """
+    value = ticker.strip().upper()
+    if not value:
+        return value
+    if "_" in value:
+        return value.split("_", 1)[0]
+    return value
+
+
+def _cache_ttl(path: str) -> float:
+    if path == "/equity/positions":
+        return 3.0
+    if path == "/equity/account/summary":
+        return 6.0
+    if path == "/equity/metadata/instruments":
+        return 600.0
+    return 5.0
+
+
+def _stale_ttl(path: str) -> float:
+    if path == "/equity/metadata/instruments":
+        return 3_600.0
+    return 60.0
+
+
+def _cache_key(path: str, params: dict[str, Any] | None) -> str:
+    if not params:
+        return path
+    suffix = "&".join(f"{key}={params[key]}" for key in sorted(params))
+    return f"{path}?{suffix}"
+
+
+def _capture_rate_headers(headers: httpx.Headers) -> None:
+    for key in ("x-ratelimit-limit", "x-ratelimit-period", "x-ratelimit-remaining", "x-ratelimit-reset"):
+        value = headers.get(key)
+        if value is not None:
+            _LAST_RATE_HEADERS[key] = value
+
+
+async def _request(path: str, *, params: dict[str, Any] | None = None) -> tuple[Any, str]:
+    key = _cache_key(path, params)
+    now = time.monotonic()
+    cached = _CACHE.get(key)
+    if cached and now - cached.stored_at <= _cache_ttl(path):
+        return cached.value, "CACHE:FRESH"
+
+    lock = _LOCKS.setdefault(key, asyncio.Lock())
+    async with lock:
+        now = time.monotonic()
+        cached = _CACHE.get(key)
+        if cached and now - cached.stored_at <= _cache_ttl(path):
+            return cached.value, "CACHE:FRESH"
+
+        headers = {
+            "Authorization": _auth_header(),
+            "Accept": "application/json",
+        }
+        timeout = httpx.Timeout(20.0, connect=10.0)
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.get(f"{_base_url()}{path}", headers=headers, params=params)
+        except httpx.RequestError as exc:
+            if cached and now - cached.stored_at <= _stale_ttl(path):
+                return cached.value, f"CACHE:STALE:{exc.__class__.__name__}"
+            raise HTTPException(status_code=502, detail=f"Trading 212 connection failed: {exc.__class__.__name__}") from exc
+
+        _capture_rate_headers(response.headers)
+        if response.status_code == 429:
+            if cached and now - cached.stored_at <= _stale_ttl(path):
+                return cached.value, "CACHE:STALE:429"
+            reset = response.headers.get("x-ratelimit-reset")
+            detail = "Trading 212 rate limit reached"
+            if reset:
+                detail += f"; reset={reset}"
+            raise HTTPException(status_code=429, detail=detail)
+        if response.status_code >= 400:
+            try:
+                upstream = response.json()
+            except ValueError:
+                upstream = response.text[:300]
+            raise HTTPException(status_code=response.status_code, detail={"provider": "Trading212", "upstream": upstream})
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise HTTPException(status_code=502, detail="Trading 212 returned non-JSON data") from exc
+
+        _CACHE[key] = _CacheEntry(time.monotonic(), payload)
+        return payload, "LIVE"
+
+
+def _position_row(raw: dict[str, Any]) -> dict[str, Any]:
+    instrument = raw.get("instrument") if isinstance(raw.get("instrument"), dict) else {}
+    broker_ticker = str(instrument.get("ticker") or raw.get("ticker") or "").strip()
+    return {
+        "brokerTicker": broker_ticker,
+        "analysisSymbol": _symbol_from_broker_ticker(broker_ticker),
+        "name": instrument.get("name") or instrument.get("shortName") or broker_ticker,
+        "isin": instrument.get("isin"),
+        "currency": instrument.get("currencyCode"),
+        "quantity": raw.get("quantity"),
+        "quantityAvailableForTrading": raw.get("quantityAvailableForTrading"),
+        "quantityInPies": raw.get("quantityInPies"),
+        "averagePricePaid": raw.get("averagePricePaid"),
+        "currentPrice": raw.get("currentPrice"),
+        "walletImpact": raw.get("walletImpact"),
+        "createdAt": raw.get("createdAt"),
+        "instrument": instrument,
+    }
+
+
+@router.get("/status")
+async def portfolio_status() -> dict[str, Any]:
+    return {
+        "provider": "Trading212",
+        "environment": _env(),
+        "configured": configured(),
+        "readOnly": True,
+        "rateLimit": dict(_LAST_RATE_HEADERS),
+        "guardrail": "This ATLAS portfolio connector exposes no order-placement method. Use a Trading 212 API key with read-only account/portfolio permissions.",
+    }
+
+
+@router.get("/live")
+async def live_portfolio() -> dict[str, Any]:
+    payload, source_status = await _request("/equity/positions")
+    rows = payload if isinstance(payload, list) else []
+    positions = [_position_row(item) for item in rows if isinstance(item, dict)]
+    return {
+        "provider": "Trading212",
+        "environment": _env(),
+        "readOnly": True,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "sourceStatus": source_status,
+        "count": len(positions),
+        "positions": positions,
+        "rateLimit": dict(_LAST_RATE_HEADERS),
+        "guardrail": "Portfolio state is read from Trading 212. ATLAS analysis is separate; broker data never fabricates an investment decision.",
+    }
+
+
+@router.get("/account")
+async def live_account() -> dict[str, Any]:
+    payload, source_status = await _request("/equity/account/summary")
+    return {
+        "provider": "Trading212",
+        "environment": _env(),
+        "readOnly": True,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "sourceStatus": source_status,
+        "account": payload,
+        "rateLimit": dict(_LAST_RATE_HEADERS),
+    }
+
+
+@router.get("/instruments")
+async def instrument_lookup(q: str = Query(..., min_length=1, max_length=80)) -> dict[str, Any]:
+    payload, source_status = await _request("/equity/metadata/instruments")
+    items = payload if isinstance(payload, list) else []
+    needle = q.strip().upper()
+    matches: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        haystack = " ".join(str(item.get(key, "")) for key in ("ticker", "name", "shortName", "isin", "currencyCode")).upper()
+        if needle in haystack:
+            matches.append(item)
+        if len(matches) >= 25:
+            break
+    return {
+        "provider": "Trading212",
+        "environment": _env(),
+        "readOnly": True,
+        "query": q.strip(),
+        "sourceStatus": source_status,
+        "count": len(matches),
+        "items": matches,
+        "rateLimit": dict(_LAST_RATE_HEADERS),
+    }

--- a/api/tests/test_provider_preparation.py
+++ b/api/tests/test_provider_preparation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+
+from api.providers.finnhub_resilient import FinnhubResilientClient, policy_for
+from api.providers.trading212_readonly import _symbol_from_broker_ticker, portfolio_status, router
+
+
+def test_finnhub_global_rate_guard_never_reaches_30_calls_per_second() -> None:
+    client = FinnhubResilientClient(max_calls_per_second=999)
+    assert client.max_calls_per_second == 29
+
+
+def test_finnhub_policy_separates_fast_and_slow_data() -> None:
+    assert policy_for('/quote').ttl_seconds < policy_for('/stock/metric').ttl_seconds
+    assert policy_for('/company-news').ttl_seconds < policy_for('/stock/profile2').ttl_seconds
+    assert policy_for('/stock/metric').stale_seconds > policy_for('/stock/metric').ttl_seconds
+
+
+def test_trading212_symbol_keeps_original_mapping_simple_and_explicit() -> None:
+    assert _symbol_from_broker_ticker('AAPL_US_EQ') == 'AAPL'
+    assert _symbol_from_broker_ticker('MSFT_US_EQ') == 'MSFT'
+    assert _symbol_from_broker_ticker('V') == 'V'
+
+
+def test_readonly_portfolio_router_has_no_write_methods() -> None:
+    methods: set[str] = set()
+    for route in router.routes:
+        methods.update(getattr(route, 'methods', set()) or set())
+    assert methods <= {'GET', 'HEAD'}
+
+
+def test_portfolio_status_declares_read_only(monkeypatch) -> None:
+    monkeypatch.setenv('TRADING212_ENV', 'live')
+    monkeypatch.delenv('TRADING212_API_KEY', raising=False)
+    monkeypatch.delenv('TRADING212_API_SECRET', raising=False)
+    payload = asyncio.run(portfolio_status())
+    assert payload['provider'] == 'Trading212'
+    assert payload['environment'] == 'live'
+    assert payload['configured'] is False
+    assert payload['readOnly'] is True

--- a/api/tests/test_provider_preparation.py
+++ b/api/tests/test_provider_preparation.py
@@ -18,10 +18,12 @@ def test_finnhub_policy_separates_fast_and_slow_data() -> None:
     assert policy_for('/stock/metric').stale_seconds > policy_for('/stock/metric').ttl_seconds
 
 
-def test_trading212_symbol_keeps_original_mapping_simple_and_explicit() -> None:
+def test_trading212_symbol_mapping_is_safe_and_explicit() -> None:
     assert _symbol_from_broker_ticker('AAPL_US_EQ') == 'AAPL'
     assert _symbol_from_broker_ticker('MSFT_US_EQ') == 'MSFT'
     assert _symbol_from_broker_ticker('V') == 'V'
+    assert _symbol_from_broker_ticker('SU_FR_EQ') == ''
+    assert _symbol_from_broker_ticker('BAE_UK_EQ') == ''
 
 
 def test_readonly_portfolio_router_has_no_write_methods() -> None:
@@ -80,3 +82,4 @@ def test_app_entrypoint_exposes_readonly_portfolio_routes() -> None:
     assert '/v1/portfolio/instruments' in paths
     assert '/v1/mobile/universe' in paths
     assert '/v1/mobile/monitor/{kind}' in paths
+    assert '/v1/mobile/analyze-symbols' in paths

--- a/api/tests/test_provider_preparation.py
+++ b/api/tests/test_provider_preparation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-from api.providers.finnhub_resilient import FinnhubResilientClient, policy_for
+from api.providers.finnhub_resilient import FinnhubResilientClient, finnhub_get, finnhub_optional, policy_for
 from api.providers.trading212_readonly import _symbol_from_broker_ticker, portfolio_status, router
 
 
@@ -39,3 +39,24 @@ def test_portfolio_status_declares_read_only(monkeypatch) -> None:
     assert payload['environment'] == 'live'
     assert payload['configured'] is False
     assert payload['readOnly'] is True
+
+
+def test_app_entrypoint_installs_resilient_finnhub_bridge() -> None:
+    import api.app  # noqa: F401
+    import api.atlas_core as atlas_core
+    import api.main as base_api
+
+    assert base_api._finnhub_get is finnhub_get
+    assert base_api._optional is finnhub_optional
+    assert atlas_core._finnhub is finnhub_get
+    assert atlas_core._optional is finnhub_optional
+
+
+def test_app_entrypoint_exposes_readonly_portfolio_routes() -> None:
+    from api.app import app
+
+    paths = {route.path for route in app.routes}
+    assert '/v1/portfolio/status' in paths
+    assert '/v1/portfolio/live' in paths
+    assert '/v1/portfolio/account' in paths
+    assert '/v1/portfolio/instruments' in paths

--- a/api/tests/test_provider_preparation.py
+++ b/api/tests/test_provider_preparation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
+from api.mobile_sync import resolved_portfolio, router as mobile_router
 from api.providers.finnhub_resilient import FinnhubResilientClient, finnhub_get, finnhub_optional, policy_for
 from api.providers.trading212_readonly import _symbol_from_broker_ticker, portfolio_status, router
 
@@ -30,6 +31,13 @@ def test_readonly_portfolio_router_has_no_write_methods() -> None:
     assert methods <= {'GET', 'HEAD'}
 
 
+def test_mobile_sync_router_has_no_write_methods() -> None:
+    methods: set[str] = set()
+    for route in mobile_router.routes:
+        methods.update(getattr(route, 'methods', set()) or set())
+    assert methods <= {'GET', 'HEAD'}
+
+
 def test_portfolio_status_declares_read_only(monkeypatch) -> None:
     monkeypatch.setenv('TRADING212_ENV', 'live')
     monkeypatch.delenv('TRADING212_API_KEY', raising=False)
@@ -39,6 +47,16 @@ def test_portfolio_status_declares_read_only(monkeypatch) -> None:
     assert payload['environment'] == 'live'
     assert payload['configured'] is False
     assert payload['readOnly'] is True
+
+
+def test_mobile_portfolio_keeps_bootstrap_until_t212_is_configured(monkeypatch) -> None:
+    monkeypatch.delenv('TRADING212_API_KEY', raising=False)
+    monkeypatch.delenv('TRADING212_API_SECRET', raising=False)
+    portfolio, meta = asyncio.run(resolved_portfolio())
+    assert portfolio
+    assert meta['provider'] == 'ATLAS_BOOTSTRAP'
+    assert meta['configured'] is False
+    assert meta['readOnly'] is True
 
 
 def test_app_entrypoint_installs_resilient_finnhub_bridge() -> None:
@@ -60,3 +78,5 @@ def test_app_entrypoint_exposes_readonly_portfolio_routes() -> None:
     assert '/v1/portfolio/live' in paths
     assert '/v1/portfolio/account' in paths
     assert '/v1/portfolio/instruments' in paths
+    assert '/v1/mobile/universe' in paths
+    assert '/v1/mobile/monitor/{kind}' in paths

--- a/docs/2026-08-11-premium-data-t212-plan.md
+++ b/docs/2026-08-11-premium-data-t212-plan.md
@@ -1,0 +1,171 @@
+# ATLAS Ω — Premium data + Trading 212 rollout
+
+Date: 2026-08-11
+Feature branch: `feat/premium-data-t212-live-20260811`
+
+## Non-negotiable baseline
+
+The Android build certified on 2026-08-10 remains the rollback point. Do not change the currently working production APK or merge this branch until every gate below is green.
+
+Known working production API base used by the certified APK: `https://atlas-genesis.onrender.com`.
+
+Known issue after the ONLINE repair: Finnhub can return HTTP 429 under portfolio-wide fan-out. The application is online; the remaining problem is provider capacity/request architecture, not APK connectivity.
+
+## Architecture target
+
+```text
+Trading 212 LIVE (read-only key)
+        |
+        v
+ATLAS backend / portfolio adapter ----> portfolio state, quantities, avg cost, broker price/P&L
+        |
+        +----> symbol/instrument resolver
+        |
+Finnhub paid plan / resilient adapter --> quotes/fundamentals/news/recommendations
+        |
+        v
+ATLAS engines / decisions
+        |
+        v
+Mobile APK (no provider secrets)
+```
+
+Provider credentials stay on the backend. The APK receives only ATLAS API responses.
+
+## Phase A — freeze and safety
+
+- [x] Create isolated feature branch from `main`.
+- [x] Keep the working APK/main untouched while preparation occurs.
+- [x] Add a server-side read-only Trading 212 connector with no order methods.
+- [x] Add a resilient Finnhub client scaffold with deduplication, endpoint TTLs, stale-last-good fallback and 429 cooldown.
+- [ ] Before merge, record final stable APK SHA-256 and production smoke result in this document.
+
+## Phase B — Finnhub paid data
+
+Before buying a plan, confirm that the chosen Finnhub plan covers all ATLAS endpoints actually required:
+
+- `/quote`
+- `/stock/profile2`
+- `/stock/metric`
+- `/stock/recommendation`
+- `/company-news`
+- any historical endpoint selected for charts
+- required international-market coverage
+
+Implementation rules:
+
+1. Centralize all Finnhub traffic through `api/providers/finnhub_resilient.py`.
+2. Never let 34 portfolio cards independently create duplicate upstream calls.
+3. One unique endpoint+symbol request may be in flight at a time; concurrent consumers share the result.
+4. Cache TTL depends on data volatility: quotes seconds, news minutes, recommendations hours, fundamentals/profile much longer.
+5. Stay below Finnhub's global 30 calls/second ceiling even if the paid minute quota is higher.
+6. HTTP 429 triggers cooldown/backoff. When a valid cached value exists, return it as stale rather than blanking the UI.
+7. Keep last-good data long enough to survive temporary provider outages; expose source freshness/status explicitly.
+8. No synthetic fundamental values.
+
+## Phase C — Trading 212 read-only LIVE portfolio
+
+Create a Trading 212 API key with **read-only account/portfolio permissions**. Do not grant order permissions for this phase.
+
+Backend variables (server only):
+
+- `TRADING212_ENV=live`
+- `TRADING212_API_KEY=<secret>`
+- `TRADING212_API_SECRET=<secret>`
+- `TRADING212_LIVE_TRADING_ENABLED=false`
+
+The new `/v1/portfolio/*` adapter is intentionally GET-only:
+
+- `/v1/portfolio/status`
+- `/v1/portfolio/live`
+- `/v1/portfolio/account`
+- `/v1/portfolio/instruments?q=...`
+
+Rate-limit policy follows Trading 212 response headers and caches endpoints conservatively. Positions are refreshed on a short interval; account summary less often; instrument metadata is long-lived.
+
+The existing broker/order guardrails remain separate. A read-only key means an accidental order call must fail at the provider even if legacy order routes exist elsewhere.
+
+## Phase D — portfolio becomes broker-authoritative
+
+`Mi Cartera Ω` will stop treating the hard-coded/bootstrap list as the live truth when Trading 212 is configured.
+
+Required normalized position fields:
+
+- broker ticker
+- ATLAS analysis symbol
+- instrument name / ISIN / currency
+- quantity
+- quantity available for trading
+- quantity in pies
+- average price paid
+- current broker price
+- wallet/P&L impact
+- opened-at timestamp
+
+The hard-coded portfolio remains only as an offline/bootstrap fallback until the migration is proven.
+
+## Phase E — symbol resolver
+
+Trading 212 symbols and Finnhub symbols are not assumed to be identical. Resolve them using broker instrument metadata, ISIN and exchange information where available.
+
+Rules:
+
+- preserve the original T212 ticker permanently;
+- store the derived ATLAS/Finnhub symbol separately;
+- never silently map an ambiguous international instrument;
+- unresolved instruments stay visible in the portfolio but show analysis as unavailable until mapped;
+- cache instrument metadata because the upstream list is slow-changing and tightly rate-limited.
+
+## Phase F — mobile resilience
+
+The mobile app must not erase valid information just because one provider is temporarily limited.
+
+Desired states:
+
+- `LIVE`: fresh provider response;
+- `CACHE:FRESH`: fresh server cache;
+- `CACHE:STALE:*`: last-good value retained during 429/outage;
+- `UNAVAILABLE:*`: no valid value has ever been obtained.
+
+When Finnhub is limited but Trading 212 remains available, the portfolio must still show broker quantity/current price/P&L. ATLAS analytical fields may show last-good timestamp rather than `No data returned`.
+
+## Phase G — certification before merge
+
+No merge to `main` and no replacement APK until all of these pass:
+
+- [ ] Python compile/tests.
+- [ ] Mobile TypeScript check.
+- [ ] Finnhub paid key configured only on backend.
+- [ ] Trading 212 read-only LIVE key configured only on backend.
+- [ ] No provider secret appears in repository or compiled APK.
+- [ ] `/v1/portfolio/live` count matches the real Trading 212 account.
+- [ ] Quantities, average prices and current values spot-check correctly against T212.
+- [ ] Portfolio refresh does not exceed documented T212 limits.
+- [ ] 34+ tickers can load without a request storm.
+- [ ] Simulated Finnhub 429 keeps last-good data and does not mark the whole app offline.
+- [ ] Android release APK contains only the ATLAS public backend URL.
+- [ ] Android emulator physically reaches ONLINE against production.
+- [ ] Home, Cartera, Watchlist, Radar, ticker detail and ATLAS decision routes work.
+- [ ] Live order execution remains disabled.
+- [ ] Rollback to the 2026-08-10 certified APK remains possible.
+
+## Deployment order
+
+1. Validate providers in feature-branch CI with mocked credentials/responses.
+2. Add real paid Finnhub and read-only T212 secrets to the backend environment manually; never commit them.
+3. Deploy backend candidate and verify `/health`, `/v1/portfolio/status`, `/v1/portfolio/live` and representative ATLAS analysis calls.
+4. Only then point/build the candidate APK against that backend.
+5. Run physical Android emulator gate.
+6. Compare with the currently working APK.
+7. Merge only after all gates are green.
+
+## Stop conditions
+
+Stop rollout and keep the current APK if any of the following occurs:
+
+- portfolio count/positions disagree materially with Trading 212;
+- credentials leak into logs, repository or APK;
+- a route can place a live order with the planned read-only key;
+- rate-limit handling causes data loss instead of stale fallback;
+- the new APK loses ONLINE status against the verified backend;
+- Render is still deploying a different branch/service contract than the code being certified.

--- a/docs/2026-08-11-provider-key-cutover.md
+++ b/docs/2026-08-11-provider-key-cutover.md
@@ -1,0 +1,48 @@
+# ATLAS Ω — Provider key cutover checklist
+
+Use only after the paid market-data plan and Trading 212 read-only key exist.
+
+## Server variables
+
+Configure on the backend environment only:
+
+- `FINNHUB_TOKEN=<paid token>`
+- `FINNHUB_MAX_CALLS_PER_SECOND=20`
+- `TRADING212_ENV=live`
+- `TRADING212_API_KEY=<read-only live key>`
+- `TRADING212_API_SECRET=<matching secret>`
+- `ATLAS_T212_SYMBOL_OVERRIDES={}` initially
+- `TRADING212_LIVE_TRADING_ENABLED=false`
+
+Do not configure `ATLAS_BROKER_CONTROL_TOKEN` for this read-only rollout.
+
+## First live checks before any mobile promotion
+
+1. `GET /health` -> backend online.
+2. `GET /v1/portfolio/status` -> `environment=live`, `configured=true`, `readOnly=true`.
+3. `GET /v1/portfolio/live` -> position count and values match Trading 212.
+4. Record every `analysisSymbolStatus=NEEDS_VERIFIED_MAPPING` instrument.
+5. Resolve those instruments using Trading 212 ticker + ISIN + exchange metadata; add only verified mappings to `ATLAS_T212_SYMBOL_OVERRIDES`.
+6. `GET /v1/mobile/universe` -> `portfolioMeta.provider=Trading212` and watchlist remains independent.
+7. Analyze portfolio in pages of at most eight via `/v1/mobile/monitor/portfolio`.
+8. Analyze the phone's editable watchlist in pages of at most eight via `/v1/mobile/analyze-symbols?context=watchlist`.
+9. Re-run pages to confirm Finnhub cache/dedupe prevents a request storm and valid data survives 429 as stale-last-good.
+10. Verify `/v1/market/history/{symbol}`, `/v1/market/rotation`, and `/v1/market/dislocation` before enabling their new mobile client paths.
+
+## Mobile promotion
+
+Only after the backend checks pass:
+
+- switch portfolio source to `AtlasPremiumSyncApi.universe()` / `monitor('portfolio')`;
+- keep local SQLite watchlist identity and analyze current local symbols with `AtlasPremiumSyncApi.analyzeSymbols()`;
+- switch historical chart and Radar to the premium sync methods;
+- preserve old v0.4 fallback during staged rollout;
+- build release APK;
+- inspect compiled APK for provider credentials (must be none);
+- run Android emulator ONLINE gate;
+- compare portfolio count and representative values with Trading 212;
+- merge PR #45 only after all gates pass.
+
+## Rollback
+
+If any mismatch, credential issue, wrong international mapping, provider blanking or OFFLINE regression appears, keep the certified existing APK/main and roll back the backend candidate. No portfolio mutation or order placement is part of this rollout.

--- a/docs/2026-08-11-repair-matrix.md
+++ b/docs/2026-08-11-repair-matrix.md
@@ -1,0 +1,64 @@
+# ATLAS Ω — Repair matrix from the working ONLINE APK
+
+Date: 2026-08-11
+Baseline: keep the currently working ONLINE APK/main unchanged until this matrix is green on the feature branch.
+
+## Observed on-device symptoms and planned repair
+
+| Symptom observed | Root cause / current constraint | Repair prepared | Acceptance criterion |
+|---|---|---|---|
+| `Finnhub rate limit reached` and `No data returned` across portfolio cards | Free-provider capacity plus fan-out across many tickers/endpoints | Central `FinnhubResilientClient`: per-key in-flight dedupe, endpoint TTL cache, <30 calls/s cap, 429 cooldown, stale-last-good | Load full portfolio + watchlist repeatedly without valid cached data disappearing on 429 |
+| A ticker can show quote but ATLAS score/metrics are empty | Quote succeeded while fundamental endpoints were unavailable/limited | Fundamental calls share the resilient adapter and preserve last-good values independently | Quote remains visible; previous valid analysis remains visible with stale/source status instead of fake zero/blank |
+| `Histórico no disponible` in ticker detail | Certified public v0.4 backend does not expose the newer multi-period history route | Prepared mobile premium sync client calls `/v1/market/history/{symbol}` after new backend deploy | 1M/3M/6M/1Y render actual delayed/reference history when backend candidate is active |
+| Money Rotation Ω shows no early proxies because multi-period data is unavailable | Public v0.4 compatibility layer intentionally returned empty rotation | Prepared client calls `/v1/market/rotation` on the new backend | Rotation sensor returns computed multi-period proxy rows without inventing canonical R3/R4 evidence |
+| Historical Dislocation Ω shows zero because deployed backend lacks history | Same old-backend contract limitation | Prepared client calls `/v1/market/dislocation` | Dislocation produces candidates when data meets the deterministic historical rule; zero is valid only when no candidates qualify |
+| Trading 212 shows `NO CONFIGURADO` | No LIVE read-only API credentials configured yet | GET-only T212 adapter plus `/v1/mobile/universe` | T212 LIVE positions become authoritative for held positions, with correct count/quantity/avg price/current price |
+| Portfolio identities are bootstrap/static | T212 was not connected | `/v1/mobile/universe` automatically uses T212 when configured and falls back only on broker outage/unconfigured state | `portfolioMeta.provider=Trading212` in normal production; fallback is explicit and visible |
+| Watchlist must remain independent of broker holdings | Watchlist is research state, not a broker position list | `/v1/mobile/universe` keeps ATLAS watchlist identity; `/v1/mobile/monitor/watchlist` analyzes it through the same paid/resilient provider layer | Adding/removing watchlist symbols does not mutate T212 holdings; every watchlist ticker can be analyzed through premium data |
+| Provider outage should not mark entire app OFFLINE | Connectivity and provider completeness were previously conflated | Separate ATLAS API health, T212 portfolio source status, and Finnhub per-endpoint source status | Backend reachable = ONLINE even if one upstream provider is limited; individual cards show stale/unavailable states |
+
+## Provider wiring target
+
+```text
+Trading 212 LIVE read-only
+  -> /v1/portfolio/*
+  -> /v1/mobile/universe (authoritative portfolio)
+
+ATLAS editable watchlist
+  -> /v1/mobile/universe (research identity)
+
+Portfolio + Watchlist symbols
+  -> /v1/mobile/monitor/{kind}
+  -> ATLAS analyze_symbol
+  -> Finnhub paid credentials
+  -> FinnhubResilientClient
+  -> cache/dedupe/cooldown/stale-last-good
+
+Historical/Radar
+  -> /v1/market/history
+  -> /v1/market/rotation
+  -> /v1/market/dislocation
+```
+
+## Credentials to configure later — server only
+
+- `FINNHUB_TOKEN`: paid-plan token selected after endpoint/market coverage check.
+- `FINNHUB_MAX_CALLS_PER_SECOND=20`: intentionally below the provider global ceiling.
+- `TRADING212_ENV=live`.
+- `TRADING212_API_KEY`: LIVE key generated with read-only account/portfolio access.
+- `TRADING212_API_SECRET`: matching secret.
+- `TRADING212_LIVE_TRADING_ENABLED=false`.
+
+Do not put any of those secrets in the APK, GitHub source files, screenshots or chat messages.
+
+## Promotion gates
+
+1. Provider-safety Python tests green.
+2. Mobile TypeScript green.
+3. New backend candidate serves `/v1/mobile/universe`, `/v1/mobile/monitor/*` and `/v1/market/history/*`.
+4. Real T212 position count and spot-check values match the account.
+5. T212 key has no order permission; new portfolio/mobile routers expose GET only.
+6. Full portfolio and watchlist analysis does not blank valid data under synthetic/real 429.
+7. Historical chart, Rotation and Dislocation no longer use the v0.4 empty compatibility placeholders.
+8. Candidate APK remains ONLINE in Android emulator and contains no provider credentials.
+9. Only after all checks: merge PR #45 and build replacement APK.

--- a/mobile/core/api/atlasPremiumSyncApi.ts
+++ b/mobile/core/api/atlasPremiumSyncApi.ts
@@ -3,6 +3,7 @@ import {
   DislocationPayload,
   MarketHistory,
   MarketOverview,
+  MonitorItem,
   MonitorPage,
   RotationPayload,
   TrackedUniverse,
@@ -17,12 +18,20 @@ export type MobileUniverse = TrackedUniverse & {
     sourceStatus?: string;
     generatedAt?: string;
     readOnly?: boolean;
+    unresolvedAnalysisSymbols?: number;
     rateLimit?: Record<string, string>;
   };
   watchlistMeta?: {
     provider?: string;
     analysisProvider?: string;
   };
+};
+
+export type AnalysisBatch = {
+  context: 'portfolio' | 'watchlist';
+  count: number;
+  items: MonitorItem[];
+  guardrail: string;
 };
 
 async function request<T>(path: string, timeoutMs = 30_000): Promise<T> {
@@ -75,6 +84,15 @@ export const AtlasPremiumSyncApi = {
       `/v1/mobile/monitor/${kind}?offset=${Math.max(0, offset)}&limit=${Math.max(1, Math.min(limit, 8))}`,
       () => AtlasOnlineApi.atlasMonitor(kind, offset, limit),
     ),
+
+  analyzeSymbols: (
+    symbols: string[],
+    context: 'portfolio' | 'watchlist' = 'watchlist',
+  ): Promise<AnalysisBatch> => {
+    const cleaned = Array.from(new Set(symbols.map((item) => item.trim().toUpperCase()).filter(Boolean))).slice(0, 8);
+    const query = encodeURIComponent(cleaned.join(','));
+    return request<AnalysisBatch>(`/v1/mobile/analyze-symbols?symbols=${query}&context=${context}`);
+  },
 
   history: (ticker: string, days = 380): Promise<MarketHistory> => newBackendOrFallback(
     `/v1/market/history/${encodeURIComponent(ticker.trim().toUpperCase())}?days=${Math.max(10, Math.min(days, 1900))}`,

--- a/mobile/core/api/atlasPremiumSyncApi.ts
+++ b/mobile/core/api/atlasPremiumSyncApi.ts
@@ -1,0 +1,98 @@
+import {
+  AtlasOnlineApi,
+  DislocationPayload,
+  MarketHistory,
+  MarketOverview,
+  MonitorPage,
+  RotationPayload,
+  TrackedUniverse,
+  atlasApiBaseUrl,
+} from './atlasOnlineApi';
+
+export type MobileUniverse = TrackedUniverse & {
+  portfolioMeta?: {
+    provider?: string;
+    configured?: boolean;
+    environment?: string;
+    sourceStatus?: string;
+    generatedAt?: string;
+    readOnly?: boolean;
+    rateLimit?: Record<string, string>;
+  };
+  watchlistMeta?: {
+    provider?: string;
+    analysisProvider?: string;
+  };
+};
+
+async function request<T>(path: string, timeoutMs = 30_000): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${atlasApiBaseUrl()}${path}`, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = typeof payload?.detail === 'string'
+        ? payload.detail
+        : `ATLAS premium API HTTP ${response.status}`;
+      const error = new Error(detail) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
+    }
+    return payload as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function newBackendOrFallback<T>(
+  path: string,
+  fallback: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await request<T>(path);
+  } catch (error) {
+    const status = (error as Error & { status?: number })?.status;
+    // During staged rollout the old public v0.4 backend may still be serving.
+    // 404/405 means the new router is not deployed yet; retain the certified
+    // compatibility behavior until backend promotion is complete.
+    if (status === 404 || status === 405) return fallback();
+    throw error;
+  }
+}
+
+export const AtlasPremiumSyncApi = {
+  universe: (): Promise<MobileUniverse> => newBackendOrFallback(
+    '/v1/mobile/universe',
+    async () => AtlasOnlineApi.atlasUniverse() as Promise<MobileUniverse>,
+  ),
+
+  monitor: (kind: 'portfolio' | 'watchlist', offset = 0, limit = 6): Promise<MonitorPage> =>
+    newBackendOrFallback(
+      `/v1/mobile/monitor/${kind}?offset=${Math.max(0, offset)}&limit=${Math.max(1, Math.min(limit, 8))}`,
+      () => AtlasOnlineApi.atlasMonitor(kind, offset, limit),
+    ),
+
+  history: (ticker: string, days = 380): Promise<MarketHistory> => newBackendOrFallback(
+    `/v1/market/history/${encodeURIComponent(ticker.trim().toUpperCase())}?days=${Math.max(10, Math.min(days, 1900))}`,
+    () => AtlasOnlineApi.marketHistory(ticker, days),
+  ),
+
+  overview: (): Promise<MarketOverview> => newBackendOrFallback(
+    '/v1/market/overview',
+    () => AtlasOnlineApi.marketOverview(),
+  ),
+
+  rotation: (): Promise<RotationPayload> => newBackendOrFallback(
+    '/v1/market/rotation',
+    () => AtlasOnlineApi.marketRotation(),
+  ),
+
+  dislocation: (limit = 15): Promise<DislocationPayload> => newBackendOrFallback(
+    `/v1/market/dislocation?limit=${Math.max(5, Math.min(limit, 30))}`,
+    () => AtlasOnlineApi.marketDislocation(limit),
+  ),
+};

--- a/mobile/core/api/trading212PortfolioApi.ts
+++ b/mobile/core/api/trading212PortfolioApi.ts
@@ -1,0 +1,90 @@
+import { atlasApiBaseUrl } from './atlasOnlineApi';
+
+export type Trading212PortfolioStatus = {
+  provider: 'Trading212';
+  environment: 'demo' | 'live';
+  configured: boolean;
+  readOnly: true;
+  rateLimit: Record<string, string>;
+  guardrail: string;
+};
+
+export type Trading212Position = {
+  brokerTicker: string;
+  analysisSymbol: string;
+  name: string;
+  isin?: string | null;
+  currency?: string | null;
+  quantity?: number | null;
+  quantityAvailableForTrading?: number | null;
+  quantityInPies?: number | null;
+  averagePricePaid?: number | null;
+  currentPrice?: number | null;
+  walletImpact?: Record<string, unknown> | null;
+  createdAt?: string | null;
+  instrument: Record<string, unknown>;
+};
+
+export type Trading212LivePortfolio = {
+  provider: 'Trading212';
+  environment: 'demo' | 'live';
+  readOnly: true;
+  generatedAt: string;
+  sourceStatus: string;
+  count: number;
+  positions: Trading212Position[];
+  rateLimit: Record<string, string>;
+  guardrail: string;
+};
+
+export type Trading212Account = {
+  provider: 'Trading212';
+  environment: 'demo' | 'live';
+  readOnly: true;
+  generatedAt: string;
+  sourceStatus: string;
+  account: Record<string, unknown>;
+  rateLimit: Record<string, string>;
+};
+
+async function request<T>(path: string, timeoutMs = 15_000): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${atlasApiBaseUrl()}${path}`, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = typeof payload?.detail === 'string'
+        ? payload.detail
+        : `ATLAS portfolio API HTTP ${response.status}`;
+      throw new Error(detail);
+    }
+    return payload as T;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Trading 212 no respondió a tiempo. Se conservará la última cartera válida.');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function getTrading212PortfolioStatus(): Promise<Trading212PortfolioStatus> {
+  return request<Trading212PortfolioStatus>('/v1/portfolio/status');
+}
+
+export function getTrading212LivePortfolio(): Promise<Trading212LivePortfolio> {
+  return request<Trading212LivePortfolio>('/v1/portfolio/live');
+}
+
+export function getTrading212Account(): Promise<Trading212Account> {
+  return request<Trading212Account>('/v1/portfolio/account');
+}
+
+export function searchTrading212Instruments(query: string): Promise<Record<string, unknown>> {
+  return request<Record<string, unknown>>(`/v1/portfolio/instruments?q=${encodeURIComponent(query.trim())}`);
+}

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,5 @@ services:
         sync: false
       - key: TRADING212_API_SECRET
         sync: false
-      - key: ATLAS_BROKER_CONTROL_TOKEN
-        sync: false
       - key: TRADING212_LIVE_TRADING_ENABLED
         value: "false"

--- a/render.yaml
+++ b/render.yaml
@@ -9,8 +9,10 @@ services:
     envVars:
       - key: FINNHUB_TOKEN
         sync: false
+      - key: FINNHUB_MAX_CALLS_PER_SECOND
+        value: "20"
       - key: TRADING212_ENV
-        value: demo
+        value: live
       - key: TRADING212_API_KEY
         sync: false
       - key: TRADING212_API_SECRET

--- a/render.yaml
+++ b/render.yaml
@@ -17,5 +17,7 @@ services:
         sync: false
       - key: TRADING212_API_SECRET
         sync: false
+      - key: ATLAS_T212_SYMBOL_OVERRIDES
+        value: "{}"
       - key: TRADING212_LIVE_TRADING_ENABLED
         value: "false"


### PR DESCRIPTION
Superseded by merged rescue PR #88. The still-valid Finnhub resilience work was preserved on current main without reintroducing this branch's obsolete read-only Trading 212/mobile-sync architecture. Closed without merging stale history.