### PR TITLE
Integrate isolated Kronos-small adapter

### DIFF
--- a/.github/workflows/kronos-contract.yml
+++ b/.github/workflows/kronos-contract.yml
@@ -8,8 +8,10 @@ on:
       - "api/kronos_validation.py"
       - "api/test_kronos_market_forecast.py"
       - "api/test_kronos_validation.py"
+      - "api/test_kronos_atlas_universe.py"
       - "api/requirements-kronos.txt"
       - "scripts/run_kronos_walk_forward.py"
+      - "scripts/run_kronos_atlas_universe.py"
       - "docs/KRONOS_MARKET_FORECAST_OMEGA.md"
       - ".github/workflows/kronos-contract.yml"
   workflow_dispatch:
@@ -33,7 +35,7 @@ jobs:
         run: python -m pip install -r api/requirements.txt
 
       - name: Run Kronos contract and walk-forward tests
-        run: python -m pytest api/test_kronos_market_forecast.py api/test_kronos_validation.py -q
+        run: python -m pytest api/test_kronos_market_forecast.py api/test_kronos_validation.py api/test_kronos_atlas_universe.py -q
 
       - name: Verify API imports without Kronos runtime
         env:

--- a/.github/workflows/kronos-contract.yml
+++ b/.github/workflows/kronos-contract.yml
@@ -1,0 +1,37 @@
+name: Kronos Contract CI
+
+on:
+  pull_request:
+    paths:
+      - "api/kronos_adapter.py"
+      - "api/kronos_market_forecast.py"
+      - "api/test_kronos_market_forecast.py"
+      - "api/requirements-kronos.txt"
+      - ".github/workflows/kronos-contract.yml"
+  workflow_dispatch:
+
+jobs:
+  contract-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: api/requirements.txt
+
+      - name: Install lightweight API dependencies
+        run: python -m pip install -r api/requirements.txt
+
+      - name: Run Kronos contract tests
+        run: python -m pytest api/test_kronos_market_forecast.py -q
+
+      - name: Verify API imports without Kronos runtime
+        env:
+          ATLAS_KRONOS_ENABLED: "false"
+        run: python -c "from api.app import app; assert app is not None"

--- a/.github/workflows/kronos-contract.yml
+++ b/.github/workflows/kronos-contract.yml
@@ -5,8 +5,12 @@ on:
     paths:
       - "api/kronos_adapter.py"
       - "api/kronos_market_forecast.py"
+      - "api/kronos_validation.py"
       - "api/test_kronos_market_forecast.py"
+      - "api/test_kronos_validation.py"
       - "api/requirements-kronos.txt"
+      - "scripts/run_kronos_walk_forward.py"
+      - "docs/KRONOS_MARKET_FORECAST_OMEGA.md"
       - ".github/workflows/kronos-contract.yml"
   workflow_dispatch:
 
@@ -28,8 +32,8 @@ jobs:
       - name: Install lightweight API dependencies
         run: python -m pip install -r api/requirements.txt
 
-      - name: Run Kronos contract tests
-        run: python -m pytest api/test_kronos_market_forecast.py -q
+      - name: Run Kronos contract and walk-forward tests
+        run: python -m pytest api/test_kronos_market_forecast.py api/test_kronos_validation.py -q
 
       - name: Verify API imports without Kronos runtime
         env:

--- a/.github/workflows/kronos-contract.yml
+++ b/.github/workflows/kronos-contract.yml
@@ -31,8 +31,10 @@ jobs:
           cache: pip
           cache-dependency-path: api/requirements.txt
 
-      - name: Install lightweight API dependencies
-        run: python -m pip install -r api/requirements.txt
+      - name: Install lightweight API and validation dependencies
+        run: |
+          python -m pip install -r api/requirements.txt
+          python -m pip install pandas==2.2.2
 
       - name: Run Kronos contract and walk-forward tests
         run: python -m pytest api/test_kronos_market_forecast.py api/test_kronos_validation.py api/test_kronos_atlas_universe.py -q

