### PR TITLE
Agentic Runtime Ω v2.1: fail-closed Red Team and durable ledger

### DIFF
--- a/.github/workflows/agentic-runtime-v2.yml
+++ b/.github/workflows/agentic-runtime-v2.yml
@@ -28,4 +28,5 @@ jobs:
           python -m pytest -q
           runtime/agentic_omega/test_orchestrator.py
           runtime/agentic_omega/test_v2.py
+          runtime/agentic_omega/test_hardening.py
           api/test_agentic_omega_v2.py

--- a/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA_V2_1_HARDENING.md
+++ b/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA_V2_1_HARDENING.md
@@ -1,0 +1,87 @@
+# ATLAS Ω — Agentic Runtime Ω v2.1 Hardening
+
+**Status:** IMPLEMENTED · MERGE CANDIDATE
+**Effective:** 2026-08-17
+**Extends:** Agentic Runtime Ω v2.
+
+## Purpose
+
+Close two fail-open edges found during post-merge review of v2:
+
+1. an empty confirmed-falsifier list did not prove that Falsifiers Ω had actually completed its review;
+2. the hash-chained file ledger could be appended by two process instances from stale in-memory tails.
+
+v2.1 strengthens both without changing investment authority or CORE-00.
+
+## Red Team completion gate
+
+`GovernedWorkerCoordinator` requires an explicit `falsifier_review_complete` state.
+
+- confirmed material falsifier → `VETO` immediately, regardless of completion flag;
+- no confirmed falsifier + review complete → normal Falsifiers PASS path;
+- no confirmed falsifier + review incomplete → Falsifiers `NOT_EVALUATED` and Evidence Director `WATCH`.
+
+Therefore absence of a known veto cannot masquerade as completion of Red Team work.
+
+## Critical provenance gate
+
+The hardening layer requires `source` and `observed_at` for core structured metrics used by:
+
+- Economic Proof Ω;
+- Valuation / Implied Return Ω;
+- CAPEX Productivity Ω;
+- Moat Ω.
+
+A core metric may still have a numeric value, but without provenance its specialist result is converted to `NOT_EVALUATED`. Evidence Director is downgraded to `WATCH` when such gaps exist.
+
+## Explicit temporal supersession
+
+Contradictory evidence is not deleted merely because one observation is newer. An observation must explicitly set `metadata.supersedes_previous=true` before older observations for the same key are removed from the active contradiction set.
+
+This preserves historical evidence while allowing explicit corrected/restated data to supersede stale observations.
+
+## Durable multi-process ledger
+
+`DurableAgenticLedger` extends the v1 append-only SHA-256 ledger.
+
+For file-backed state it:
+
+1. obtains a process lock and OS file lock where available;
+2. reloads the current ledger from disk;
+3. verifies the complete hash chain;
+4. appends from the verified current tail;
+5. releases the lock.
+
+This prevents two API worker processes from independently extending the same stale hash tail.
+
+The operational `api/agentic_omega.py` engine now uses `DurableAgenticLedger`; v2 continues sharing that same engine and ledger.
+
+## API surface
+
+`/v1/agentic-omega/v2/run-workers` adds:
+
+- `falsifier_review_complete` (default false).
+
+Capabilities now disclose:
+
+- Red Team completion required;
+- critical metric provenance required;
+- explicit temporal supersession;
+- durable multi-process ledger.
+
+## Tests
+
+Hardening tests cover:
+
+- incomplete Falsifiers review fails closed;
+- a confirmed falsifier still vetoes immediately;
+- explicit temporal supersession removes the superseded conflict only when declared;
+- stale DurableAgenticLedger instances reload before appending;
+- API readiness requires completed Falsifiers review;
+- API readiness requires critical metric provenance.
+
+The dedicated Agentic Runtime v2 CI workflow is extended to run the hardening suite in addition to all v1/v2 tests.
+
+## Invariants preserved
+
+No majority voting. Falsifiers Ω veto remains absolute. Missing evidence remains non-evidence. External candidate evidence remains non-canonical by default. `READY_FOR_EXECUTION_GATE` remains separate from BUY/SELL and broker execution. Evolution remains proposal-only. CORE-00 is untouched.

