### PR TITLE
Agentic Runtime Ω v2.2: governed evidence-envelope bridge

### DIFF
--- a/.github/workflows/agentic-runtime-v2.yml
+++ b/.github/workflows/agentic-runtime-v2.yml
@@ -6,7 +6,9 @@ on:
       - "runtime/agentic_omega/**"
       - "api/agentic_omega.py"
       - "api/agentic_omega_v2.py"
+      - "api/agentic_evidence_bridge.py"
       - "api/test_agentic_omega_v2.py"
+      - "api/test_agentic_evidence_bridge.py"
       - "api/app.py"
       - ".github/workflows/agentic-runtime-v2.yml"
   workflow_dispatch:
@@ -29,4 +31,6 @@ jobs:
           runtime/agentic_omega/test_orchestrator.py
           runtime/agentic_omega/test_v2.py
           runtime/agentic_omega/test_hardening.py
+          runtime/agentic_omega/test_evidence_adapter.py
           api/test_agentic_omega_v2.py
+          api/test_agentic_evidence_bridge.py

--- a/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA_V2_2_EVIDENCE_BRIDGE.md
+++ b/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA_V2_2_EVIDENCE_BRIDGE.md
@@ -1,0 +1,117 @@
+# ATLAS Ω — Agentic Runtime Ω v2.2 Evidence Bridge
+
+**Status:** IMPLEMENTED · MERGE CANDIDATE
+**Effective:** 2026-08-17
+**Extends:** Agentic Runtime Ω v2.1 Hardening.
+
+## Purpose
+
+Connect governed Agent Infrastructure Ω evidence envelopes to the executable Agentic Runtime Ω without introducing prose extraction, automatic canon promotion or hidden observation dates.
+
+## Pipeline
+
+`Agent Infrastructure EvidenceEnvelope → explicit metadata.metrics → EvidenceEnvelopeAdapter → MetricObservation candidates → v2.1 provenance/Red-Team/Evidence-Director gates → eight workers → OutcomeReceipt`
+
+The bridge is intentionally narrow. It does not treat arbitrary scraped/document text as structured investment evidence.
+
+## Input contract
+
+The bridge consumes the existing `EvidenceEnvelope` from `api/agent_infrastructure.py` and only adapts metric objects explicitly supplied under:
+
+`metadata.metrics[]`
+
+Each metric may contain:
+
+- `key`;
+- `value`;
+- `observed_at`;
+- `confidence`;
+- `freshness_days`;
+- `unit`;
+- `polarity`;
+- `metadata`.
+
+`key` and `value` are required for conversion. Malformed metrics are rejected rather than guessed.
+
+## Provenance invariants
+
+The resulting `MetricObservation` preserves:
+
+- envelope source;
+- envelope source type (`web`, `document`, `api`, `memory`);
+- content hash;
+- envelope retrieval timestamp in metadata;
+- evidence classification;
+- provider metadata;
+- metric-specific observation time when supplied.
+
+### Retrieval time is not observation time
+
+`retrieved_at` is never copied into `MetricObservation.observed_at`. It proves when ATLAS acquired the envelope, not when the underlying economic fact occurred. A critical metric lacking its own `observed_at` therefore fails the v2.1 critical-provenance gate.
+
+## Candidate-only law
+
+All adapted metrics carry:
+
+- `evidenceCandidateOnly=true`;
+- `autoCanonical=false`.
+
+Even if an inbound envelope claims `canonical=true`, the bridge records that claim only as metadata and does not promote the metric. Canonical authority remains downstream of ATLAS evidence governance.
+
+## No prose extraction
+
+The adapter never:
+
+- parses envelope `content` for numbers;
+- uses LLM-generated semantic extraction;
+- infers missing metric keys;
+- infers units;
+- invents polarity;
+- substitutes retrieval timestamps for observation dates.
+
+An envelope containing useful prose but no explicit `metadata.metrics` produces zero observations and the worker system fails closed to `WATCH/NOT_EVALUATED` as applicable.
+
+## Evidence weighting
+
+`source_type` is preserved so Evidence Director Ω continues to apply its v2 source-quality weights. In particular, `memory` remains materially lower-weight than primary/regulatory/company-quality evidence.
+
+## API
+
+New router: `api/agentic_evidence_bridge.py`.
+
+Endpoints:
+
+- `GET /v1/agentic-omega/v2/evidence-capabilities`;
+- `POST /v1/agentic-omega/v2/from-evidence`.
+
+The execution endpoint shares the v2.1 `DurableAgenticLedger`, governance lock, `GovernedWorkerCoordinator` and `RunRecovery` chain. It emits an append-only `EVIDENCE_ADAPTER_RECEIPT` containing adapter counts and envelope content hashes.
+
+## Guardrails
+
+- `parseEnvelopeProse=false`;
+- `externalEvidenceAutoCanonical=false`;
+- `retrievalTimeIsObservationTime=false`;
+- Falsifiers review completion required;
+- critical metric provenance required;
+- `READY_FOR_EXECUTION_GATE` is not a trade instruction;
+- bridge `decisionAuthority=false`.
+
+## Tests
+
+The focused suite covers:
+
+1. explicit structured metric conversion;
+2. no prose parsing without `metadata.metrics`;
+3. retrieval timestamp never substitutes economic observation time;
+4. inbound canonical claim cannot auto-promote a metric;
+5. memory source type remains preserved;
+6. malformed metrics are rejected;
+7. full structured envelope can reach only `READY_FOR_EXECUTION_GATE`, never a trade;
+8. unstructured envelope fails closed;
+9. missing metric observation date fails critical provenance downstream.
+
+The existing Agentic Runtime v2 CI workflow is extended to execute both runtime adapter tests and API bridge tests in addition to all v1/v2/v2.1 suites.
+
+## Invariants preserved
+
+No majority voting. Falsifiers Ω retains absolute independent veto. External infrastructure has no investment-decision authority. Evidence candidates remain non-canonical by default. Broker execution remains separate. Evolution remains proposal-only. CORE-00 remains frozen.