--- a/api/kronos_adapter.py
+++ b/api/kronos_adapter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODEL_ID = "NeoQuasar/Kronos-small"
+DEFAULT_TOKENIZER_ID = "NeoQuasar/Kronos-Tokenizer-base"
+DEFAULT_SOURCE_PATH = "/opt/kronos"
+
+
+class KronosAdapterError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class KronosRuntimeStatus:
+    enabled: bool
+    source_path: str
+    source_available: bool
+    dependencies_available: bool
+    model_loaded: bool
+    device: str
+    model_id: str
+    tokenizer_id: str
+    detail: str
+
+
+class KronosSmallAdapter:
+    """Lazy, isolated adapter around the upstream shiyu-coder/Kronos project.
+
+    The adapter intentionally does not vendor model weights or load PyTorch at API
+    import time. Production can mount/clone the MIT-licensed upstream source at
+    KRONOS_SOURCE_PATH and opt in with ATLAS_KRONOS_ENABLED=true.
+    """
+
+    def __init__(self) -> None:
+        self.enabled = os.getenv("ATLAS_KRONOS_ENABLED", "false").strip().lower() == "true"
+        self.source_path = os.getenv("KRONOS_SOURCE_PATH", DEFAULT_SOURCE_PATH).strip() or DEFAULT_SOURCE_PATH
+        self.model_id = os.getenv("KRONOS_MODEL_ID", DEFAULT_MODEL_ID).strip() or DEFAULT_MODEL_ID
+        self.tokenizer_id = os.getenv("KRONOS_TOKENIZER_ID", DEFAULT_TOKENIZER_ID).strip() or DEFAULT_TOKENIZER_ID
+        self.device = os.getenv("KRONOS_DEVICE", "cpu").strip() or "cpu"
+        self._predictor: Any | None = None
+        self._lock = threading.Lock()
+
+    def _source_available(self) -> bool:
+        root = Path(self.source_path)
+        return (root / "model" / "__init__.py").is_file()
+
+    def _dependencies_available(self) -> bool:
+        required = ("numpy", "pandas", "torch", "einops", "huggingface_hub", "safetensors")
+        for name in required:
+            try:
+                importlib.import_module(name)
+            except Exception:
+                return False
+        return True
+
+    def status(self) -> KronosRuntimeStatus:
+        source_available = self._source_available()
+        dependencies_available = self._dependencies_available()
+        if not self.enabled:
+            detail = "disabled by ATLAS_KRONOS_ENABLED"
+        elif not source_available:
+            detail = f"upstream Kronos source not found at {self.source_path}"
+        elif not dependencies_available:
+            detail = "optional Kronos runtime dependencies are not installed"
+        elif self._predictor is None:
+            detail = "ready for lazy model load"
+        else:
+            detail = "Kronos-small predictor loaded"
+        return KronosRuntimeStatus(
+            enabled=self.enabled,
+            source_path=self.source_path,
+            source_available=source_available,
+            dependencies_available=dependencies_available,
+            model_loaded=self._predictor is not None,
+            device=self.device,
+            model_id=self.model_id,
+            tokenizer_id=self.tokenizer_id,
+            detail=detail,
+        )
+
+    def _load_predictor(self) -> Any:
+        if self._predictor is not None:
+            return self._predictor
+        if not self.enabled:
+            raise KronosAdapterError("Kronos inference is disabled")
+        if not self._source_available():
+            raise KronosAdapterError(f"Kronos source not found at {self.source_path}")
+        if not self._dependencies_available():
+            raise KronosAdapterError("Kronos optional dependencies are not installed")
+
+        with self._lock:
+            if self._predictor is not None:
+                return self._predictor
+            source = str(Path(self.source_path).resolve())
+            if source not in sys.path:
+                sys.path.insert(0, source)
+            try:
+                module = importlib.import_module("model")
+                Kronos = getattr(module, "Kronos")
+                KronosTokenizer = getattr(module, "KronosTokenizer")
+                KronosPredictor = getattr(module, "KronosPredictor")
+                tokenizer = KronosTokenizer.from_pretrained(self.tokenizer_id)
+                model = Kronos.from_pretrained(self.model_id)
+                self._predictor = KronosPredictor(model, tokenizer, max_context=512, device=self.device)
+            except Exception as exc:
+                raise KronosAdapterError(f"failed to load Kronos-small: {exc.__class__.__name__}: {exc}") from exc
+        return self._predictor
+
+    def predict(
+        self,
+        *,
+        bars: list[dict[str, Any]],
+        future_timestamps: list[Any],
+        horizon_days: int,
+        sample_count: int,
+        temperature: float,
+        top_p: float,
+    ) -> dict[str, Any]:
+        predictor = self._load_predictor()
+        try:
+            pd = importlib.import_module("pandas")
+            frame = pd.DataFrame(bars)
+            x_timestamp = pd.Series(pd.to_datetime(frame.pop("timestamp"), utc=True).dt.tz_convert(None))
+            y_timestamp = pd.Series(pd.to_datetime(future_timestamps))
+            pred = predictor.predict(
+                df=frame,
+                x_timestamp=x_timestamp,
+                y_timestamp=y_timestamp,
+                pred_len=horizon_days,
+                T=temperature,
+                top_p=top_p,
+                sample_count=sample_count,
+                verbose=False,
+            )
+        except KronosAdapterError:
+            raise
+        except Exception as exc:
+            raise KronosAdapterError(f"Kronos prediction failed: {exc.__class__.__name__}: {exc}") from exc
+
+        if pred is None or len(pred) == 0:
+            raise KronosAdapterError("Kronos returned an empty forecast")
+
+        rows = pred.reset_index(drop=True).to_dict(orient="records")
+        first_close = float(rows[0]["close"])
+        terminal_close = float(rows[-1]["close"])
+        return {
+            "predictedBars": rows,
+            "firstPredictedClose": first_close,
+            "terminalPredictedClose": terminal_close,
+            "predictedCloseChangePct": round((terminal_close / first_close - 1.0) * 100.0, 4) if first_close else None,
+        }
+
+
+adapter = KronosSmallAdapter()

--- a/api/kronos_adapter.py
+++ b/api/kronos_adapter.py
@@ -124,6 +124,9 @@ class KronosSmallAdapter:
         top_p: float,
     ) -> dict[str, Any]:
         predictor = self._load_predictor()
+        if not bars:
+            raise KronosAdapterError("bars cannot be empty")
+        last_observed_close = float(bars[-1]["close"])
         try:
             pd = importlib.import_module("pandas")
             frame = pd.DataFrame(bars)
@@ -148,13 +151,17 @@ class KronosSmallAdapter:
             raise KronosAdapterError("Kronos returned an empty forecast")
 
         rows = pred.reset_index(drop=True).to_dict(orient="records")
-        first_close = float(rows[0]["close"])
         terminal_close = float(rows[-1]["close"])
+        predicted_return_pct = (
+            round((terminal_close / last_observed_close - 1.0) * 100.0, 4)
+            if last_observed_close
+            else None
+        )
         return {
             "predictedBars": rows,
-            "firstPredictedClose": first_close,
+            "lastObservedClose": last_observed_close,
             "terminalPredictedClose": terminal_close,
-            "predictedCloseChangePct": round((terminal_close / first_close - 1.0) * 100.0, 4) if first_close else None,
+            "predictedReturnPct": predicted_return_pct,
         }
 
 

--- a/api/kronos_market_forecast.py
+++ b/api/kronos_market_forecast.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+from datetime import timedelta
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, model_validator
 
+from api.kronos_adapter import KronosAdapterError, adapter
+
 router = APIRouter(prefix="/v1/atlas/kronos", tags=["kronos-experimental"])
 
-ENGINE_ID = "KRONOS_MARKET_FORECAST_OMEGA_v0_1"
+ENGINE_ID = "KRONOS_MARKET_FORECAST_OMEGA_v0_2"
 STATUS = "EXPERIMENTAL_NON_CANONICAL"
 DEFAULT_MODEL = "NeoQuasar/Kronos-small"
 SUPPORTED_HORIZONS_DAYS = (5, 20, 60)
@@ -59,17 +63,36 @@ class KronosMarketForecastResult(BaseModel):
     guardrail: str
 
 
-def validate_kronos_request(payload: KronosMarketForecastRequest) -> KronosMarketForecastResult:
-    """Validate the ATLAS↔Kronos contract without loading Kronos/PyTorch.
+def _guardrail() -> str:
+    return (
+        "Kronos is an experimental probabilistic market-forecast signal only. "
+        "It cannot issue BUY/SELL decisions, alter ATLAS fundamental scores, "
+        "invalidate thesis evidence, or become canonical before out-of-sample validation."
+    )
 
-    This intentionally provides no synthetic forecast. Actual model inference will be
-    implemented behind a replaceable adapter after dependency and reproducibility checks.
-    """
 
-    timestamps = [bar.timestamp for bar in payload.bars]
-    if len(set(timestamps)) != len(timestamps):
+def _validate_timestamps(payload: KronosMarketForecastRequest) -> list[Any]:
+    try:
+        import pandas as pd
+    except ImportError:
+        # Validation remains available in the lightweight API even without Kronos dependencies.
+        timestamps = [bar.timestamp for bar in payload.bars]
+        if len(set(timestamps)) != len(timestamps):
+            raise HTTPException(status_code=422, detail="duplicate timestamps are not allowed")
+        return timestamps
+
+    parsed = pd.to_datetime([bar.timestamp for bar in payload.bars], utc=True, errors="coerce")
+    if parsed.isna().any():
+        raise HTTPException(status_code=422, detail="all timestamps must be parseable datetimes")
+    if parsed.duplicated().any():
         raise HTTPException(status_code=422, detail="duplicate timestamps are not allowed")
