### PR TITLE
Implement Agentic Runtime Omega inspired by Ouroboros

### DIFF
--- a/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA.md
+++ b/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA.md
@@ -3,6 +3,7 @@
 **Status:** ACTIVE · IMPLEMENTED v1.0
 **Effective:** 2026-08-17
 **Implementation:** `runtime/agentic_omega/`
+**API:** `api/agentic_omega.py`
 **Reference architecture studied:** `razzant/ouroboros`
 
 ## Purpose
@@ -93,6 +94,16 @@ The runtime can create an `EvolutionProposal` backed by evidence IDs, but v1.0 h
 
 No runtime component is authorized to rewrite ATLAS code, Constitution, canon, gates, prompts or dependencies autonomously.
 
+### 9. Operational API
+
+`api/agentic_omega.py` exposes the runtime through:
+
+- `GET /v1/agentic-omega/health`;
+- `POST /v1/agentic-omega/evaluate`;
+- `POST /v1/agentic-omega/evolution-proposals`.
+
+The router is mounted in `api/app.py`. Evaluation is atomic at request level and guarded by the same software invariants as the Python runtime. The API explicitly states that `READY_FOR_EXECUTION_GATE` is not a trade instruction.
+
 ## Ouroboros adaptation boundary
 
 ### Adopt
@@ -144,20 +155,23 @@ The initial implementation includes tests proving:
 6. ledger records are hash chained and reload-verifiable;
 7. evolution remains proposal-only.
 
-Initial local validation on 2026-08-17: **7/7 tests passed**.
+Initial local validation on 2026-08-17: **7/7 tests passed**. API smoke validation also returned `READY_FOR_EXECUTION_GATE` for a complete eight-specialist PASS packet without creating a trade action.
+
+## Persistence
+
+The implementation is subject to `GITHUB_NOTION_SYNC_LAW.md`. GitHub is the versioned technical source of truth; the operational mirror lives under Notion `13 — Proyectos · Atlas Genesis, App, Software y GitHub` in `ATLAS Ω — Agentic Runtime Ω · Ouroboros Adaptation · 17-ago-2026`.
 
 ## Next runtime layers
 
 The following extensions may build on v1.0 without changing its invariants:
 
-- API/router surface for starting/evaluating runs;
 - persistent state backend for multi-process deployments;
 - specialist worker adapters;
 - Evidence Director source-quality/freshness scoring;
 - contradiction graph;
 - replay/recovery of interrupted runs;
 - post-decision forecast-vs-realized calibration;
-- Notion/GitHub synchronization receipts;
+- automated GitHub↔Notion synchronization receipts;
 - model/tool capability evidence by exact route fingerprint.
 
 Any extension that weakens Falsifiers Ω, provenance, no-majority-vote, null-opportunity or execution separation is constitutionally invalid unless explicitly superseded by Vicente.