--- a/api/agentic_omega.py
+++ b/api/agentic_omega.py
@@ -10,13 +10,13 @@ from pydantic import BaseModel, Field
 
 from runtime.agentic_omega import (
     AgenticOmegaOrchestrator,
-    AppendOnlyEventLedger,
     EpistemicLabel,
     EvidenceAssertion,
     GateState,
     Specialist,
     SpecialistResult,
 )
+from runtime.agentic_omega.durable_ledger import DurableAgenticLedger
 
 
 router = APIRouter(prefix="/v1/agentic-omega", tags=["agentic-omega"])
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/v1/agentic-omega", tags=["agentic-omega"])
 _LEDGER_PATH = Path(
     os.getenv("ATLAS_AGENTIC_LEDGER_PATH", ".atlas_state/agentic_omega/events.jsonl")
 )
-_ENGINE = AgenticOmegaOrchestrator(AppendOnlyEventLedger(_LEDGER_PATH))
+_ENGINE = AgenticOmegaOrchestrator(DurableAgenticLedger(_LEDGER_PATH))
 _ENGINE_LOCK = RLock()
 
 
@@ -88,9 +88,10 @@ def agentic_omega_health() -> dict[str, Any]:
     return {
         "ok": True,
         "engine": "Agentic Runtime Ω",
-        "version": "1.0",
+        "version": "1.0+durable-ledger",
         "ledgerPath": str(_LEDGER_PATH),
         "ledgerEvents": len(_ENGINE.ledger.events),
+        "durableLedger": True,
         "invariants": {
             "majorityVoting": False,
             "falsifiersAbsoluteVeto": True,

--- a/api/agentic_omega_v2.py
+++ b/api/agentic_omega_v2.py
@@ -17,13 +17,13 @@ from runtime.agentic_omega import (
     CalibrationEngine,
     MetricObservation,
     RunRecovery,
-    WorkerCoordinator,
     WorkerPacket,
 )
+from runtime.agentic_omega.hardening import GovernedWorkerCoordinator
 
 
 router = APIRouter(prefix="/v1/agentic-omega", tags=["agentic-omega-v2"])
-_COORDINATOR = WorkerCoordinator()
+_COORDINATOR = GovernedWorkerCoordinator()
 _RECOVERY = RunRecovery(_ENGINE.ledger)
 _CALIBRATION = CalibrationEngine(_ENGINE.ledger)
 _ACTIVE_RUNS: dict[str, AgenticRun] = {}
@@ -47,6 +47,7 @@ class WorkerRunRequest(BaseModel):
     context: dict[str, Any] = Field(default_factory=dict)
     observations: list[MetricObservationPayload] = Field(default_factory=list)
     confirmed_falsifiers: list[str] = Field(default_factory=list)
+    falsifier_review_complete: bool = False
     policies: dict[str, dict[str, float]] = Field(default_factory=dict)
     no_opportunity: bool = False
 
@@ -100,11 +101,15 @@ def _load_open_run(run_id: str) -> AgenticRun:
 def agentic_v2_capabilities() -> dict[str, Any]:
     return {
         "engine": "Agentic Runtime Ω",
-        "version": "2.0",
+        "version": "2.1-hardened",
         "workers": 8,
         "deterministicWorkers": True,
         "contradictionGraph": True,
+        "explicitTemporalSupersession": True,
         "evidenceDirectorScoring": True,
+        "criticalMetricProvenanceRequired": True,
+        "falsifierReviewCompleteRequired": True,
+        "durableMultiProcessLedger": True,
         "replayRecovery": True,
         "predictionCalibration": True,
         "externalEvidenceAutoCanonical": False,
@@ -124,13 +129,16 @@ def run_workers(request: WorkerRunRequest) -> dict[str, Any]:
         with _ENGINE_LOCK:
             run = _ENGINE.start_run(request.objective, request.context)
             _RECOVERY.snapshot_context(run)
-            results = _COORDINATOR.run(packet)
+            results = _COORDINATOR.run(
+                packet,
+                falsifier_review_complete=request.falsifier_review_complete,
+            )
             for result in results:
                 _ENGINE.submit_result(run, result)
             receipt = _ENGINE.finalize(run, no_opportunity=request.no_opportunity)
             return {
                 "engine": "Agentic Runtime Ω",
-                "version": "2.0",
+                "version": "2.1-hardened",
                 "runId": run.run_id,
                 "receipt": receipt.to_dict(),
                 "results": [result.to_dict() for result in results],
@@ -138,6 +146,8 @@ def run_workers(request: WorkerRunRequest) -> dict[str, Any]:
                     "externalEvidenceAutoCanonical": False,
                     "majorityVoting": False,
                     "falsifiersAbsoluteVeto": True,
+                    "falsifierReviewCompleteRequired": True,
+                    "criticalMetricProvenanceRequired": True,
                     "readyForExecutionIsTrade": False,
                 },
             }

--- a/api/test_agentic_omega_v2.py
+++ b/api/test_agentic_omega_v2.py
@@ -30,6 +30,7 @@ def _request() -> WorkerRunRequest:
     return WorkerRunRequest(
         objective="worker-api-smoke",
         context={"ticker": "TEST"},
+        falsifier_review_complete=True,
         observations=[
             _metric("demand_growth", 0.20),
             _metric("capture_growth", 0.15),
@@ -53,6 +54,26 @@ def test_worker_api_reaches_execution_gate_without_trade() -> None:
     assert response["receipt"]["status"] == "READY_FOR_EXECUTION_GATE"
     assert len(response["results"]) == 8
     assert response["guardrails"]["readyForExecutionIsTrade"] is False
+
+
+def test_worker_api_requires_completed_falsifiers_review() -> None:
+    request = _request()
+    request.falsifier_review_complete = False
+    response = run_workers(request)
+    assert response["receipt"]["status"] == "WATCH"
+    falsifiers = response["results"][6]
+    assert falsifiers["gate_state"] == "NOT_EVALUATED"
+    assert falsifiers["metadata"]["reviewComplete"] is False
+
+
+def test_worker_api_requires_critical_metric_provenance() -> None:
+    request = _request()
+    request.observations[0].source = ""
+    response = run_workers(request)
+    assert response["receipt"]["status"] == "WATCH"
+    economic = response["results"][0]
+    assert economic["gate_state"] == "NOT_EVALUATED"
+    assert "demand_growth" in economic["metadata"]["provenanceGap"]
 
 
 def test_worker_api_material_contradiction_does_not_pass_evidence_director() -> None:

--- a/runtime/agentic_omega/__init__.py
+++ b/runtime/agentic_omega/__init__.py
@@ -28,11 +28,14 @@ from .workers import (
 )
 from .calibration import CalibrationEngine, CalibrationResult, PredictionRecord
 from .recovery import RecoveredRunView, RunRecovery
+from .durable_ledger import DurableAgenticLedger
+from .hardening import GovernedWorkerCoordinator
 
 __all__ = [
     "AgenticOmegaOrchestrator",
     "AgenticRun",
     "AppendOnlyEventLedger",
+    "DurableAgenticLedger",
     "EpistemicLabel",
     "EvidenceAssertion",
     "EvolutionProposal",
@@ -47,6 +50,7 @@ __all__ = [
     "EvidenceDirectorWorker",
     "WorkerPacket",
     "WorkerCoordinator",
+    "GovernedWorkerCoordinator",
     "PredictionRecord",
     "CalibrationResult",
     "CalibrationEngine",

--- a/runtime/agentic_omega/durable_ledger.py
+++ b/runtime/agentic_omega/durable_ledger.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from threading import RLock
+from typing import Iterator
+
+from .orchestrator import AppendOnlyEventLedger
+
+try:
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover - Windows/local fallback
+    fcntl = None
+
+
+_PROCESS_LOCK = RLock()
+
+
+class DurableAgenticLedger(AppendOnlyEventLedger):
+    """Append-only agentic ledger hardened for multiple process instances.
+
+    The original v1 ledger is hash chained but keeps an in-memory tail. Two
+    processes can therefore otherwise append from the same stale tail. This
+    subclass serializes file-backed appends with an OS lock where available,
+    reloads the ledger under that lock, verifies the chain, and only then
+    appends the next event.
+    """
+
+    @contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        if self.path is None:
+            with _PROCESS_LOCK:
+                yield
+            return
+        lock_path = Path(str(self.path) + ".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with _PROCESS_LOCK:
+            with lock_path.open("a+", encoding="utf-8") as handle:
+                if fcntl is not None:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    if fcntl is not None:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _reload_verified(self) -> None:
+        if self.path is None or not self.path.exists():
+            self._events = []
+            return
+        self._events = [
+            json.loads(line)
+            for line in self.path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        super().verify()
+
+    def append(self, event_type: str, payload: dict) -> dict:
+        if self.path is None:
+            return super().append(event_type, payload)
+        with self._exclusive():
+            self._reload_verified()
+            return super().append(event_type, payload)
+
+    def refresh(self) -> tuple[dict, ...]:
+        with self._exclusive():
+            self._reload_verified()
+            return self.events

--- a/runtime/agentic_omega/hardening.py
+++ b/runtime/agentic_omega/hardening.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import replace
+from typing import Iterable
+
+from .orchestrator import GateState, Specialist, SpecialistResult
+from .workers import MetricObservation, WorkerCoordinator, WorkerPacket
+
+
+_CRITICAL_PROVENANCE: dict[Specialist, tuple[str, ...]] = {
+    Specialist.ECONOMIC_PROOF: ("demand_growth", "capture_growth", "fcf_conversion", "roic"),
+    Specialist.VALUATION: ("expected_return_annualized",),
+    Specialist.CAPEX_PRODUCTIVITY: ("incremental_roic", "capex_payback_years"),
+    Specialist.MOAT: ("moat_score",),
+}
+
+
+def _temporal_filter(observations: Iterable[MetricObservation]) -> tuple[MetricObservation, ...]:
+    """Apply explicit supersession only; never infer that newer automatically wins."""
+    grouped: dict[str, list[MetricObservation]] = defaultdict(list)
+    for item in observations:
+        grouped[item.key].append(item)
+    kept: list[MetricObservation] = []
+    for items in grouped.values():
+        superseding = [item for item in items if bool(item.metadata.get("supersedes_previous"))]
+        if superseding:
+            latest = sorted(superseding, key=lambda item: item.observed_at)[-1]
+            kept.append(latest)
+        else:
+            kept.extend(items)
+    return tuple(kept)
+
+
+def _replace_state(result: SpecialistResult, state: GateState, conclusion: str, **metadata) -> SpecialistResult:
+    merged = dict(result.metadata)
+    merged.update(metadata)
+    return replace(result, gate_state=state, conclusion=conclusion, metadata=merged)
+
+
+class GovernedWorkerCoordinator:
+    """Hardening wrapper around v2 workers.
+
+    Adds three fail-closed gates without changing the v1/v2 orchestrator:
+    1) core financial metrics require source + observed_at;
+    2) no-falsifier PASS requires an explicit completed Red Team review;
+    3) explicit temporal supersession removes stale contradiction edges only when
+       the newer observation declares that it supersedes prior evidence.
+    """
+
+    def __init__(self) -> None:
+        self._base = WorkerCoordinator()
+
+    def run(
+        self,
+        packet: WorkerPacket,
+        *,
+        falsifier_review_complete: bool,
+    ) -> tuple[SpecialistResult, ...]:
+        filtered = WorkerPacket(
+            observations=_temporal_filter(packet.observations),
+            confirmed_falsifiers=packet.confirmed_falsifiers,
+            policies=packet.policies,
+        )
+        results = list(self._base.run(filtered))
+        by_specialist = {result.specialist: index for index, result in enumerate(results)}
+        observations_by_key: dict[str, list[MetricObservation]] = defaultdict(list)
+        for item in filtered.observations:
+            observations_by_key[item.key].append(item)
+
+        provenance_gaps: dict[str, list[str]] = {}
+        for specialist, keys in _CRITICAL_PROVENANCE.items():
+            missing: list[str] = []
+            for key in keys:
+                candidates = observations_by_key.get(key, [])
+                if not candidates or not any(item.source.strip() and item.observed_at.strip() for item in candidates):
+                    missing.append(key)
+            if missing:
+                index = by_specialist[specialist]
+                results[index] = _replace_state(
+                    results[index],
+                    GateState.NOT_EVALUATED,
+                    "critical metric provenance incomplete: " + ", ".join(missing),
+                    provenanceGap=missing,
+                    failClosed=True,
+                )
+                provenance_gaps[specialist.value] = missing
+
+        falsifier_index = by_specialist[Specialist.FALSIFIERS]
+        falsifier_result = results[falsifier_index]
+        if not packet.confirmed_falsifiers and not falsifier_review_complete:
+            results[falsifier_index] = _replace_state(
+                falsifier_result,
+                GateState.NOT_EVALUATED,
+                "Falsifiers Ω review has not been explicitly completed",
+                reviewComplete=False,
+                failClosed=True,
+            )
+
+        director_index = by_specialist[Specialist.EVIDENCE_DIRECTOR]
+        director = results[director_index]
+        unresolved_governance = bool(provenance_gaps) or (
+            not packet.confirmed_falsifiers and not falsifier_review_complete
+        )
+        if unresolved_governance and director.gate_state is GateState.PASS:
+            reasons: list[str] = []
+            if provenance_gaps:
+                reasons.append("critical provenance gaps")
+            if not packet.confirmed_falsifiers and not falsifier_review_complete:
+                reasons.append("Falsifiers review incomplete")
+            results[director_index] = _replace_state(
+                director,
+                GateState.WATCH,
+                "governance review incomplete: " + "; ".join(reasons),
+                governanceWatch=True,
+                provenanceGaps=provenance_gaps,
+                falsifierReviewComplete=falsifier_review_complete,
+            )
+        else:
+            results[director_index] = replace(
+                director,
+                metadata={
+                    **director.metadata,
+                    "provenanceGaps": provenance_gaps,
+                    "falsifierReviewComplete": falsifier_review_complete,
+                },
+            )
+
+        return tuple(results)

--- a/runtime/agentic_omega/test_hardening.py
+++ b/runtime/agentic_omega/test_hardening.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from runtime.agentic_omega import GateState, MetricObservation, Specialist, WorkerPacket
+from runtime.agentic_omega.durable_ledger import DurableAgenticLedger
+from runtime.agentic_omega.hardening import GovernedWorkerCoordinator
+
+
+def _obs(key: str, value, *, source: str = "primary:test", observed_at: str = "2026-08-17", polarity: int = 0, **metadata) -> MetricObservation:
+    return MetricObservation(
+        key=key,
+        value=value,
+        source=source,
+        observed_at=observed_at,
+        confidence=0.95,
+        source_type="primary",
+        freshness_days=1,
+        polarity=polarity,
+        metadata=metadata,
+    )
+
+
+def _packet(extra=()) -> WorkerPacket:
+    return WorkerPacket(
+        observations=(
+            _obs("demand_growth", 0.20),
+            _obs("capture_growth", 0.15),
+            _obs("fcf_conversion", 0.30),
+            _obs("roic", 0.22),
+            _obs("expected_return_annualized", 0.15),
+            _obs("hurdle_rate", 0.10),
+            _obs("incremental_roic", 0.18),
+            _obs("capex_payback_years", 3),
+            _obs("wacc", 0.08),
+            _obs("moat_score", 82),
+            _obs("moat_erosion_confirmed", False),
+            _obs("institutional_flow_score", 72),
+            _obs("macro_regime_support_score", 55),
+        ) + tuple(extra)
+    )
+
+
+def test_falsifiers_review_incomplete_is_fail_closed() -> None:
+    results = GovernedWorkerCoordinator().run(_packet(), falsifier_review_complete=False)
+    falsifier = next(result for result in results if result.specialist is Specialist.FALSIFIERS)
+    director = next(result for result in results if result.specialist is Specialist.EVIDENCE_DIRECTOR)
+    assert falsifier.gate_state is GateState.NOT_EVALUATED
+    assert director.gate_state is GateState.WATCH
+
+
+def test_confirmed_falsifier_veto_does_not_require_review_complete_flag() -> None:
+    packet = WorkerPacket(
+        observations=_packet().observations,
+        confirmed_falsifiers=("confirmed fraud",),
+    )
+    results = GovernedWorkerCoordinator().run(packet, falsifier_review_complete=False)
+    falsifier = next(result for result in results if result.specialist is Specialist.FALSIFIERS)
+    assert falsifier.gate_state is GateState.VETO
+    assert falsifier.confirmed_falsifier is True
+
+
+def test_temporal_supersession_removes_only_explicitly_superseded_conflict() -> None:
+    packet = _packet(
+        extra=(
+            _obs("moat_intact", False, source="old:test", observed_at="2026-07-01", polarity=-1),
+            _obs(
+                "moat_intact",
+                True,
+                source="new:test",
+                observed_at="2026-08-17",
+                polarity=1,
+                supersedes_previous=True,
+            ),
+        )
+    )
+    results = GovernedWorkerCoordinator().run(packet, falsifier_review_complete=True)
+    director = next(result for result in results if result.specialist is Specialist.EVIDENCE_DIRECTOR)
+    assert director.metadata["contradictions"] == []
+
+
+def test_durable_ledger_refreshes_stale_instance_before_append(tmp_path) -> None:
+    path = tmp_path / "events.jsonl"
+    first = DurableAgenticLedger(path)
+    second = DurableAgenticLedger(path)
+    first.append("A", {"n": 1})
+    second.append("B", {"n": 2})
+    first.append("C", {"n": 3})
+    refreshed = DurableAgenticLedger(path)
+    assert [event["event_type"] for event in refreshed.events] == ["A", "B", "C"]
+    assert refreshed.verify() is True


### PR DESCRIPTION
## Hardening scope

Post-v2 review found two fail-open edges and this PR closes both.

### 1. Falsifiers review completeness
An empty confirmed-falsifier list no longer implies Red Team work was performed. `falsifier_review_complete` defaults false. Without an explicit completed review, Falsifiers Ω becomes `NOT_EVALUATED` and Evidence Director Ω becomes `WATCH`. Confirmed falsifiers still veto immediately regardless of the flag.

### 2. Critical metric provenance
Economic Proof, Valuation, CAPEX Productivity and Moat worker inputs require source + observed_at. Numeric values without provenance are converted to `NOT_EVALUATED` rather than being used as hard evidence.

### 3. Durable ledger
Adds `DurableAgenticLedger`: process lock + OS file lock (where available), reload, full hash-chain verify, append from current tail. Operational v1/v2 API now shares this durable ledger.

### 4. Explicit temporal supersession
Newer evidence only removes older contradiction edges when it explicitly declares `metadata.supersedes_previous=true`; chronology alone never erases conflicting evidence.

### Tests
Extends focused Agentic Runtime CI with hardening tests plus API tests for incomplete Red Team review and missing critical provenance.

### Invariants
No majority voting. Falsifiers veto remains absolute. CORE-00 untouched. External evidence remains non-canonical by default. READY_FOR_EXECUTION_GATE is not BUY/SELL. Broker execution remains separate. Evolution remains proposal-only.