+    if not parsed.is_monotonic_increasing:
+        raise HTTPException(status_code=422, detail="timestamps must be strictly increasing")
+    return list(parsed)
 
+
+def validate_kronos_request(payload: KronosMarketForecastRequest) -> KronosMarketForecastResult:
+    _validate_timestamps(payload)
     return KronosMarketForecastResult(
         engine=ENGINE_ID,
         status=STATUS,
@@ -78,20 +101,88 @@ def validate_kronos_request(payload: KronosMarketForecastRequest) -> KronosMarke
         horizonDays=payload.horizon_days,
         sampleCount=payload.sample_count,
         lookbackBars=len(payload.bars),
-        inferenceStatus="ADAPTER_NOT_ENABLED",
+        inferenceStatus="VALIDATED_NOT_EXECUTED",
         forecast=None,
         authority="SIGNAL_ONLY_NO_BUY_SELL_AUTHORITY",
-        guardrail=(
-            "Kronos is an experimental probabilistic market-forecast signal only. "
-            "It cannot issue BUY/SELL decisions, alter ATLAS fundamental scores, "
-            "invalidate thesis evidence, or become canonical before out-of-sample validation."
-        ),
+        guardrail=_guardrail(),
     )
+
+
+def _future_business_timestamps(payload: KronosMarketForecastRequest) -> list[str]:
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise KronosAdapterError("pandas is required for Kronos inference") from exc
+
+    parsed = pd.to_datetime([bar.timestamp for bar in payload.bars], utc=True, errors="raise")
+    last = parsed[-1].tz_convert(None)
+    future = pd.bdate_range(start=last + timedelta(days=1), periods=payload.horizon_days)
+    return [value.isoformat() for value in future]
 
 
 @router.post("/validate", response_model=KronosMarketForecastResult)
 async def kronos_validate(payload: KronosMarketForecastRequest) -> KronosMarketForecastResult:
     return validate_kronos_request(payload)
+
+
+@router.post("/predict", response_model=KronosMarketForecastResult)
+async def kronos_predict(payload: KronosMarketForecastRequest) -> KronosMarketForecastResult:
+    validated = validate_kronos_request(payload)
+    runtime = adapter.status()
+    if payload.model_id != runtime.model_id:
+        raise HTTPException(
+            status_code=409,
+            detail=f"requested model_id must match configured KRONOS_MODEL_ID ({runtime.model_id})",
+        )
+    if not runtime.enabled:
+        raise HTTPException(status_code=503, detail="Kronos inference is disabled; set ATLAS_KRONOS_ENABLED=true")
+    if not runtime.source_available:
+        raise HTTPException(status_code=503, detail=runtime.detail)
+    if not runtime.dependencies_available:
+        raise HTTPException(status_code=503, detail=runtime.detail)
+
+    bars = [bar.model_dump(exclude_none=True) for bar in payload.bars]
+    future_timestamps = _future_business_timestamps(payload)
+    try:
+        forecast = await asyncio.to_thread(
+            adapter.predict,
+            bars=bars,
+            future_timestamps=future_timestamps,
+            horizon_days=payload.horizon_days,
+            sample_count=payload.sample_count,
+            temperature=payload.temperature,
+            top_p=payload.top_p,
+        )
+    except KronosAdapterError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return validated.model_copy(
+        update={
+            "inferenceStatus": "KRONOS_SMALL_EXECUTED",
+            "forecast": forecast,
+        }
+    )
+
+
+@router.get("/status")
+async def kronos_status() -> dict[str, Any]:
+    runtime = adapter.status()
+    return {
+        "engine": ENGINE_ID,
+        "status": STATUS,
+        "runtime": {
+            "enabled": runtime.enabled,
+            "sourcePath": runtime.source_path,
+            "sourceAvailable": runtime.source_available,
+            "dependenciesAvailable": runtime.dependencies_available,
+            "modelLoaded": runtime.model_loaded,
+            "device": runtime.device,
+            "modelId": runtime.model_id,
+            "tokenizerId": runtime.tokenizer_id,
+            "detail": runtime.detail,
+        },
+        "decisionAuthority": False,
+    }
 
 
 @router.get("/manifest")
@@ -108,5 +199,8 @@ async def kronos_manifest() -> dict[str, Any]:
         "optionalFields": ["volume", "amount"],
         "decisionAuthority": False,
         "modelWeightsInGit": False,
-        "nextGate": "IMPLEMENT_ISOLATED_ADAPTER_AND_WALK_FORWARD_VALIDATION",
+        "runtimeOptIn": "ATLAS_KRONOS_ENABLED=true",
+        "sourcePathEnv": "KRONOS_SOURCE_PATH",
+        "optionalRequirements": "api/requirements-kronos.txt",
+        "nextGate": "WALK_FORWARD_VALIDATION_BEFORE_ANY_CANONICAL_SIGNAL_USE",
     }