--- a/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA.md
+++ b/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA.md
@@ -1,0 +1,163 @@
+# ATLAS Ω — Agentic Runtime Ω
+
+**Status:** ACTIVE · IMPLEMENTED v1.0
+**Effective:** 2026-08-17
+**Implementation:** `runtime/agentic_omega/`
+**Reference architecture studied:** `razzant/ouroboros`
+
+## Purpose
+
+Materialize the Investment Committee Ω as an auditable agentic execution layer while preserving ATLAS constitutional authority. The runtime borrows architectural ideas from Ouroboros — task/result pipelines, durable outcome records, post-task learning, evidence-aware capability gating and specialist/subagent separation — but does not import Ouroboros governance or self-modifying authority.
+
+ATLAS remains the epistemic and investment authority.
+
+## Position in ATLAS
+
+`CONSTITUTION / CURRENT_CANON → CORE-00 integrity + epistemics → Agentic Runtime Ω → specialist results → Falsifiers Ω → execution gate → measurement → learning`
+
+`runtime/core00/` is frozen and MUST NOT be extended by this module. Agentic Runtime Ω lives in a separate package and consumes ATLAS invariants rather than rewriting them.
+
+## Implemented v1.0
+
+### 1. Eight independent specialists
+
+The runtime has explicit identities for:
+
+1. Economic Proof Ω
+2. Valuation / Implied Return Ω
+3. CAPEX Productivity Ω
+4. Moat Ω
+5. Institutional Rotation Ω
+6. Macro / Regime Ω
+7. Falsifiers Ω / Red Team
+8. Evidence Director Ω
+
+Results are stored by specialist identity. Duplicate specialist submissions are rejected.
+
+### 2. No-majority-vote invariant
+
+A run cannot progress merely because most specialists agree. If any required specialist is absent the output is `WATCH`, not BUY/HOLD or an inferred positive action.
+
+### 3. Absolute Falsifiers Ω veto
+
+Only Falsifiers Ω can emit `VETO` or set `confirmed_falsifier=true`. A confirmed falsifier produces `REJECT` regardless of every other specialist result.
+
+This is a hard software invariant, not a prompt preference.
+
+### 4. Epistemic assertions
+
+Every assertion is explicitly labeled:
+
+- `FACT`
+- `HYPOTHESIS`
+- `INTERPRETATION`
+- `NOISE`
+
+`FACT` cannot be instantiated without both `source` and `observed_at`. Confidence, freshness and evidence ID are preserved when supplied.
+
+### 5. Outcome receipts
+
+Every finalized run emits an `OutcomeReceipt` containing:
+
+- run ID;
+- terminal orchestration state;
+- reason;
+- missing specialists;
+- veto state;
+- context hash;
+- emission timestamp.
+
+`READY_FOR_EXECUTION_GATE` is deliberately not BUY. Passing research gates only authorizes the separate execution/sizing layer to evaluate an action.
+
+### 6. Append-only execution memory
+
+`AppendOnlyEventLedger` records:
+
+- run start;
+- every specialist result;
+- final outcome receipt;
+- evolution proposals.
+
+Events are JSONL records linked by `previous_hash` and SHA-256 `event_hash`. The ledger verifies its full hash chain when reopened. Mutation of historical events therefore fails verification instead of being silently accepted.
+
+### 7. Null opportunity
+
+`NO_OPPORTUNITY` is a first-class valid terminal state. ATLAS must never manufacture a portfolio change to justify the cost of a research run.
+
+### 8. Controlled evolution
+
+The runtime can create an `EvolutionProposal` backed by evidence IDs, but v1.0 hard-codes:
+
+- `requires_owner_approval = true`
+- `auto_apply = false`
+
+No runtime component is authorized to rewrite ATLAS code, Constitution, canon, gates, prompts or dependencies autonomously.
+
+## Ouroboros adaptation boundary
+
+### Adopt
+
+- explicit task/result lifecycle;
+- specialist/subagent separation;
+- append-only durable operational memory;
+- auditable outcome receipts;
+- post-task learning proposals;
+- sourced evidence and fail-closed thinking for unknown capability/evidence states;
+- distinction between genuine failures, unresolved states and successfully recovered work.
+
+### Adapt
+
+Ouroboros-style self-improvement becomes **proposal-only evolution** in ATLAS. Learning may recommend a code/rule change, but promotion requires constitutional compatibility, evidence, Falsifiers review and explicit owner-controlled implementation.
+
+### Reject
+
+- autonomous self-modification of canonical ATLAS rules;
+- majority voting among agents;
+- LLM confidence as a substitute for evidence;
+- rewriting historical evidence after outcomes are known;
+- allowing institutional flow, macro or momentum to override fundamental evidence gates;
+- direct trade execution from the agentic committee.
+
+## Runtime state machine
+
+`OPEN → WATCH | REJECT | NO_OPPORTUNITY | READY_FOR_EXECUTION_GATE`
+
+Precedence:
+
+1. confirmed Falsifiers Ω veto → `REJECT`;
+2. Evidence Director Ω rejection → `REJECT`;
+3. core hard-gate rejection → `REJECT`;
+4. missing specialist → `WATCH`;
+5. unresolved core gate → `WATCH`;
+6. explicit null opportunity → `NO_OPPORTUNITY`;
+7. all research gates satisfied → `READY_FOR_EXECUTION_GATE`.
+
+## Test contract
+
+The initial implementation includes tests proving:
+
+1. FACT without provenance is rejected;
+2. majority cannot bypass a missing specialist;
+3. Falsifiers Ω veto is absolute;
+4. all gates passing reaches only the execution gate, not an automatic trade;
+5. null opportunity is valid;
+6. ledger records are hash chained and reload-verifiable;
+7. evolution remains proposal-only.
+
+Initial local validation on 2026-08-17: **7/7 tests passed**.
+
+## Next runtime layers
+
+The following extensions may build on v1.0 without changing its invariants:
+
+- API/router surface for starting/evaluating runs;
+- persistent state backend for multi-process deployments;
+- specialist worker adapters;
+- Evidence Director source-quality/freshness scoring;
+- contradiction graph;
+- replay/recovery of interrupted runs;
+- post-decision forecast-vs-realized calibration;
+- Notion/GitHub synchronization receipts;
+- model/tool capability evidence by exact route fingerprint.
+
+Any extension that weakens Falsifiers Ω, provenance, no-majority-vote, null-opportunity or execution separation is constitutionally invalid unless explicitly superseded by Vicente.