--- a/api/agentic_evidence_bridge.py
+++ b/api/agentic_evidence_bridge.py
@@ -27,6 +27,23 @@ class EvidenceWorkerRunRequest(BaseModel):
     no_opportunity: bool = False
 
 
+@router.get("/evidence-capabilities")
+def evidence_bridge_capabilities() -> dict[str, Any]:
+    return {
+        "engine": "Agentic Runtime Ω",
+        "version": "2.2-evidence-bridge",
+        "inputContract": "Agent Infrastructure EvidenceEnvelope",
+        "structuredMetricPath": "metadata.metrics",
+        "parseEnvelopeProse": False,
+        "externalEvidenceAutoCanonical": False,
+        "retrievalTimeIsObservationTime": False,
+        "contentHashPreserved": True,
+        "sourceTypePreserved": True,
+        "candidateOnly": True,
+        "decisionAuthority": False,
+    }
+
+
 @router.post("/from-evidence")
 def run_from_governed_evidence(request: EvidenceWorkerRunRequest) -> dict[str, Any]:
     """Run ATLAS workers from explicit structured metrics inside evidence envelopes.

--- a/api/agentic_evidence_bridge.py
+++ b/api/agentic_evidence_bridge.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from api.agent_infrastructure import EvidenceEnvelope
+from api.agentic_omega import _ENGINE, _ENGINE_LOCK
+from runtime.agentic_omega import EvidenceEnvelopeAdapter, RunRecovery, WorkerPacket
+from runtime.agentic_omega.hardening import GovernedWorkerCoordinator
+
+
+router = APIRouter(prefix="/v1/agentic-omega/v2", tags=["agentic-evidence-bridge"])
+_ADAPTER = EvidenceEnvelopeAdapter()
+_COORDINATOR = GovernedWorkerCoordinator()
+_RECOVERY = RunRecovery(_ENGINE.ledger)
+
+
+class EvidenceWorkerRunRequest(BaseModel):
+    objective: str = Field(min_length=1, max_length=1000)
+    context: dict[str, Any] = Field(default_factory=dict)
+    envelopes: list[EvidenceEnvelope] = Field(default_factory=list)
+    confirmed_falsifiers: list[str] = Field(default_factory=list)
+    falsifier_review_complete: bool = False
+    policies: dict[str, dict[str, float]] = Field(default_factory=dict)
+    no_opportunity: bool = False
+
+
+@router.post("/from-evidence")
+def run_from_governed_evidence(request: EvidenceWorkerRunRequest) -> dict[str, Any]:
+    """Run ATLAS workers from explicit structured metrics inside evidence envelopes.
+
+    Envelope prose/content is never parsed here. Only ``metadata.metrics`` is
+    adapted, and every resulting observation remains candidate-only until the
+    Agentic Runtime evidence gates pass it.
+    """
+    adapted = _ADAPTER.adapt(envelope.model_dump(mode="python") for envelope in request.envelopes)
+    packet = WorkerPacket(
+        observations=adapted.observations,
+        confirmed_falsifiers=tuple(request.confirmed_falsifiers),
+        policies=request.policies,
+    )
+    try:
+        with _ENGINE_LOCK:
+            run = _ENGINE.start_run(request.objective, request.context)
+            _RECOVERY.snapshot_context(run)
+            results = _COORDINATOR.run(
+                packet,
+                falsifier_review_complete=request.falsifier_review_complete,
+            )
+            for result in results:
+                _ENGINE.submit_result(run, result)
+            receipt = _ENGINE.finalize(run, no_opportunity=request.no_opportunity)
+            _ENGINE.ledger.append(
+                "EVIDENCE_ADAPTER_RECEIPT",
+                {
+                    "run_id": run.run_id,
+                    **adapted.to_dict(),
+                    "envelopeContentHashes": [item.content_hash for item in request.envelopes],
+                },
+            )
+            return {
+                "engine": "Agentic Runtime Ω",
+                "version": "2.2-evidence-bridge",
+                "runId": run.run_id,
+                "adapter": adapted.to_dict(),
+                "receipt": receipt.to_dict(),
+                "results": [result.to_dict() for result in results],
+                "guardrails": {
+                    "parseEnvelopeProse": False,
+                    "externalEvidenceAutoCanonical": False,
+                    "retrievalTimeIsObservationTime": False,
+                    "falsifierReviewCompleteRequired": True,
+                    "criticalMetricProvenanceRequired": True,
+                    "readyForExecutionIsTrade": False,
+                },
+            }
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from api.agent_infrastructure import router as agent_infrastructure_router
+from api.agentic_evidence_bridge import router as agentic_evidence_bridge_router
 from api.agentic_omega import router as agentic_omega_router
 from api.agentic_omega_v2 import router as agentic_omega_v2_router
 from api.atlas_core import router as atlas_router
@@ -26,6 +27,7 @@ app.include_router(evidence_router)
 app.include_router(kronos_market_forecast_router)
 app.include_router(agentic_omega_router)
 app.include_router(agentic_omega_v2_router)
+app.include_router(agentic_evidence_bridge_router)
 app.include_router(agent_infrastructure_router)
 app.include_router(document_ingestion_router)
 

--- a/api/test_agentic_evidence_bridge.py
+++ b/api/test_agentic_evidence_bridge.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from api.agent_infrastructure import EvidenceEnvelope
+from api.agentic_evidence_bridge import EvidenceWorkerRunRequest, run_from_governed_evidence
+
+
+def _envelope(metrics, *, canonical=False, source_type="api") -> EvidenceEnvelope:
+    return EvidenceEnvelope(
+        source="provider:test",
+        source_type=source_type,
+        retrieved_at="2026-08-17T21:00:00+00:00",
+        content_hash="hash-test",
+        classification="FACT",
+        confidence=0.95,
+        canonical=canonical,
+        content="Structured provider payload.",
+        metadata={"provider": "test", "metrics": metrics},
+    )
+
+
+def _metrics():
+    observed = "2026-08-17"
+    return [
+        {"key": "demand_growth", "value": 0.20, "observed_at": observed},
+        {"key": "capture_growth", "value": 0.15, "observed_at": observed},
+        {"key": "fcf_conversion", "value": 0.30, "observed_at": observed},
+        {"key": "roic", "value": 0.22, "observed_at": observed},
+        {"key": "expected_return_annualized", "value": 0.15, "observed_at": observed},
+        {"key": "hurdle_rate", "value": 0.10, "observed_at": observed},
+        {"key": "incremental_roic", "value": 0.18, "observed_at": observed},
+        {"key": "capex_payback_years", "value": 3, "observed_at": observed},
+        {"key": "wacc", "value": 0.08, "observed_at": observed},
+        {"key": "moat_score", "value": 82, "observed_at": observed},
+        {"key": "moat_erosion_confirmed", "value": False, "observed_at": observed},
+        {"key": "institutional_flow_score", "value": 72, "observed_at": observed},
+        {"key": "macro_regime_support_score", "value": 55, "observed_at": observed},
+    ]
+
+
+def test_structured_envelope_can_reach_execution_gate_without_trade() -> None:
+    response = run_from_governed_evidence(
+        EvidenceWorkerRunRequest(
+            objective="bridge-smoke",
+            context={"ticker": "TEST"},
+            envelopes=[_envelope(_metrics())],
+            falsifier_review_complete=True,
+        )
+    )
+    assert response["adapter"]["observations"] == len(_metrics())
+    assert response["receipt"]["status"] == "READY_FOR_EXECUTION_GATE"
+    assert response["guardrails"]["readyForExecutionIsTrade"] is False
+    assert response["guardrails"]["externalEvidenceAutoCanonical"] is False
+
+
+def test_unstructured_envelope_fails_closed() -> None:
+    envelope = _envelope([])
+    envelope.metadata = {"provider": "test"}
+    response = run_from_governed_evidence(
+        EvidenceWorkerRunRequest(
+            objective="bridge-no-metrics",
+            envelopes=[envelope],
+            falsifier_review_complete=True,
+        )
+    )
+    assert response["adapter"]["observations"] == 0
+    assert response["receipt"]["status"] == "WATCH"
+
+
+def test_missing_metric_observed_at_is_not_filled_from_retrieved_at() -> None:
+    metrics = _metrics()
+    metrics[0] = {"key": "demand_growth", "value": 0.20}
+    response = run_from_governed_evidence(
+        EvidenceWorkerRunRequest(
+            objective="bridge-missing-date",
+            envelopes=[_envelope(metrics)],
+            falsifier_review_complete=True,
+        )
+    )
+    economic = response["results"][0]
+    assert economic["gate_state"] == "NOT_EVALUATED"
+    assert "demand_growth" in economic["metadata"]["provenanceGap"]
+    assert response["receipt"]["status"] == "WATCH"
+
+
+def test_canonical_envelope_claim_still_remains_candidate_only() -> None:
+    response = run_from_governed_evidence(
+        EvidenceWorkerRunRequest(
+            objective="bridge-canonical-claim",
+            envelopes=[_envelope(_metrics(), canonical=True)],
+            falsifier_review_complete=True,
+        )
+    )
+    assert response["adapter"]["autoCanonical"] is False
+    assert response["guardrails"]["externalEvidenceAutoCanonical"] is False

--- a/runtime/agentic_omega/__init__.py
+++ b/runtime/agentic_omega/__init__.py
@@ -30,6 +30,7 @@ from .calibration import CalibrationEngine, CalibrationResult, PredictionRecord
 from .recovery import RecoveredRunView, RunRecovery
 from .durable_ledger import DurableAgenticLedger
 from .hardening import GovernedWorkerCoordinator
+from .evidence_adapter import EvidenceAdapterResult, EvidenceEnvelopeAdapter
 
 __all__ = [
     "AgenticOmegaOrchestrator",
@@ -51,6 +52,8 @@ __all__ = [
     "WorkerPacket",
     "WorkerCoordinator",
     "GovernedWorkerCoordinator",
+    "EvidenceAdapterResult",
+    "EvidenceEnvelopeAdapter",
     "PredictionRecord",
     "CalibrationResult",
     "CalibrationEngine",

--- a/runtime/agentic_omega/evidence_adapter.py
+++ b/runtime/agentic_omega/evidence_adapter.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .workers import MetricObservation
+
+
+@dataclass(frozen=True)
+class EvidenceAdapterResult:
+    observations: tuple[MetricObservation, ...]
+    envelopes_seen: int
+    structured_metrics_seen: int
+    rejected_metrics: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "observations": len(self.observations),
+            "envelopesSeen": self.envelopes_seen,
+            "structuredMetricsSeen": self.structured_metrics_seen,
+            "rejectedMetrics": self.rejected_metrics,
+            "candidateOnly": True,
+            "autoCanonical": False,
+        }
+
+
+class EvidenceEnvelopeAdapter:
+    """Convert only explicitly structured envelope metadata into metric candidates.
+
+    This adapter deliberately does not parse prose, infer numbers from content, or
+    promote an Agent Infrastructure envelope to canonical evidence. A provider or
+    upstream parser must place explicit metric objects in ``metadata.metrics``.
+
+    Metric observation time is never substituted with envelope retrieval time:
+    retrieval time proves when ATLAS acquired the evidence, not when the economic
+    fact was observed. Missing metric ``observed_at`` therefore remains missing and
+    will fail the v2.1 critical-provenance gate where applicable.
+    """
+
+    @staticmethod
+    def _mapping(value: Any) -> Mapping[str, Any] | None:
+        return value if isinstance(value, Mapping) else None
+
+    def adapt(self, envelopes: Iterable[Mapping[str, Any]]) -> EvidenceAdapterResult:
+        observations: list[MetricObservation] = []
+        envelope_count = 0
+        metric_count = 0
+        rejected = 0
+
+        for raw_envelope in envelopes:
+            envelope_count += 1
+            envelope = self._mapping(raw_envelope)
+            if envelope is None:
+                continue
+            metadata = self._mapping(envelope.get("metadata")) or {}
+            metrics = metadata.get("metrics")
+            if not isinstance(metrics, list):
+                continue
+
+            source = str(envelope.get("source") or "")
+            source_type = str(envelope.get("source_type") or "unspecified")
+            envelope_confidence = envelope.get("confidence")
+            retrieved_at = str(envelope.get("retrieved_at") or "")
+            content_hash = str(envelope.get("content_hash") or "")
+            classification = str(envelope.get("classification") or "UNCLASSIFIED")
+            envelope_canonical = bool(envelope.get("canonical", False))
+
+            for raw_metric in metrics:
+                metric_count += 1
+                metric = self._mapping(raw_metric)
+                if metric is None:
+                    rejected += 1
+                    continue
+                key = str(metric.get("key") or "").strip()
+                if not key or "value" not in metric:
+                    rejected += 1
+                    continue
+                confidence = metric.get("confidence", envelope_confidence)
+                try:
+                    parsed_confidence = None if confidence is None else float(confidence)
+                    if parsed_confidence is not None and not 0 <= parsed_confidence <= 1:
+                        raise ValueError
+                    freshness = metric.get("freshness_days")
+                    parsed_freshness = None if freshness is None else int(freshness)
+                    polarity = int(metric.get("polarity", 0))
+                    observation = MetricObservation(
+                        key=key,
+                        value=metric["value"],
+                        source=source,
+                        observed_at=str(metric.get("observed_at") or ""),
+                        confidence=parsed_confidence,
+                        source_type=source_type,
+                        freshness_days=parsed_freshness,
+                        unit=str(metric.get("unit") or ""),
+                        polarity=polarity,
+                        metadata={
+                            **(dict(self._mapping(metric.get("metadata")) or {})),
+                            "evidenceCandidateOnly": True,
+                            "autoCanonical": False,
+                            "envelopeCanonicalClaim": envelope_canonical,
+                            "envelopeRetrievedAt": retrieved_at,
+                            "contentHash": content_hash,
+                            "classification": classification,
+                            "provider": metadata.get("provider"),
+                        },
+                    )
+                except (TypeError, ValueError):
+                    rejected += 1
+                    continue
+                observations.append(observation)
+
+        return EvidenceAdapterResult(
+            observations=tuple(observations),
+            envelopes_seen=envelope_count,
+            structured_metrics_seen=metric_count,
+            rejected_metrics=rejected,
+        )

--- a/runtime/agentic_omega/test_evidence_adapter.py
+++ b/runtime/agentic_omega/test_evidence_adapter.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from runtime.agentic_omega import EvidenceEnvelopeAdapter
+
+
+def _envelope(*, metrics=None, canonical=False, source_type="web"):
+    return {
+        "source": "https://example.test/source",
+        "source_type": source_type,
+        "retrieved_at": "2026-08-17T21:00:00+00:00",
+        "content_hash": "abc123",
+        "classification": "FACT",
+        "confidence": 0.9,
+        "canonical": canonical,
+        "content": "Revenue grew 20%.",
+        "metadata": {"provider": "test", **({"metrics": metrics} if metrics is not None else {})},
+    }
+
+
+def test_adapter_only_reads_explicit_structured_metrics() -> None:
+    result = EvidenceEnvelopeAdapter().adapt([
+        _envelope(metrics=[{"key": "demand_growth", "value": 0.20, "observed_at": "2026-06-30"}])
+    ])
+    assert len(result.observations) == 1
+    observation = result.observations[0]
+    assert observation.key == "demand_growth"
+    assert observation.value == 0.20
+    assert observation.observed_at == "2026-06-30"
+    assert observation.metadata["evidenceCandidateOnly"] is True
+    assert observation.metadata["autoCanonical"] is False
+
+
+def test_adapter_does_not_parse_prose_without_metrics() -> None:
+    result = EvidenceEnvelopeAdapter().adapt([_envelope(metrics=None)])
+    assert result.observations == ()
+    assert result.structured_metrics_seen == 0
+
+
+def test_retrieval_time_never_substitutes_metric_observation_time() -> None:
+    result = EvidenceEnvelopeAdapter().adapt([
+        _envelope(metrics=[{"key": "roic", "value": 0.21}])
+    ])
+    assert len(result.observations) == 1
+    observation = result.observations[0]
+    assert observation.observed_at == ""
+    assert observation.metadata["envelopeRetrievedAt"] == "2026-08-17T21:00:00+00:00"
+
+
+def test_envelope_canonical_claim_does_not_auto_promote_metric() -> None:
+    result = EvidenceEnvelopeAdapter().adapt([
+        _envelope(
+            canonical=True,
+            metrics=[{"key": "moat_score", "value": 85, "observed_at": "2026-08-17"}],
+        )
+    ])
+    observation = result.observations[0]
+    assert observation.metadata["envelopeCanonicalClaim"] is True
+    assert observation.metadata["autoCanonical"] is False
+    assert result.to_dict()["autoCanonical"] is False
+
+
+def test_memory_source_type_is_preserved_for_lower_evidence_weight() -> None:
+    result = EvidenceEnvelopeAdapter().adapt([
+        _envelope(
+            source_type="memory",
+            metrics=[{"key": "macro_regime_support_score", "value": 60, "observed_at": "2026-08-17"}],
+        )
+    ])
+    assert result.observations[0].source_type == "memory"
+
+
+def test_malformed_metric_is_rejected_not_guessed() -> None:
+    result = EvidenceEnvelopeAdapter().adapt([
+        _envelope(metrics=[{"value": 1}, {"key": "roic"}, "bad"])
+    ])
+    assert result.observations == ()
+    assert result.structured_metrics_seen == 3
+    assert result.rejected_metrics == 3


### PR DESCRIPTION
## Scope

Connects the governed Agent Infrastructure Ω `EvidenceEnvelope` contract to Agentic Runtime Ω without prose extraction or automatic evidence promotion.

### Strict adapter
- Converts only explicit `metadata.metrics[]` objects.
- Never parses envelope prose/content for numbers.
- Never substitutes `retrieved_at` for metric `observed_at`.
- Preserves source type, content hash, classification, provider and retrieval timestamp.
- Malformed metric objects are rejected, not guessed.

### Candidate-only governance
- Every adapted metric is `evidenceCandidateOnly=true` and `autoCanonical=false`.
- Even an inbound `canonical=true` envelope cannot auto-promote the metric.
- Memory source type remains preserved so Evidence Director Ω applies its lower evidence weight.

### API
- `GET /v1/agentic-omega/v2/evidence-capabilities`
- `POST /v1/agentic-omega/v2/from-evidence`
- Shares DurableAgenticLedger, GovernedWorkerCoordinator, RunRecovery and Falsifiers/provenance gates.
- Adds append-only `EVIDENCE_ADAPTER_RECEIPT` with content hashes and adapter counts.

### Tests
Adds runtime adapter tests and API bridge tests, and extends the existing Agentic Runtime v2 CI workflow to run them together with all v1/v2/v2.1 suites.

### Invariants
No majority voting. Falsifiers Ω retains absolute veto. External infrastructure remains non-canonical and has no decision authority. READY_FOR_EXECUTION_GATE is not BUY/SELL. Broker execution stays separate. CORE-00 untouched.