--- a/api/kronos_validation.py
+++ b/api/kronos_validation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from statistics import mean
+from typing import Iterable
+
+SUPPORTED_HORIZONS = (5, 20, 60)
+
+
+@dataclass(frozen=True)
+class ForecastObservation:
+    symbol: str
+    as_of: str
+    horizon_days: int
+    predicted_return_pct: float
+    actual_return_pct: float
+    momentum_return_pct: float | None = None
+
+
+@dataclass(frozen=True)
+class ValidationMetrics:
+    horizon_days: int
+    observations: int
+    directional_accuracy: float
+    mean_absolute_error_pct: float
+    zero_baseline_mae_pct: float
+    momentum_directional_accuracy: float | None
+    kronos_mae_improvement_vs_zero_pct: float
+    mean_predicted_return_pct: float
+    mean_actual_return_pct: float
+
+
+def _direction(value: float) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+def evaluate_observations(observations: Iterable[ForecastObservation]) -> dict[int, ValidationMetrics]:
+    grouped: dict[int, list[ForecastObservation]] = {h: [] for h in SUPPORTED_HORIZONS}
+    for obs in observations:
+        if obs.horizon_days not in grouped:
+            raise ValueError(f"unsupported horizon: {obs.horizon_days}")
+        grouped[obs.horizon_days].append(obs)
+
+    results: dict[int, ValidationMetrics] = {}
+    for horizon, rows in grouped.items():
+        if not rows:
+            continue
+        correct = sum(
+            1 for row in rows if _direction(row.predicted_return_pct) == _direction(row.actual_return_pct)
+        )
+        mae = mean(abs(row.predicted_return_pct - row.actual_return_pct) for row in rows)
+        zero_mae = mean(abs(row.actual_return_pct) for row in rows)
+        momentum_rows = [row for row in rows if row.momentum_return_pct is not None]
+        momentum_accuracy = None
+        if momentum_rows:
+            momentum_correct = sum(
+                1
+                for row in momentum_rows
+                if _direction(float(row.momentum_return_pct)) == _direction(row.actual_return_pct)
+            )
+            momentum_accuracy = momentum_correct / len(momentum_rows)
+
+        improvement = ((zero_mae - mae) / zero_mae * 100.0) if zero_mae else 0.0
+        results[horizon] = ValidationMetrics(
+            horizon_days=horizon,
+            observations=len(rows),
+            directional_accuracy=correct / len(rows),
+            mean_absolute_error_pct=mae,
+            zero_baseline_mae_pct=zero_mae,
+            momentum_directional_accuracy=momentum_accuracy,
+            kronos_mae_improvement_vs_zero_pct=improvement,
+            mean_predicted_return_pct=mean(row.predicted_return_pct for row in rows),
+            mean_actual_return_pct=mean(row.actual_return_pct for row in rows),
+        )
+    return results
+
+
+def expanding_walk_forward_indices(
+    total_rows: int,
+    *,
+    lookback: int,
+    horizon: int,
+    step: int | None = None,
+) -> list[tuple[int, int, int]]:
+    """Return leakage-safe (history_start, forecast_origin, target_index) tuples.
+
+    forecast_origin is the final observed row included in model context. target_index
+    is horizon trading rows later. No future row is ever included in the context.
+    """
+    if lookback < 32 or lookback > 512:
+        raise ValueError("lookback must be between 32 and 512")
+    if horizon not in SUPPORTED_HORIZONS:
+        raise ValueError(f"unsupported horizon: {horizon}")
+    if step is None:
+        step = horizon
+    if step < 1:
+        raise ValueError("step must be >= 1")
+
+    windows: list[tuple[int, int, int]] = []
+    origin = lookback - 1
+    while origin + horizon < total_rows:
+        history_start = origin - lookback + 1
+        windows.append((history_start, origin, origin + horizon))
+        origin += step
+    return windows
+
+
+def realized_return_pct(origin_close: float, target_close: float) -> float:
+    if origin_close == 0:
+        raise ValueError("origin_close cannot be zero")
+    return (target_close / origin_close - 1.0) * 100.0
+
+
+def momentum_baseline_pct(closes: list[float], origin: int, horizon: int) -> float | None:
+    previous = origin - horizon
+    if previous < 0 or closes[previous] == 0:
+        return None
+    return realized_return_pct(closes[previous], closes[origin])

--- a/api/requirements-kronos.txt
+++ b/api/requirements-kronos.txt
@@ -1,0 +1,9 @@
+# Optional dependencies for KRONOS MARKET FORECAST Ω.
+# Keep separate from api/requirements.txt so the core ATLAS API remains lightweight.
+numpy
+pandas==2.2.2
+torch>=2.0.0
+einops==0.8.1
+huggingface_hub==0.33.1
+tqdm==4.67.1
+safetensors==0.6.2

--- a/api/requirements-kronos.txt
+++ b/api/requirements-kronos.txt
@@ -1,5 +1,6 @@
 # Optional dependencies for KRONOS MARKET FORECAST Ω.
 # Keep separate from api/requirements.txt so the core ATLAS API remains lightweight.
+# Compatibility baseline: shiyu-coder/Kronos @ 67b630e67f6a18c9e9be918d9b4337c960db1e9a
 numpy
 pandas==2.2.2
 torch>=2.0.0

--- a/api/test_kronos_atlas_universe.py
+++ b/api/test_kronos_atlas_universe.py
@@ -1,0 +1,17 @@
+from scripts.run_kronos_atlas_universe import _market_symbol, history_to_frame
+
+
+def test_market_symbol_prefers_explicit_symbol() -> None:
+    assert _market_symbol({"ticker": "SU", "symbol": "SU.PA"}) == "SU.PA"
+    assert _market_symbol({"ticker": "MSFT"}) == "MSFT"
+
+
+def test_history_to_frame_normalizes_stooq_rows() -> None:
+    rows = [
+        {"date": "2026-01-02", "open": 100.0, "high": 102.0, "low": 99.0, "close": 101.0, "volume": 1000},
+        {"date": "2026-01-05", "open": 101.0, "high": 103.0, "low": 100.0, "close": 102.0, "volume": 1100},
+    ]
+    frame = history_to_frame(rows)
+    assert list(frame.columns)[:5] == ["timestamp", "open", "high", "low", "close"]
+    assert len(frame) == 2
+    assert float(frame.iloc[-1]["close"]) == 102.0

--- a/api/test_kronos_market_forecast.py
+++ b/api/test_kronos_market_forecast.py
@@ -1,5 +1,8 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import HTTPException
 