--- a/api/agentic_omega.py
+++ b/api/agentic_omega.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from runtime.agentic_omega import (
+    AgenticOmegaOrchestrator,
+    AppendOnlyEventLedger,
+    EpistemicLabel,
+    EvidenceAssertion,
+    GateState,
+    Specialist,
+    SpecialistResult,
+)
+
+
+router = APIRouter(prefix="/v1/agentic-omega", tags=["agentic-omega"])
+
+_LEDGER_PATH = Path(
+    os.getenv("ATLAS_AGENTIC_LEDGER_PATH", ".atlas_state/agentic_omega/events.jsonl")
+)
+_ENGINE = AgenticOmegaOrchestrator(AppendOnlyEventLedger(_LEDGER_PATH))
+_ENGINE_LOCK = RLock()
+
+
+class EvidenceAssertionPayload(BaseModel):
+    claim: str = Field(min_length=1)
+    label: EpistemicLabel
+    source: str = ""
+    observed_at: str = ""
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    freshness: str = ""
+
+
+class SpecialistResultPayload(BaseModel):
+    specialist: Specialist
+    gate_state: GateState
+    conclusion: str = Field(min_length=1)
+    assertions: list[EvidenceAssertionPayload] = Field(default_factory=list)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    confirmed_falsifier: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvaluateRunRequest(BaseModel):
+    objective: str = Field(min_length=1, max_length=1000)
+    context: dict[str, Any] = Field(default_factory=dict)
+    results: list[SpecialistResultPayload] = Field(default_factory=list)
+    no_opportunity: bool = False
+
+
+class EvolutionProposalRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=300)
+    rationale: str = Field(min_length=1, max_length=4000)
+    evidence_ids: list[str] = Field(min_length=1)
+
+
+def _materialize_result(payload: SpecialistResultPayload) -> SpecialistResult:
+    assertions = tuple(
+        EvidenceAssertion(
+            claim=item.claim,
+            label=item.label,
+            source=item.source,
+            observed_at=item.observed_at,
+            confidence=item.confidence,
+            freshness=item.freshness,
+        )
+        for item in payload.assertions
+    )
+    return SpecialistResult(
+        specialist=payload.specialist,
+        gate_state=payload.gate_state,
+        conclusion=payload.conclusion,
+        assertions=assertions,
+        confidence=payload.confidence,
+        confirmed_falsifier=payload.confirmed_falsifier,
+        metadata=payload.metadata,
+    )
+
+
+@router.get("/health")
+def agentic_omega_health() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "engine": "Agentic Runtime Ω",
+        "version": "1.0",
+        "ledgerPath": str(_LEDGER_PATH),
+        "ledgerEvents": len(_ENGINE.ledger.events),
+        "invariants": {
+            "majorityVoting": False,
+            "falsifiersAbsoluteVeto": True,
+            "factRequiresProvenance": True,
+            "autoSelfModification": False,
+            "directTradeExecution": False,
+        },
+    }
+
+
+@router.post("/evaluate")
+def evaluate_agentic_run(request: EvaluateRunRequest) -> dict[str, Any]:
+    try:
+        with _ENGINE_LOCK:
+            run = _ENGINE.start_run(request.objective, request.context)
+            for item in request.results:
+                _ENGINE.submit_result(run, _materialize_result(item))
+            receipt = _ENGINE.finalize(run, no_opportunity=request.no_opportunity)
+            return {
+                "engine": "Agentic Runtime Ω",
+                "runId": run.run_id,
+                "receipt": receipt.to_dict(),
+                "specialistsReceived": [item.specialist.value for item in request.results],
+                "ledgerEvents": len(_ENGINE.ledger.events),
+                "guardrail": (
+                    "READY_FOR_EXECUTION_GATE is not a trade instruction. "
+                    "Broker execution and sizing remain separate."
+                ),
+            }
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/evolution-proposals")
+def create_evolution_proposal(request: EvolutionProposalRequest) -> dict[str, Any]:
+    try:
+        with _ENGINE_LOCK:
+            proposal = _ENGINE.propose_evolution(
+                title=request.title,
+                rationale=request.rationale,
+                evidence_ids=request.evidence_ids,
+            )
+            return {
+                "proposal": {
+                    "proposalId": proposal.proposal_id,
+                    "title": proposal.title,
+                    "rationale": proposal.rationale,
+                    "evidenceIds": list(proposal.evidence_ids),
+                    "createdAt": proposal.created_at,
+                    "requiresOwnerApproval": proposal.requires_owner_approval,
+                    "autoApply": proposal.auto_apply,
+                },
+                "guardrail": "Evolution is proposal-only; no code or canon is modified by this endpoint.",
+            }
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/api/app.py
+++ b/api/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from api.agentic_omega import router as agentic_omega_router
 from api.atlas_core import router as atlas_router
 from api.bottom_score import router as bottom_score_router
 from api.evidence import router as evidence_router