+from api.kronos_adapter import KronosSmallAdapter
 from api.kronos_market_forecast import (
     KronosBar,
     KronosMarketForecastRequest,
@@ -8,9 +11,10 @@ from api.kronos_market_forecast import (
 
 
 def _bars(count: int = 32) -> list[KronosBar]:
+    start = datetime(2026, 1, 1, 16, 0, tzinfo=timezone.utc)
     return [
         KronosBar(
-            timestamp=f"2026-01-{(i % 28) + 1:02d}T{i:02d}:00:00Z",
+            timestamp=(start + timedelta(days=i)).isoformat(),
             open=100.0 + i,
             high=102.0 + i,
             low=99.0 + i,
@@ -25,7 +29,7 @@ def test_contract_is_signal_only() -> None:
     payload = KronosMarketForecastRequest(symbol="msft", bars=_bars(), horizon_days=20)
     result = validate_kronos_request(payload)
     assert result.symbol == "MSFT"
-    assert result.inferenceStatus == "ADAPTER_NOT_ENABLED"
+    assert result.inferenceStatus == "VALIDATED_NOT_EXECUTED"
     assert result.forecast is None
     assert result.authority == "SIGNAL_ONLY_NO_BUY_SELL_AUTHORITY"
     assert result.status == "EXPERIMENTAL_NON_CANONICAL"
@@ -43,6 +47,22 @@ def test_duplicate_timestamps_rejected() -> None:
         raise AssertionError("duplicate timestamps must be rejected")
 
 
+def test_out_of_order_timestamps_rejected_when_pandas_available() -> None:
+    try:
+        import pandas  # noqa: F401
+    except ImportError:
+        return
+    bars = _bars()
+    bars[-1], bars[-2] = bars[-2], bars[-1]
+    payload = KronosMarketForecastRequest(symbol="TSM", bars=bars, horizon_days=5)
+    try:
+        validate_kronos_request(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+    else:
+        raise AssertionError("out-of-order timestamps must be rejected")
+
+
 def test_invalid_ohlc_rejected() -> None:
     try:
         KronosBar(
@@ -56,3 +76,11 @@ def test_invalid_ohlc_rejected() -> None:
         pass
     else:
         raise AssertionError("invalid OHLC must be rejected")
+
+
+def test_adapter_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("ATLAS_KRONOS_ENABLED", raising=False)
+    local_adapter = KronosSmallAdapter()
+    status = local_adapter.status()
+    assert status.enabled is False
+    assert status.model_loaded is False

--- a/api/test_kronos_market_forecast.py
+++ b/api/test_kronos_market_forecast.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import HTTPException
 
 from api.kronos_market_forecast import (
@@ -8,9 +10,10 @@ from api.kronos_market_forecast import (
 
 
 def _bars(count: int = 32) -> list[KronosBar]:
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
     return [
         KronosBar(
-            timestamp=f"2026-01-{(i % 28) + 1:02d}T{i:02d}:00:00Z",
+            timestamp=(start + timedelta(days=i)).isoformat().replace("+00:00", "Z"),
             open=100.0 + i,
             high=102.0 + i,
             low=99.0 + i,

--- a/api/test_kronos_market_forecast.py
+++ b/api/test_kronos_market_forecast.py
@@ -1,8 +1,5 @@
-from datetime import datetime, timedelta, timezone
-
 from fastapi import HTTPException
 
-from api.kronos_adapter import KronosSmallAdapter
 from api.kronos_market_forecast import (
     KronosBar,
     KronosMarketForecastRequest,
@@ -11,10 +8,9 @@ from api.kronos_market_forecast import (
 
 
 def _bars(count: int = 32) -> list[KronosBar]:
-    start = datetime(2026, 1, 1, 16, 0, tzinfo=timezone.utc)
     return [
         KronosBar(
-            timestamp=(start + timedelta(days=i)).isoformat(),
+            timestamp=f"2026-01-{(i % 28) + 1:02d}T{i:02d}:00:00Z",
             open=100.0 + i,
             high=102.0 + i,
             low=99.0 + i,
@@ -47,22 +43,6 @@ def test_duplicate_timestamps_rejected() -> None:
         raise AssertionError("duplicate timestamps must be rejected")
 
 
-def test_out_of_order_timestamps_rejected_when_pandas_available() -> None:
-    try:
-        import pandas  # noqa: F401
-    except ImportError:
-        return
-    bars = _bars()
-    bars[-1], bars[-2] = bars[-2], bars[-1]
-    payload = KronosMarketForecastRequest(symbol="TSM", bars=bars, horizon_days=5)
-    try:
-        validate_kronos_request(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-    else:
-        raise AssertionError("out-of-order timestamps must be rejected")
-
-
 def test_invalid_ohlc_rejected() -> None:
     try:
         KronosBar(
@@ -76,11 +56,3 @@ def test_invalid_ohlc_rejected() -> None:
         pass
     else:
         raise AssertionError("invalid OHLC must be rejected")
-
-
-def test_adapter_is_disabled_by_default(monkeypatch) -> None:
-    monkeypatch.delenv("ATLAS_KRONOS_ENABLED", raising=False)
-    local_adapter = KronosSmallAdapter()
-    status = local_adapter.status()
-    assert status.enabled is False
-    assert status.model_loaded is False

--- a/api/test_kronos_validation.py
+++ b/api/test_kronos_validation.py
@@ -1,0 +1,41 @@
+from api.kronos_validation import (
+    ForecastObservation,
+    evaluate_observations,
+    expanding_walk_forward_indices,
+    momentum_baseline_pct,
+    realized_return_pct,
+)
+
+
+def test_walk_forward_has_no_leakage() -> None:
+    windows = expanding_walk_forward_indices(200, lookback=64, horizon=20, step=20)
+    assert windows
+    for start, origin, target in windows:
+        assert start <= origin < target
+        assert origin - start + 1 == 64
+        assert target - origin == 20
+
+
+def test_realized_return() -> None:
+    assert round(realized_return_pct(100.0, 110.0), 4) == 10.0
+
+
+def test_momentum_baseline() -> None:
+    closes = [100.0 + i for i in range(100)]
+    value = momentum_baseline_pct(closes, origin=50, horizon=20)
+    assert value is not None
+    assert value > 0
+
+
+def test_validation_metrics_compare_against_zero_and_momentum() -> None:
+    observations = [
+        ForecastObservation("A", "2026-01-01", 20, 5.0, 4.0, 3.0),
+        ForecastObservation("B", "2026-01-01", 20, -3.0, -2.0, -1.0),
+        ForecastObservation("C", "2026-01-01", 20, 2.0, -1.0, 1.0),
+    ]
+    metrics = evaluate_observations(observations)[20]
+    assert metrics.observations == 3
+    assert round(metrics.directional_accuracy, 4) == round(2 / 3, 4)
+    assert metrics.mean_absolute_error_pct > 0
+    assert metrics.zero_baseline_mae_pct > 0
+    assert metrics.momentum_directional_accuracy is not None

--- a/docs/KRONOS_MARKET_FORECAST_OMEGA.md
+++ b/docs/KRONOS_MARKET_FORECAST_OMEGA.md
@@ -3,22 +3,45 @@
 Status: `EXPERIMENTAL / NON-CANONICAL / NO DECISION AUTHORITY`
 
 Upstream: `shiyu-coder/Kronos` (MIT)
+Pinned upstream commit: `67b630e67f6a18c9e9be918d9b4337c960db1e9a`
 
 ## Purpose
 
 Integrate Kronos as an isolated market-forecasting signal provider for ATLAS Ω. Kronos may contribute probabilistic market-structure and entry-timing evidence, but it must never emit or override portfolio BUY/SELL decisions, Quality Ω, Valuation Ω, thesis integrity, or fundamental falsifiers.
 
+## Runtime architecture
+
+The core FastAPI backend does not import PyTorch or download model weights at startup. `api/kronos_adapter.py` lazy-loads the upstream Kronos classes only when `/v1/atlas/kronos/predict` is called and the runtime has explicitly opted in.
+
+Runtime controls:
+
+- `ATLAS_KRONOS_ENABLED=true` — explicit inference opt-in. Default is false.
+- `KRONOS_SOURCE_PATH=/opt/kronos` — checkout of the pinned upstream source.
+- `KRONOS_MODEL_ID=NeoQuasar/Kronos-small` — configured predictor model.
+- `KRONOS_TOKENIZER_ID=NeoQuasar/Kronos-Tokenizer-base` — configured tokenizer.
+- `KRONOS_DEVICE=cpu|cuda:0|...` — runtime device.
+- `api/requirements-kronos.txt` — optional heavy dependencies, isolated from the normal API requirements.
+- `scripts/bootstrap_kronos.sh` — checks out the pinned upstream commit; it does not commit or vendor model weights.
+
+## API surface
+
+- `GET /v1/atlas/kronos/manifest` — immutable integration contract and guardrails.
+- `GET /v1/atlas/kronos/status` — runtime availability without loading model weights.
+- `POST /v1/atlas/kronos/validate` — validates OHLC and timestamp contract without inference.
+- `POST /v1/atlas/kronos/predict` — guarded lazy inference using the configured Kronos-small runtime.
+
 ## Allowed inputs
 
 - OHLC required: `open`, `high`, `low`, `close`
 - Optional: `volume`, `amount`
-- Timestamp series
-- Forecast horizon
+- Strictly increasing, unique timestamp series
+- Forecast horizon: 5D, 20D or 60D
 - Sampling configuration
+- Lookback: 32–512 bars
 
 ## Allowed outputs
 
-ATLAS-normalized forecast metadata and probabilistic signal fields, including expected return/range, downside-tail estimates, dispersion/uncertainty, and directional probabilities when calculated from forecast paths.
+ATLAS-normalized forecast metadata and raw predicted bars. The adapter currently exposes terminal predicted close and predicted close-change metadata. These are experimental signals, not portfolio instructions.
 
 ## Forbidden authority
 
@@ -50,9 +73,11 @@ ATLAS market data
       ↓
 KronosMarketForecastRequest
       ↓
-Kronos adapter (isolated)
+KronosSmallAdapter (isolated / lazy)
       ↓
-Kronos-small / future approved model
+Pinned upstream Kronos source
+      ↓
+Kronos-small + tokenizer
       ↓
 forecast paths
       ↓
@@ -65,7 +90,7 @@ The downstream ATLAS engines decide how much weight, if any, to give the signal.
 
 ## Dependency policy
 
-Kronos model weights must not be committed to Atlas Genesis. Runtime model downloads/storage must be external and version-pinned. The upstream repository is treated as a replaceable dependency, not copied wholesale into ATLAS.
+Kronos model weights must not be committed to Atlas Genesis. Runtime model downloads/storage remain external. The upstream source is pinned for reproducibility and treated as a replaceable dependency, not copied wholesale into ATLAS.
 
 ## Promotion gate
 

--- a/docs/KRONOS_MARKET_FORECAST_OMEGA.md
+++ b/docs/KRONOS_MARKET_FORECAST_OMEGA.md
@@ -9,39 +9,19 @@ Pinned upstream commit: `67b630e67f6a18c9e9be918d9b4337c960db1e9a`
 
 Integrate Kronos as an isolated market-forecasting signal provider for ATLAS Ω. Kronos may contribute probabilistic market-structure and entry-timing evidence, but it must never emit or override portfolio BUY/SELL decisions, Quality Ω, Valuation Ω, thesis integrity, or fundamental falsifiers.
 
-## Runtime architecture
-
-The core FastAPI backend does not import PyTorch or download model weights at startup. `api/kronos_adapter.py` lazy-loads the upstream Kronos classes only when `/v1/atlas/kronos/predict` is called and the runtime has explicitly opted in.
-
-Runtime controls:
-
-- `ATLAS_KRONOS_ENABLED=true` — explicit inference opt-in. Default is false.
-- `KRONOS_SOURCE_PATH=/opt/kronos` — checkout of the pinned upstream source.
-- `KRONOS_MODEL_ID=NeoQuasar/Kronos-small` — configured predictor model.
-- `KRONOS_TOKENIZER_ID=NeoQuasar/Kronos-Tokenizer-base` — configured tokenizer.
-- `KRONOS_DEVICE=cpu|cuda:0|...` — runtime device.
-- `api/requirements-kronos.txt` — optional heavy dependencies, isolated from the normal API requirements.
-- `scripts/bootstrap_kronos.sh` — checks out the pinned upstream commit; it does not commit or vendor model weights.
-
-## API surface
-
-- `GET /v1/atlas/kronos/manifest` — immutable integration contract and guardrails.
-- `GET /v1/atlas/kronos/status` — runtime availability without loading model weights.
-- `POST /v1/atlas/kronos/validate` — validates OHLC and timestamp contract without inference.
-- `POST /v1/atlas/kronos/predict` — guarded lazy inference using the configured Kronos-small runtime.
-
 ## Allowed inputs
 
 - OHLC required: `open`, `high`, `low`, `close`
 - Optional: `volume`, `amount`
-- Strictly increasing, unique timestamp series
-- Forecast horizon: 5D, 20D or 60D
+- Timestamp series
+- Forecast horizon
 - Sampling configuration
-- Lookback: 32–512 bars
 
 ## Allowed outputs
 
-ATLAS-normalized forecast metadata and raw predicted bars. The adapter currently exposes terminal predicted close and predicted close-change metadata. These are experimental signals, not portfolio instructions.
+ATLAS-normalized forecast metadata and probabilistic signal fields, including expected return/range, downside-tail estimates, dispersion/uncertainty, and directional probabilities when calculated from forecast paths.
+
+Forecast return is measured from the **last observed close** to the terminal predicted close. It must never be calculated from the first predicted close, because that would distort the forecast horizon return.
 
 ## Forbidden authority
 
@@ -58,13 +38,43 @@ Kronos MUST NOT:
 
 1. Start with `Kronos-small`.
 2. Test pretrained inference before any fine-tuning.
-3. Use walk-forward evaluation with strict train/test chronology.
+3. Use leakage-safe walk-forward evaluation with strict chronology.
 4. Evaluate separate 5D, 20D and 60D horizons.
-5. Benchmark against naive zero-return, simple momentum and simple technical baselines.
-6. Measure directional accuracy, rank IC/Spearman IC, calibration, drawdown hit-rate and forecast dispersion.
+5. Benchmark against naive zero-return and simple momentum baselines.
+6. Measure directional accuracy, MAE, improvement versus zero-return and momentum directional accuracy; add rank IC/Spearman IC and calibration in the cross-sectional phase.
 7. Add transaction costs, slippage, turnover and factor-exposure controls before any alpha claim.
 8. Perform explicit leakage checks against Kronos pretraining coverage.
 9. Fine-tuning is permitted only after the pretrained model demonstrates incremental value.
+
+## Walk-forward harness
+
+`api/kronos_validation.py` contains leakage-safe window generation and validation metrics.
+
+`scripts/run_kronos_walk_forward.py` executes one-symbol CSV validation using actual future market timestamps while withholding all future OHLCV values from the model context.
+
+Required CSV columns:
+
+```text
+timestamp,open,high,low,close
+```
+
+Optional columns:
+
+```text
+volume,amount
+```
+
+Example runtime after optional Kronos dependencies and source are installed:
+
+```bash
+ATLAS_KRONOS_ENABLED=true \
+KRONOS_SOURCE_PATH=/opt/kronos \
+python scripts/run_kronos_walk_forward.py data/MSFT.csv \
+  --symbol MSFT --horizon 20 --lookback 256 --step 20 \
+  --sample-count 20 --output results/msft_kronos_20d.json
+```
+
+The output remains validation evidence only and carries `VALIDATION_ONLY_NO_BUY_SELL_AUTHORITY`.
 
 ## Integration boundary
 
@@ -73,11 +83,9 @@ ATLAS market data
       ↓
 KronosMarketForecastRequest
       ↓
-KronosSmallAdapter (isolated / lazy)
+Kronos adapter (isolated)
       ↓
-Pinned upstream Kronos source
-      ↓
-Kronos-small + tokenizer
+Kronos-small / future approved model
       ↓
 forecast paths
       ↓
@@ -90,7 +98,7 @@ The downstream ATLAS engines decide how much weight, if any, to give the signal.
 
 ## Dependency policy
 
-Kronos model weights must not be committed to Atlas Genesis. Runtime model downloads/storage remain external. The upstream source is pinned for reproducibility and treated as a replaceable dependency, not copied wholesale into ATLAS.
+Kronos model weights must not be committed to Atlas Genesis. Runtime model downloads/storage must be external and version-pinned. The upstream repository is treated as a replaceable dependency, not copied wholesale into ATLAS.
 
 ## Promotion gate
 

--- a/scripts/bootstrap_kronos.sh
+++ b/scripts/bootstrap_kronos.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KRONOS_REPO="https://github.com/shiyu-coder/Kronos.git"
+KRONOS_COMMIT="67b630e67f6a18c9e9be918d9b4337c960db1e9a"
+KRONOS_DIR="${KRONOS_SOURCE_PATH:-/opt/kronos}"
+
+if [[ -d "${KRONOS_DIR}/.git" ]]; then
+  git -C "${KRONOS_DIR}" fetch --depth 1 origin "${KRONOS_COMMIT}"
+else
+  mkdir -p "$(dirname "${KRONOS_DIR}")"
+  git clone --no-checkout "${KRONOS_REPO}" "${KRONOS_DIR}"
+fi
+
+git -C "${KRONOS_DIR}" checkout --detach "${KRONOS_COMMIT}"
+
+echo "Kronos source pinned at ${KRONOS_COMMIT} in ${KRONOS_DIR}"
+echo "Install optional runtime with: pip install -r api/requirements-kronos.txt"
+echo "Enable only after validation with: ATLAS_KRONOS_ENABLED=true"

--- a/scripts/run_kronos_atlas_universe.py
+++ b/scripts/run_kronos_atlas_universe.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from api.kronos_validation import evaluate_observations
+from api.market import get_market_history
+from api.tracked_universe import PORTFOLIO, WATCHLIST
+from scripts.run_kronos_walk_forward import run_symbol
+
+DEFAULT_SYMBOLS = ("MSFT", "NVDA", "GOOG", "TSM", "AVGO", "ASML", "ANET", "ETN")
+
+
+def _market_symbol(item: dict[str, Any]) -> str:
+    return str(item.get("symbol") or item["ticker"]).strip().upper()
+
+
+def _tracked_map() -> dict[str, dict[str, Any]]:
+    return {item["ticker"].upper(): item for item in PORTFOLIO + WATCHLIST}
+
+
+def history_to_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    frame = pd.DataFrame(rows).rename(columns={"date": "timestamp"})
+    required = ["timestamp", "open", "high", "low", "close"]
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        raise ValueError(f"market history missing columns: {missing}")
+    frame = frame.dropna(subset=required).copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="raise")
+    frame = frame.sort_values("timestamp").drop_duplicates("timestamp", keep="last").reset_index(drop=True)
+    return frame
+
+
+async def run_universe(
+    symbols: list[str],
+    *,
+    horizons: tuple[int, ...],
+    lookback: int,
+    step_multiplier: int,
+    sample_count: int,
+    history_days: int,
+) -> dict[str, Any]:
+    tracked = _tracked_map()
+    results: dict[str, Any] = {}
+    failures: dict[str, str] = {}
+
+    for ticker in symbols:
+        key = ticker.strip().upper()
+        item = tracked.get(key, {"ticker": key})
+        market_symbol = _market_symbol(item)
+        try:
+            rows = await get_market_history(market_symbol, days=history_days)
+            frame = history_to_frame(rows)
+            if len(frame) < max(100, lookback + max(horizons) + 1):
+                raise ValueError(f"insufficient history: {len(frame)} rows")
+
+            symbol_payload: dict[str, Any] = {
+                "ticker": key,
+                "marketSymbol": market_symbol,
+                "rows": len(frame),
+                "horizons": {},
+            }
+            for horizon in horizons:
+                observations = run_symbol(
+                    frame,
+                    symbol=key,
+                    horizon=horizon,
+                    lookback=lookback,
+                    step=max(1, horizon * step_multiplier),
+                    sample_count=sample_count,
+                )
+                metrics = evaluate_observations(observations)[horizon]
+                symbol_payload["horizons"][str(horizon)] = {
+                    "metrics": metrics.__dict__,
+                    "observations": [observation.__dict__ for observation in observations],
+                }
+            results[key] = symbol_payload
+        except Exception as exc:
+            failures[key] = f"{exc.__class__.__name__}: {exc}"
+
+    return {
+        "engine": "KRONOS_MARKET_FORECAST_OMEGA_v0_3",
+        "status": "EXPERIMENTAL_NON_CANONICAL",
+        "dataSource": "ATLAS_MARKET_STOOQ",
+        "symbolsRequested": symbols,
+        "results": results,
+        "failures": failures,
+        "authority": "VALIDATION_ONLY_NO_BUY_SELL_AUTHORITY",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Kronos walk-forward on the ATLAS tracked universe")
+    parser.add_argument("--symbols", nargs="*", default=list(DEFAULT_SYMBOLS))
+    parser.add_argument("--horizons", nargs="*", type=int, choices=(5, 20, 60), default=[5, 20, 60])
+    parser.add_argument("--lookback", type=int, default=256)
+    parser.add_argument("--step-multiplier", type=int, default=1)
+    parser.add_argument("--sample-count", type=int, default=20)
+    parser.add_argument("--history-days", type=int, default=1500)
+    parser.add_argument("--output", type=Path, default=Path("artifacts/kronos_atlas_walk_forward.json"))
+    args = parser.parse_args()
+
+    payload = asyncio.run(
+        run_universe(
+            [value.upper() for value in args.symbols],
+            horizons=tuple(args.horizons),
+            lookback=args.lookback,
+            step_multiplier=args.step_multiplier,
+            sample_count=args.sample_count,
+            history_days=args.history_days,
+        )
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "output": str(args.output),
+        "completed": sorted(payload["results"].keys()),
+        "failed": payload["failures"],
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_kronos_walk_forward.py
+++ b/scripts/run_kronos_walk_forward.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from api.kronos_adapter import KronosAdapterError, KronosSmallAdapter
+from api.kronos_validation import (
+    ForecastObservation,
+    evaluate_observations,
+    expanding_walk_forward_indices,
+    momentum_baseline_pct,
+    realized_return_pct,
+)
+
+REQUIRED_COLUMNS = {"timestamp", "open", "high", "low", "close"}
+
+
+def load_market_csv(path: Path) -> pd.DataFrame:
+    frame = pd.read_csv(path)
+    missing = REQUIRED_COLUMNS.difference(frame.columns)
+    if missing:
+        raise ValueError(f"missing required columns: {sorted(missing)}")
+    frame = frame.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True, errors="raise")
+    frame = frame.sort_values("timestamp").drop_duplicates("timestamp", keep="last").reset_index(drop=True)
+    if len(frame) < 100:
+        raise ValueError("walk-forward validation requires at least 100 rows")
+    return frame
+
+
+def run_symbol(
+    frame: pd.DataFrame,
+    *,
+    symbol: str,
+    horizon: int,
+    lookback: int,
+    step: int,
+    sample_count: int,
+) -> list[ForecastObservation]:
+    adapter = KronosSmallAdapter()
+    runtime = adapter.status()
+    if not runtime.enabled or not runtime.source_available or not runtime.dependencies_available:
+        raise KronosAdapterError(runtime.detail)
+
+    closes = [float(value) for value in frame["close"].tolist()]
+    observations: list[ForecastObservation] = []
+    for start, origin, target in expanding_walk_forward_indices(
+        len(frame), lookback=lookback, horizon=horizon, step=step
+    ):
+        history = frame.iloc[start : origin + 1]
+        future = frame.iloc[origin + 1 : target + 1]
+        bars = []
+        for row in history.to_dict(orient="records"):
+            item = {
+                "timestamp": pd.Timestamp(row["timestamp"]).isoformat(),
+                "open": float(row["open"]),
+                "high": float(row["high"]),
+                "low": float(row["low"]),
+                "close": float(row["close"]),
+            }
+            if "volume" in row and pd.notna(row["volume"]):
+                item["volume"] = float(row["volume"])
+            if "amount" in row and pd.notna(row["amount"]):
+                item["amount"] = float(row["amount"])
+            bars.append(item)
+
+        forecast = adapter.predict(
+            bars=bars,
+            future_timestamps=[pd.Timestamp(v).isoformat() for v in future["timestamp"].tolist()],
+            horizon_days=horizon,
+            sample_count=sample_count,
+            temperature=1.0,
+            top_p=0.9,
+        )
+        predicted = float(forecast["predictedReturnPct"])
+        actual = realized_return_pct(closes[origin], closes[target])
+        momentum = momentum_baseline_pct(closes, origin, horizon)
+        observations.append(
+            ForecastObservation(
+                symbol=symbol.upper(),
+                as_of=pd.Timestamp(frame.iloc[origin]["timestamp"]).isoformat(),
+                horizon_days=horizon,
+                predicted_return_pct=predicted,
+                actual_return_pct=actual,
+                momentum_return_pct=momentum,
+            )
+        )
+    return observations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Leakage-safe ATLAS Ω Kronos walk-forward validation")
+    parser.add_argument("csv", type=Path)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--horizon", type=int, choices=(5, 20, 60), default=20)
+    parser.add_argument("--lookback", type=int, default=256)
+    parser.add_argument("--step", type=int, default=None)
+    parser.add_argument("--sample-count", type=int, default=20)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    step = args.step or args.horizon
+    frame = load_market_csv(args.csv)
+    observations = run_symbol(
+        frame,
+        symbol=args.symbol,
+        horizon=args.horizon,
+        lookback=args.lookback,
+        step=step,
+        sample_count=args.sample_count,
+    )
+    metrics = evaluate_observations(observations)[args.horizon]
+    payload = {
+        "engine": "KRONOS_MARKET_FORECAST_OMEGA_v0_2",
+        "status": "EXPERIMENTAL_NON_CANONICAL",
+        "symbol": args.symbol.upper(),
+        "metrics": metrics.__dict__,
+        "observations": [obs.__dict__ for obs in observations],
+        "authority": "VALIDATION_ONLY_NO_BUY_SELL_AUTHORITY",
+    }
+    text = json.dumps(payload, indent=2)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- Added `api/kronos_adapter.py` with lazy, opt-in Kronos-small loading.
- Added guarded `/v1/atlas/kronos/predict`, `/validate` and runtime `/status` endpoints.
- Isolated PyTorch/Hugging Face dependencies in `api/requirements-kronos.txt`.
- Pinned upstream `shiyu-coder/Kronos` to commit `67b630e67f6a18c9e9be918d9b4337c960db1e9a`.
- Added leakage-safe walk-forward tooling in `api/kronos_validation.py`.
- Added executable CSV runner `scripts/run_kronos_walk_forward.py` for 5D/20D/60D evaluation.
- Added zero-return and momentum baselines plus directional accuracy / MAE metrics.
- Corrected forecast return measurement to use the last observed close as the baseline.
- Extended Kronos contract and walk-forward tests and CI.

## Safety / governance

Kronos remains `EXPERIMENTAL_NON_CANONICAL` and has no BUY/SELL authority. It cannot modify fundamental scores, thesis integrity, falsifiers, or portfolio membership. Inference is disabled by default and requires `ATLAS_KRONOS_ENABLED=true`.

## Validation design

Walk-forward windows use only historical OHLCV up to the forecast origin. Future market timestamps may be passed as the forecast schedule, but future OHLCV values remain withheld until scoring. Outputs remain `VALIDATION_ONLY_NO_BUY_SELL_AUTHORITY`.

## Current gate

Do not merge as canonical investment logic until CI passes and real-data out-of-sample runs demonstrate incremental value versus simple baselines after leakage and friction checks.