@@ -23,6 +24,7 @@ app.include_router(bottom_score_router)
 app.include_router(realizable_alpha_router)
 app.include_router(evidence_router)
 app.include_router(kronos_market_forecast_router)
+app.include_router(agentic_omega_router)
 
 
 @app.exception_handler(HTTPException)

--- a/runtime/agentic_omega/__init__.py
+++ b/runtime/agentic_omega/__init__.py
@@ -1,0 +1,34 @@
+"""ATLAS Ω Agentic Runtime.
+
+This package is deliberately separate from frozen CORE-00. It orchestrates
+specialists and persists execution evidence while remaining subordinate to
+ATLAS constitutional and epistemic gates.
+"""
+
+from .orchestrator import (
+    AgenticOmegaOrchestrator,
+    AgenticRun,
+    AppendOnlyEventLedger,
+    EpistemicLabel,
+    EvidenceAssertion,
+    EvolutionProposal,
+    GateState,
+    OutcomeReceipt,
+    RunStatus,
+    Specialist,
+    SpecialistResult,
+)
+
+__all__ = [
+    "AgenticOmegaOrchestrator",
+    "AgenticRun",
+    "AppendOnlyEventLedger",
+    "EpistemicLabel",
+    "EvidenceAssertion",
+    "EvolutionProposal",
+    "GateState",
+    "OutcomeReceipt",
+    "RunStatus",
+    "Specialist",
+    "SpecialistResult",
+]

--- a/runtime/agentic_omega/orchestrator.py
+++ b/runtime/agentic_omega/orchestrator.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+
+class EpistemicLabel(str, Enum):
+    FACT = "FACT"
+    HYPOTHESIS = "HYPOTHESIS"
+    INTERPRETATION = "INTERPRETATION"
+    NOISE = "NOISE"
+
+
+class Specialist(str, Enum):
+    ECONOMIC_PROOF = "Economic Proof Ω"
+    VALUATION = "Valuation / Implied Return Ω"
+    CAPEX_PRODUCTIVITY = "CAPEX Productivity Ω"
+    MOAT = "Moat Ω"
+    INSTITUTIONAL_ROTATION = "Institutional Rotation Ω"
+    MACRO_REGIME = "Macro / Regime Ω"
+    FALSIFIERS = "Falsifiers Ω / Red Team"
+    EVIDENCE_DIRECTOR = "Evidence Director Ω"
+
+
+class GateState(str, Enum):
+    PASS = "PASS"
+    WATCH = "WATCH"
+    REJECT = "REJECT"
+    VETO = "VETO"
+    NOT_EVALUATED = "NOT_EVALUATED"
+
+
+class RunStatus(str, Enum):
+    OPEN = "OPEN"
+    WATCH = "WATCH"
+    REJECT = "REJECT"
+    NO_OPPORTUNITY = "NO_OPPORTUNITY"
+    READY_FOR_EXECUTION_GATE = "READY_FOR_EXECUTION_GATE"
+
+
+REQUIRED_SPECIALISTS = tuple(Specialist)
+CORE_DECISION_GATES = frozenset(
+    {
+        Specialist.ECONOMIC_PROOF,
+        Specialist.VALUATION,
+        Specialist.CAPEX_PRODUCTIVITY,
+        Specialist.MOAT,
+        Specialist.EVIDENCE_DIRECTOR,
+    }
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+@dataclass(frozen=True)
+class EvidenceAssertion:
+    claim: str
+    label: EpistemicLabel
+    source: str = ""
+    observed_at: str = ""
+    confidence: float | None = None
+    freshness: str = ""
+    evidence_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def __post_init__(self) -> None:
+        if not self.claim.strip():
+            raise ValueError("claim must be non-empty")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+        if self.label is EpistemicLabel.FACT and (not self.source.strip() or not self.observed_at.strip()):
+            raise ValueError("FACT requires source and observed_at")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["label"] = self.label.value
+        return payload
+
+
+@dataclass(frozen=True)
+class SpecialistResult:
+    specialist: Specialist
+    gate_state: GateState
+    conclusion: str
+    assertions: tuple[EvidenceAssertion, ...] = ()
+    confidence: float | None = None
+    confirmed_falsifier: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.conclusion.strip():
+            raise ValueError("conclusion must be non-empty")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+        if self.confirmed_falsifier and self.specialist is not Specialist.FALSIFIERS:
+            raise ValueError("only Falsifiers Ω may confirm an absolute veto")
+        if self.gate_state is GateState.VETO and self.specialist is not Specialist.FALSIFIERS:
+            raise ValueError("only Falsifiers Ω may emit VETO")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "specialist": self.specialist.value,
+            "gate_state": self.gate_state.value,
+            "conclusion": self.conclusion,
+            "assertions": [item.to_dict() for item in self.assertions],
+            "confidence": self.confidence,
+            "confirmed_falsifier": self.confirmed_falsifier,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class AgenticRun:
+    objective: str
+    context: dict[str, Any]
+    run_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    created_at: str = field(default_factory=_utc_now)
+    results: dict[Specialist, SpecialistResult] = field(default_factory=dict)
+    status: RunStatus = RunStatus.OPEN
+
+    @property
+    def context_hash(self) -> str:
+        return hashlib.sha256(_canonical_json(self.context).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class OutcomeReceipt:
+    run_id: str
+    status: RunStatus
+    reason: str
+    missing_specialists: tuple[str, ...]
+    vetoed: bool
+    context_hash: str
+    emitted_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["status"] = self.status.value
+        return payload
+
+
+@dataclass(frozen=True)
+class EvolutionProposal:
+    proposal_id: str
+    title: str
+    rationale: str
+    evidence_ids: tuple[str, ...]
+    created_at: str
+    requires_owner_approval: bool = True
+    auto_apply: bool = False
+
+
+class AppendOnlyEventLedger:
+    """Append-only JSONL ledger with a SHA-256 hash chain.
+
+    A missing path keeps the ledger in memory, which is useful for tests and
+    ephemeral execution. Persistent runs should provide a path outside frozen
+    CORE-00.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path else None
+        self._events: list[dict[str, Any]] = []
+        if self.path and self.path.exists():
+            self._events = [
+                json.loads(line)
+                for line in self.path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            self.verify()
+
+    @property
+    def events(self) -> tuple[dict[str, Any], ...]:
+        return tuple(self._events)
+
+    def append(self, event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+        previous_hash = self._events[-1]["event_hash"] if self._events else "GENESIS"
+        core = {
+            "event_type": event_type,
+            "payload": payload,
+            "previous_hash": previous_hash,
+            "recorded_at": _utc_now(),
+        }
+        event_hash = hashlib.sha256(_canonical_json(core).encode("utf-8")).hexdigest()
+        event = {**core, "event_hash": event_hash}
+        self._events.append(event)
+        if self.path:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(_canonical_json(event) + "\n")
+        return event
+
+    def verify(self) -> bool:
+        previous_hash = "GENESIS"
+        for event in self._events:
+            core = {
+                "event_type": event["event_type"],
+                "payload": event["payload"],
+                "previous_hash": event["previous_hash"],
+                "recorded_at": event["recorded_at"],
+            }
+            expected = hashlib.sha256(_canonical_json(core).encode("utf-8")).hexdigest()
+            if event["previous_hash"] != previous_hash or event["event_hash"] != expected:
+                raise ValueError("agentic ledger hash-chain verification failed")
+            previous_hash = event["event_hash"]
+        return True
+
+
+class AgenticOmegaOrchestrator:
+    """Ouroboros-inspired orchestration subordinate to ATLAS Ω governance.
+
+    It coordinates specialists, preserves evidence and outcomes, and records
+    evolution proposals. It never self-modifies code, never turns a majority
+    vote into an investment action, and never bypasses Falsifiers Ω.
+    """
+
+    def __init__(self, ledger: AppendOnlyEventLedger | None = None) -> None:
+        self.ledger = ledger or AppendOnlyEventLedger()
+
+    def start_run(self, objective: str, context: dict[str, Any] | None = None) -> AgenticRun:
+        if not objective.strip():
+            raise ValueError("objective must be non-empty")
+        run = AgenticRun(objective=objective.strip(), context=context or {})
+        self.ledger.append(
+            "RUN_STARTED",
+            {
+                "run_id": run.run_id,
+                "objective": run.objective,
+                "context_hash": run.context_hash,
+                "required_specialists": [item.value for item in REQUIRED_SPECIALISTS],
+            },
+        )
+        return run
+
+    def submit_result(self, run: AgenticRun, result: SpecialistResult) -> None:
+        if run.status is not RunStatus.OPEN:
+            raise RuntimeError("cannot submit a result after run finalization")
+        if result.specialist in run.results:
+            raise ValueError(f"duplicate specialist result: {result.specialist.value}")
+        run.results[result.specialist] = result
+        self.ledger.append(
+            "SPECIALIST_RESULT",
+            {"run_id": run.run_id, "result": result.to_dict()},
+        )
+
+    def finalize(self, run: AgenticRun, *, no_opportunity: bool = False) -> OutcomeReceipt:
+        if run.status is not RunStatus.OPEN:
+            raise RuntimeError("run has already been finalized")
+
+        falsifier = run.results.get(Specialist.FALSIFIERS)
+        if falsifier and (falsifier.confirmed_falsifier or falsifier.gate_state is GateState.VETO):
+            status = RunStatus.REJECT
+            reason = "confirmed material falsifier; absolute independent veto"
+            vetoed = True
+        else:
+            vetoed = False
+            missing = [item for item in REQUIRED_SPECIALISTS if item not in run.results]
+            evidence_director = run.results.get(Specialist.EVIDENCE_DIRECTOR)
+            rejected_core = [
+                item for item in CORE_DECISION_GATES
+                if item in run.results and run.results[item].gate_state is GateState.REJECT
+            ]
+            watched_core = [
+                item for item in CORE_DECISION_GATES
+                if item in run.results and run.results[item].gate_state in {GateState.WATCH, GateState.NOT_EVALUATED}
+            ]
+
+            if evidence_director and evidence_director.gate_state is GateState.REJECT:
+                status = RunStatus.REJECT
+                reason = "Evidence Director Ω rejected the evidence packet"
+            elif rejected_core:
+                status = RunStatus.REJECT
+                reason = "hard decision gate rejected: " + ", ".join(item.value for item in rejected_core)
+            elif missing:
+                status = RunStatus.WATCH
+                reason = "committee incomplete; majority voting is prohibited"
+            elif watched_core:
+                status = RunStatus.WATCH
+                reason = "one or more hard gates remain unresolved"
+            elif no_opportunity:
+                status = RunStatus.NO_OPPORTUNITY
+                reason = "valid null result; no portfolio action is manufactured"
+            else:
+                status = RunStatus.READY_FOR_EXECUTION_GATE
+                reason = "all evidence gates passed; execution/sizing remains separate"
+
+        run.status = status
+        missing_names = tuple(item.value for item in REQUIRED_SPECIALISTS if item not in run.results)
+        receipt = OutcomeReceipt(
+            run_id=run.run_id,
+            status=status,
+            reason=reason,
+            missing_specialists=missing_names,
+            vetoed=vetoed,
+            context_hash=run.context_hash,
+            emitted_at=_utc_now(),
+        )
+        self.ledger.append("OUTCOME_RECEIPT", receipt.to_dict())
+        return receipt
+
+    def propose_evolution(
+        self,
+        *,
+        title: str,
+        rationale: str,
+        evidence_ids: Iterable[str],
+    ) -> EvolutionProposal:
+        if not title.strip() or not rationale.strip():
+            raise ValueError("title and rationale must be non-empty")
+        evidence = tuple(item for item in evidence_ids if str(item).strip())
+        if not evidence:
+            raise ValueError("evolution proposals require evidence_ids")
+        proposal = EvolutionProposal(
+            proposal_id=uuid.uuid4().hex,
+            title=title.strip(),
+            rationale=rationale.strip(),
+            evidence_ids=evidence,
+            created_at=_utc_now(),
+        )
+        self.ledger.append("EVOLUTION_PROPOSED", asdict(proposal))
+        return proposal

--- a/runtime/agentic_omega/test_orchestrator.py
+++ b/runtime/agentic_omega/test_orchestrator.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from runtime.agentic_omega import (
+    AgenticOmegaOrchestrator,
+    AppendOnlyEventLedger,
+    EpistemicLabel,
+    EvidenceAssertion,
+    GateState,
+    RunStatus,
+    Specialist,
+    SpecialistResult,
+)
+
+
+def _fact(claim: str = "verified") -> EvidenceAssertion:
+    return EvidenceAssertion(
+        claim=claim,
+        label=EpistemicLabel.FACT,
+        source="primary:test",
+        observed_at="2026-08-17",
+        confidence=0.95,
+    )
+
+
+def _result(specialist: Specialist, state: GateState = GateState.PASS, **kwargs) -> SpecialistResult:
+    return SpecialistResult(
+        specialist=specialist,
+        gate_state=state,
+        conclusion=f"{specialist.value}: {state.value}",
+        assertions=(_fact(),),
+        **kwargs,
+    )
+
+
+def test_fact_requires_provenance() -> None:
+    with pytest.raises(ValueError):
+        EvidenceAssertion(claim="x", label=EpistemicLabel.FACT)
+
+
+def test_majority_cannot_bypass_missing_specialist() -> None:
+    engine = AgenticOmegaOrchestrator()
+    run = engine.start_run("test")
+    for specialist in list(Specialist)[:-1]:
+        engine.submit_result(run, _result(specialist))
+    receipt = engine.finalize(run)
+    assert receipt.status is RunStatus.WATCH
+    assert "majority voting" in receipt.reason
+
+
+def test_falsifier_veto_is_absolute() -> None:
+    engine = AgenticOmegaOrchestrator()
+    run = engine.start_run("test")
+    for specialist in Specialist:
+        if specialist is Specialist.FALSIFIERS:
+            result = _result(specialist, GateState.VETO, confirmed_falsifier=True)
+        else:
+            result = _result(specialist)
+        engine.submit_result(run, result)
+    receipt = engine.finalize(run)
+    assert receipt.status is RunStatus.REJECT
+    assert receipt.vetoed is True
+
+
+def test_all_gates_pass_only_reaches_execution_gate() -> None:
+    engine = AgenticOmegaOrchestrator()
+    run = engine.start_run("test")
+    for specialist in Specialist:
+        engine.submit_result(run, _result(specialist))
+    receipt = engine.finalize(run)
+    assert receipt.status is RunStatus.READY_FOR_EXECUTION_GATE
+
+
+def test_null_opportunity_is_valid() -> None:
+    engine = AgenticOmegaOrchestrator()
+    run = engine.start_run("test")
+    for specialist in Specialist:
+        engine.submit_result(run, _result(specialist))
+    receipt = engine.finalize(run, no_opportunity=True)
+    assert receipt.status is RunStatus.NO_OPPORTUNITY
+
+
+def test_ledger_is_hash_chained(tmp_path) -> None:
+    path = tmp_path / "events.jsonl"
+    ledger = AppendOnlyEventLedger(path)
+    ledger.append("A", {"x": 1})
+    ledger.append("B", {"x": 2})
+    assert ledger.verify() is True
+    reloaded = AppendOnlyEventLedger(path)
+    assert len(reloaded.events) == 2
+
+
+def test_evolution_is_proposal_only() -> None:
+    engine = AgenticOmegaOrchestrator()
+    proposal = engine.propose_evolution(
+        title="Improve specialist routing",
+        rationale="Observed repeated evidence-routing mismatch.",
+        evidence_ids=["ev-1"],
+    )
+    assert proposal.requires_owner_approval is True
+    assert proposal.auto_apply is False


### PR DESCRIPTION
## What changed

- Added `runtime/agentic_omega/` as a new agentic orchestration layer separate from frozen CORE-00.
- Materialized the eight Investment Committee Ω specialists as explicit identities.
- Enforced no-majority-vote, provenance for FACT, independent absolute Falsifiers Ω veto, null-opportunity, and separation from trade execution.
- Added an append-only SHA-256 hash-chained execution ledger and outcome receipts.
- Added proposal-only evolution (`auto_apply = false`, owner approval required).
- Added `/v1/agentic-omega/health`, `/evaluate`, and `/evolution-proposals` API routes and mounted them in `api.app`.
- Added canonical documentation in `CURRENT_CANON/AGENTIC_RUNTIME_OMEGA.md`.

## Why

Adapt useful execution patterns observed in `razzant/ouroboros`—task/result lifecycle, durable outcome records, specialist separation, post-task learning proposals and sourced evidence—without importing autonomous self-modification or weakening ATLAS Ω governance.

## Validation

Local focused suite: **7/7 tests passed** for the new runtime invariants.

## Safety / governance

`READY_FOR_EXECUTION_GATE` is not BUY/SELL. Falsifiers Ω retains absolute veto. Evolution is proposal-only. CORE-00 remains untouched and frozen.