### PR TITLE
Agentic Runtime Ω v2.3: capability evidence and dual-persistence receipts

### DIFF
--- a/.github/workflows/agentic-runtime-v2.yml
+++ b/.github/workflows/agentic-runtime-v2.yml
@@ -7,8 +7,10 @@ on:
       - "api/agentic_omega.py"
       - "api/agentic_omega_v2.py"
       - "api/agentic_evidence_bridge.py"
+      - "api/agentic_governance.py"
       - "api/test_agentic_omega_v2.py"
       - "api/test_agentic_evidence_bridge.py"
+      - "api/test_agentic_governance.py"
       - "api/app.py"
       - ".github/workflows/agentic-runtime-v2.yml"
   workflow_dispatch:
@@ -32,5 +34,8 @@ jobs:
           runtime/agentic_omega/test_v2.py
           runtime/agentic_omega/test_hardening.py
           runtime/agentic_omega/test_evidence_adapter.py
+          runtime/agentic_omega/test_capability_evidence.py
+          runtime/agentic_omega/test_sync_receipts.py
           api/test_agentic_omega_v2.py
           api/test_agentic_evidence_bridge.py
+          api/test_agentic_governance.py

--- a/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA_V2_3_GOVERNANCE_EVIDENCE.md
+++ b/CURRENT_CANON/AGENTIC_RUNTIME_OMEGA_V2_3_GOVERNANCE_EVIDENCE.md
@@ -1,0 +1,119 @@
+# ATLAS Ω — Agentic Runtime Ω v2.3 Governance Evidence
+
+**Status:** IMPLEMENTED · MERGE CANDIDATE
+**Effective:** 2026-08-17
+**Extends:** Agentic Runtime Ω v2.2 Evidence Bridge.
+
+## Purpose
+
+Materialize two remaining governance requirements as executable evidence rather than narrative assumptions:
+
+1. model/tool capabilities must be tied to an exact route fingerprint and fail closed when unknown, failed or stale;
+2. GitHub + Notion dual persistence must produce an auditable receipt based on concrete identifiers, not intention.
+
+## Capability Evidence Ω
+
+`RouteDescriptor` fingerprints:
+
+- provider;
+- base URL;
+- model;
+- non-credential headers/beta controls;
+- route options.
+
+Credential headers such as Authorization/API keys are excluded from both the fingerprint inputs persisted as evidence and the safe route identity returned by the API. Rotating a credential therefore does not invalidate an otherwise identical capability route; changing model, beta/routing headers or options creates a distinct fingerprint.
+
+### Evidence statuses
+
+- `confirmed` — provider metadata, local health or a probe supplied evidence;
+- `asserted` — explicit owner acknowledgement;
+- `unprobeable` — capability could not be established;
+- `failed` — capability evidence attempt failed.
+
+Only `confirmed` and `asserted` are trusted states. An asserted record requires source `owner_ack`. Unknown/unprobeable/failed records fail closed.
+
+### Freshness
+
+Capability records may include `valid_until`. When `require_fresh=true`, expired or unparsable validity fails closed. Freshness policy remains explicit at the check call site.
+
+### Exact-route authorization
+
+Checks support:
+
+- boolean capability must be true;
+- numeric capability must meet an `at_least` threshold.
+
+An otherwise identical record under a different route fingerprint cannot authorize the new route.
+
+## Dual-Persistence Receipt Ω
+
+`DualPersistenceRegistry` records append-only receipts with:
+
+- `change_id`;
+- GitHub commit SHA;
+- optional GitHub path;
+- Notion page ID;
+- optional Notion URL;
+- timestamp/detail.
+
+State is computed mechanically:
+
+- both concrete IDs → `COMPLETE`;
+- GitHub only → `GITHUB_ONLY`;
+- Notion only → `NOTION_ONLY`;
+- neither → `INCOMPLETE`.
+
+`require_complete(change_id)` fails unless the latest receipt is `COMPLETE`.
+
+The registry does not execute connector writes itself and therefore cannot claim synchronization from requested/intended operations.
+
+## Durable concurrency
+
+Capability and persistence registries share the existing `DurableAgenticLedger`. Read paths call `refresh()` when supported before selecting the latest event, preventing another process's completed write from remaining invisible because of a stale in-memory view.
+
+## API
+
+New protected router: `api/agentic_governance.py` under `/v1/agentic-omega/v2/governance`.
+
+Endpoints:
+
+- `GET /capabilities`;
+- `POST /capability-evidence`;
+- `POST /capability-check`;
+- `POST /sync-receipts`;
+- `GET /sync-receipts/{change_id}`.
+
+Governance write endpoints use the existing `ATLAS_AGENT_CONTROL_TOKEN` gate. Capability checks and receipt reads return safe non-secret route/receipt evidence.
+
+## Security invariants
+
+- credential values are never persisted in capability route identity;
+- write endpoints require the agent control token;
+- unknown capability never authorizes;
+- stale capability does not authorize when fresh evidence is required;
+- owner assertion requires explicit `owner_ack` source;
+- GitHub-only persistence cannot be reported as COMPLETE;
+- Notion-only persistence cannot be reported as COMPLETE.
+
+## Tests
+
+Focused tests cover:
+
+1. credential rotation keeps the same route fingerprint;
+2. model/beta change creates a different route fingerprint;
+3. unknown and failed capability evidence fails closed;
+4. confirmed numeric capability is route-scoped;
+5. asserted evidence requires owner acknowledgement;
+6. stale capability fails a fresh check;
+7. credential values are absent from persisted capability events;
+8. dual persistence remains incomplete with one/no destination;
+9. a later complete receipt upgrades prior partial state;
+10. governance write endpoints reject an invalid control token;
+11. API capability check is fail-closed on a different route;
+12. API dual-persistence COMPLETE requires both concrete identifiers.
+
+The existing Agentic Runtime v2 CI workflow is extended again so this phase cannot regress any v1/v2/v2.1/v2.2 invariant.
+
+## Invariants preserved
+
+No majority voting. Falsifiers Ω absolute veto. External evidence remains candidate-only until admitted. Missing evidence is not positive evidence. READY_FOR_EXECUTION_GATE remains separate from BUY/SELL and broker execution. Evolution remains proposal-only. CORE-00 remains frozen.

--- a/api/agentic_governance.py
+++ b/api/agentic_governance.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from api.agent_infrastructure import _control
+from api.agentic_omega import _ENGINE, _ENGINE_LOCK
+from runtime.agentic_omega import (
+    CapabilityEvidenceRegistry,
+    CapabilitySource,
+    CapabilityStatus,
+    DualPersistenceRegistry,
+    RouteDescriptor,
+)
+
+
+router = APIRouter(prefix="/v1/agentic-omega/v2/governance", tags=["agentic-governance"])
+_CAPABILITIES = CapabilityEvidenceRegistry(_ENGINE.ledger)
+_SYNC = DualPersistenceRegistry(_ENGINE.ledger)
+
+
+class RoutePayload(BaseModel):
+    provider: str = Field(min_length=1, max_length=100)
+    base_url: str = Field(default="", max_length=1000)
+    model: str = Field(default="", max_length=300)
+    headers: dict[str, Any] = Field(default_factory=dict)
+    options: dict[str, Any] = Field(default_factory=dict)
+
+    def materialize(self) -> RouteDescriptor:
+        return RouteDescriptor(
+            provider=self.provider,
+            base_url=self.base_url,
+            model=self.model,
+            headers=self.headers,
+            options=self.options,
+        )
+
+
+class CapabilityRecordRequest(BaseModel):
+    route: RoutePayload
+    capability: str = Field(min_length=1, max_length=200)
+    value: bool | int | float | str | None = None
+    status: CapabilityStatus
+    source: CapabilitySource
+    observed_at: str | None = None
+    valid_until: str = ""
+    detail: str = Field(default="", max_length=4000)
+
+
+class CapabilityCheckRequest(BaseModel):
+    route: RoutePayload
+    capability: str = Field(min_length=1, max_length=200)
+    mode: Literal["boolean_true", "at_least"]
+    threshold: float | None = None
+    require_fresh: bool = True
+
+
+class SyncReceiptRequest(BaseModel):
+    change_id: str = Field(min_length=1, max_length=300)
+    github_commit_sha: str = Field(default="", max_length=100)
+    notion_page_id: str = Field(default="", max_length=200)
+    github_path: str = Field(default="", max_length=1000)
+    notion_url: str = Field(default="", max_length=2000)
+    detail: str = Field(default="", max_length=4000)
+
+
+@router.get("/capabilities")
+def governance_capabilities() -> dict[str, Any]:
+    return {
+        "engine": "Agentic Runtime Ω",
+        "version": "2.3-governance-evidence",
+        "routeFingerprinting": True,
+        "credentialValuesPersisted": False,
+        "unknownCapabilityFailsClosed": True,
+        "trustedStatuses": ["confirmed", "asserted"],
+        "ownerAssertionsRequire": "owner_ack",
+        "dualPersistenceReceipts": True,
+        "dualPersistenceCompleteRequires": ["github_commit_sha", "notion_page_id"],
+        "writeEndpointsRequireAgentControlToken": True,
+    }
+
+
+@router.post("/capability-evidence")
+def record_capability_evidence(
+    request: CapabilityRecordRequest,
+    x_atlas_agent_token: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _control(x_atlas_agent_token)
+    try:
+        with _ENGINE_LOCK:
+            record = _CAPABILITIES.record(
+                route=request.route.materialize(),
+                capability=request.capability,
+                value=request.value,
+                status=request.status,
+                source=request.source,
+                observed_at=request.observed_at,
+                valid_until=request.valid_until,
+                detail=request.detail,
+            )
+            return {
+                "record": record.to_dict(),
+                "route": request.route.materialize().safe_identity(),
+                "guardrail": "Credential header values are excluded from route identity and persistence.",
+            }
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/capability-check")
+def check_capability(request: CapabilityCheckRequest) -> dict[str, Any]:
+    route = request.route.materialize()
+    record = _CAPABILITIES.latest(route=route, capability=request.capability)
+    if request.mode == "boolean_true":
+        allowed = _CAPABILITIES.boolean_allows(
+            route=route,
+            capability=request.capability,
+            require_fresh=request.require_fresh,
+        )
+    else:
+        if request.threshold is None:
+            raise HTTPException(status_code=400, detail="threshold is required for at_least mode")
+        allowed = _CAPABILITIES.at_least(
+            route=route,
+            capability=request.capability,
+            threshold=request.threshold,
+            require_fresh=request.require_fresh,
+        )
+    return {
+        "route": route.safe_identity(),
+        "capability": request.capability,
+        "mode": request.mode,
+        "allowed": allowed,
+        "failClosed": True,
+        "evidence": record.to_dict() if record else None,
+    }
+
+
+@router.post("/sync-receipts")
+def record_sync_receipt(
+    request: SyncReceiptRequest,
+    x_atlas_agent_token: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _control(x_atlas_agent_token)
+    with _ENGINE_LOCK:
+        receipt = _SYNC.record(
+            change_id=request.change_id,
+            github_commit_sha=request.github_commit_sha,
+            notion_page_id=request.notion_page_id,
+            github_path=request.github_path,
+            notion_url=request.notion_url,
+            detail=request.detail,
+        )
+        return {
+            "receipt": receipt.to_dict(),
+            "complete": receipt.status.value == "COMPLETE",
+            "guardrail": "COMPLETE reflects concrete GitHub + Notion identifiers, not intended writes.",
+        }
+
+
+@router.get("/sync-receipts/{change_id}")
+def get_sync_receipt(change_id: str) -> dict[str, Any]:
+    receipt = _SYNC.latest(change_id)
+    if receipt is None:
+        raise HTTPException(status_code=404, detail="dual-persistence receipt not found")
+    return {
+        "receipt": receipt.to_dict(),
+        "complete": receipt.status.value == "COMPLETE",
+    }

--- a/api/app.py
+++ b/api/app.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 
 from api.agent_infrastructure import router as agent_infrastructure_router
 from api.agentic_evidence_bridge import router as agentic_evidence_bridge_router
+from api.agentic_governance import router as agentic_governance_router
 from api.agentic_omega import router as agentic_omega_router
 from api.agentic_omega_v2 import router as agentic_omega_v2_router
 from api.atlas_core import router as atlas_router
@@ -28,6 +29,7 @@ app.include_router(kronos_market_forecast_router)
 app.include_router(agentic_omega_router)
 app.include_router(agentic_omega_v2_router)
 app.include_router(agentic_evidence_bridge_router)
+app.include_router(agentic_governance_router)
 app.include_router(agent_infrastructure_router)
 app.include_router(document_ingestion_router)
 

--- a/api/test_agentic_governance.py
+++ b/api/test_agentic_governance.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+import api.agent_infrastructure as agent_infrastructure
+from api.agentic_governance import (
+    CapabilityCheckRequest,
+    CapabilityRecordRequest,
+    RoutePayload,
+    SyncReceiptRequest,
+    check_capability,
+    get_sync_receipt,
+    record_capability_evidence,
+    record_sync_receipt,
+)
+from runtime.agentic_omega import CapabilitySource, CapabilityStatus
+
+
+def _token() -> str:
+    agent_infrastructure.ATLAS_AGENT_CONTROL_TOKEN = "governance-test-token"
+    return "governance-test-token"
+
+
+def _route(model: str = "m") -> RoutePayload:
+    return RoutePayload(
+        provider="test-provider",
+        base_url="https://api.example.test/v1",
+        model=model,
+        headers={"Authorization": "Bearer SECRET", "x-beta": "large"},
+        options={"reasoning": "high"},
+    )
+
+
+def test_capability_write_requires_agent_control_token() -> None:
+    _token()
+    request = CapabilityRecordRequest(
+        route=_route(),
+        capability="tool_calling",
+        value=True,
+        status=CapabilityStatus.CONFIRMED,
+        source=CapabilitySource.LOCAL_HEALTH,
+    )
+    with pytest.raises(HTTPException) as exc:
+        record_capability_evidence(request, x_atlas_agent_token="wrong")
+    assert exc.value.status_code == 401
+
+
+def test_capability_record_and_fail_closed_check() -> None:
+    token = _token()
+    model = f"m-{uuid.uuid4().hex}"
+    route = _route(model)
+    response = record_capability_evidence(
+        CapabilityRecordRequest(
+            route=route,
+            capability="context_window_tokens",
+            value=1_000_000,
+            status=CapabilityStatus.CONFIRMED,
+            source=CapabilitySource.PROVIDER_METADATA,
+            valid_until="2099-01-01T00:00:00+00:00",
+        ),
+        x_atlas_agent_token=token,
+    )
+    assert response["record"]["status"] == "confirmed"
+    assert "headers" not in response["route"]
+    allowed = check_capability(
+        CapabilityCheckRequest(
+            route=route,
+            capability="context_window_tokens",
+            mode="at_least",
+            threshold=1_000_000,
+        )
+    )
+    assert allowed["allowed"] is True
+    unknown = check_capability(
+        CapabilityCheckRequest(
+            route=_route(model + "-other"),
+            capability="context_window_tokens",
+            mode="at_least",
+            threshold=1_000_000,
+        )
+    )
+    assert unknown["allowed"] is False
+    assert unknown["failClosed"] is True
+
+
+def test_sync_receipt_requires_both_destinations_for_complete() -> None:
+    token = _token()
+    change_id = f"change-{uuid.uuid4().hex}"
+    partial = record_sync_receipt(
+        SyncReceiptRequest(change_id=change_id, github_commit_sha="abc123"),
+        x_atlas_agent_token=token,
+    )
+    assert partial["complete"] is False
+    assert partial["receipt"]["status"] == "GITHUB_ONLY"
+    complete = record_sync_receipt(
+        SyncReceiptRequest(
+            change_id=change_id,
+            github_commit_sha="abc123",
+            notion_page_id="notion-page-test",
+            github_path="CURRENT_CANON/example.md",
+            notion_url="https://notion.test/page",
+        ),
+        x_atlas_agent_token=token,
+    )
+    assert complete["complete"] is True
+    assert complete["receipt"]["status"] == "COMPLETE"
+    latest = get_sync_receipt(change_id)
+    assert latest["complete"] is True

--- a/runtime/agentic_omega/__init__.py
+++ b/runtime/agentic_omega/__init__.py
@@ -31,6 +31,18 @@ from .recovery import RecoveredRunView, RunRecovery
 from .durable_ledger import DurableAgenticLedger
 from .hardening import GovernedWorkerCoordinator
 from .evidence_adapter import EvidenceAdapterResult, EvidenceEnvelopeAdapter
+from .capability_evidence import (
+    CapabilityEvidenceRecord,
+    CapabilityEvidenceRegistry,
+    CapabilitySource,
+    CapabilityStatus,
+    RouteDescriptor,
+)
+from .sync_receipts import (
+    DualPersistenceReceipt,
+    DualPersistenceRegistry,
+    DualPersistenceStatus,
+)
 
 __all__ = [
     "AgenticOmegaOrchestrator",
@@ -54,6 +66,14 @@ __all__ = [
     "GovernedWorkerCoordinator",
     "EvidenceAdapterResult",
     "EvidenceEnvelopeAdapter",
+    "CapabilityEvidenceRecord",
+    "CapabilityEvidenceRegistry",
+    "CapabilitySource",
+    "CapabilityStatus",
+    "RouteDescriptor",
+    "DualPersistenceReceipt",
+    "DualPersistenceRegistry",
+    "DualPersistenceStatus",
     "PredictionRecord",
     "CalibrationResult",
     "CalibrationEngine",

--- a/runtime/agentic_omega/capability_evidence.py
+++ b/runtime/agentic_omega/capability_evidence.py
@@ -117,6 +117,11 @@ class CapabilityEvidenceRegistry:
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed.astimezone(timezone.utc)
 
+    def _refresh_if_supported(self) -> None:
+        refresh = getattr(self.ledger, "refresh", None)
+        if callable(refresh):
+            refresh()
+
     @staticmethod
     def _validate_source(status: CapabilityStatus, source: CapabilitySource) -> None:
         if status is CapabilityStatus.CONFIRMED and source not in {
@@ -162,6 +167,7 @@ class CapabilityEvidenceRegistry:
         return record
 
     def latest(self, *, route: RouteDescriptor, capability: str) -> CapabilityEvidenceRecord | None:
+        self._refresh_if_supported()
         fingerprint = route.fingerprint()
         for event in reversed(self.ledger.events):
             if event.get("event_type") != "CAPABILITY_EVIDENCE_RECORDED":

--- a/runtime/agentic_omega/capability_evidence.py
+++ b/runtime/agentic_omega/capability_evidence.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping
+
+from .orchestrator import AppendOnlyEventLedger
+
+
+_CREDENTIAL_HEADERS = {
+    "authorization",
+    "proxy-authorization",
+    "api-key",
+    "x-api-key",
+    "x-goog-api-key",
+    "anthropic-api-key",
+    "openai-api-key",
+}
+
+
+class CapabilityStatus(str, Enum):
+    CONFIRMED = "confirmed"
+    ASSERTED = "asserted"
+    UNPROBEABLE = "unprobeable"
+    FAILED = "failed"
+
+
+class CapabilitySource(str, Enum):
+    PROVIDER_METADATA = "provider_metadata"
+    LOCAL_HEALTH = "local_health"
+    OWNER_ACK = "owner_ack"
+    PROBE = "probe"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class RouteDescriptor:
+    provider: str
+    base_url: str = ""
+    model: str = ""
+    headers: Mapping[str, Any] | None = None
+    options: Mapping[str, Any] | None = None
+
+    def fingerprint(self) -> str:
+        safe_headers = tuple(
+            sorted(
+                (str(key).lower(), str(value))
+                for key, value in (self.headers or {}).items()
+                if str(key).lower() not in _CREDENTIAL_HEADERS
+            )
+        )
+        options = tuple(sorted((str(key), str(value)) for key, value in (self.options or {}).items()))
+        payload = json.dumps(
+            {
+                "provider": self.provider.strip().lower(),
+                "base_url": self.base_url.strip().rstrip("/").lower(),
+                "model": self.model.strip(),
+                "headers": safe_headers,
+                "options": options,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+    def safe_identity(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider.strip().lower(),
+            "baseUrl": self.base_url.strip().rstrip("/"),
+            "model": self.model.strip(),
+            "routeFingerprint": self.fingerprint(),
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityEvidenceRecord:
+    evidence_id: str
+    route_fingerprint: str
+    capability: str
+    value: bool | int | float | str | None
+    status: CapabilityStatus
+    source: CapabilitySource
+    observed_at: str
+    valid_until: str = ""
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["status"] = self.status.value
+        data["source"] = self.source.value
+        return data
+
+
+class CapabilityEvidenceRegistry:
+    """Sourced route capability registry with fail-closed authorization checks."""
+
+    def __init__(self, ledger: AppendOnlyEventLedger) -> None:
+        self.ledger = ledger
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _parse_datetime(value: str) -> datetime | None:
+        if not value:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _validate_source(status: CapabilityStatus, source: CapabilitySource) -> None:
+        if status is CapabilityStatus.CONFIRMED and source not in {
+            CapabilitySource.PROVIDER_METADATA,
+            CapabilitySource.LOCAL_HEALTH,
+            CapabilitySource.PROBE,
+        }:
+            raise ValueError("confirmed capability evidence requires provider/local/probe source")
+        if status is CapabilityStatus.ASSERTED and source is not CapabilitySource.OWNER_ACK:
+            raise ValueError("asserted capability evidence requires owner_ack source")
+
+    def record(
+        self,
+        *,
+        route: RouteDescriptor,
+        capability: str,
+        value: bool | int | float | str | None,
+        status: CapabilityStatus,
+        source: CapabilitySource,
+        observed_at: str | None = None,
+        valid_until: str = "",
+        detail: str = "",
+    ) -> CapabilityEvidenceRecord:
+        capability = capability.strip()
+        if not capability:
+            raise ValueError("capability is required")
+        self._validate_source(status, source)
+        record = CapabilityEvidenceRecord(
+            evidence_id=uuid.uuid4().hex,
+            route_fingerprint=route.fingerprint(),
+            capability=capability,
+            value=value,
+            status=status,
+            source=source,
+            observed_at=observed_at or self._utc_now(),
+            valid_until=valid_until,
+            detail=detail,
+        )
+        self.ledger.append(
+            "CAPABILITY_EVIDENCE_RECORDED",
+            {**record.to_dict(), "route": route.safe_identity()},
+        )
+        return record
+
+    def latest(self, *, route: RouteDescriptor, capability: str) -> CapabilityEvidenceRecord | None:
+        fingerprint = route.fingerprint()
+        for event in reversed(self.ledger.events):
+            if event.get("event_type") != "CAPABILITY_EVIDENCE_RECORDED":
+                continue
+            payload = event.get("payload", {})
+            if payload.get("route_fingerprint") != fingerprint or payload.get("capability") != capability:
+                continue
+            return CapabilityEvidenceRecord(
+                evidence_id=str(payload["evidence_id"]),
+                route_fingerprint=str(payload["route_fingerprint"]),
+                capability=str(payload["capability"]),
+                value=payload.get("value"),
+                status=CapabilityStatus(str(payload["status"])),
+                source=CapabilitySource(str(payload["source"])),
+                observed_at=str(payload["observed_at"]),
+                valid_until=str(payload.get("valid_until") or ""),
+                detail=str(payload.get("detail") or ""),
+            )
+        return None
+
+    def is_trusted(self, record: CapabilityEvidenceRecord | None, *, require_fresh: bool = True) -> bool:
+        if record is None or record.status not in {CapabilityStatus.CONFIRMED, CapabilityStatus.ASSERTED}:
+            return False
+        if require_fresh and record.valid_until:
+            valid_until = self._parse_datetime(record.valid_until)
+            if valid_until is None or valid_until < datetime.now(timezone.utc):
+                return False
+        return True
+
+    def boolean_allows(self, *, route: RouteDescriptor, capability: str, require_fresh: bool = True) -> bool:
+        record = self.latest(route=route, capability=capability)
+        return self.is_trusted(record, require_fresh=require_fresh) and record.value is True
+
+    def at_least(
+        self,
+        *,
+        route: RouteDescriptor,
+        capability: str,
+        threshold: float,
+        require_fresh: bool = True,
+    ) -> bool:
+        record = self.latest(route=route, capability=capability)
+        if not self.is_trusted(record, require_fresh=require_fresh):
+            return False
+        if isinstance(record.value, bool) or not isinstance(record.value, (int, float)):
+            return False
+        return float(record.value) >= float(threshold)

--- a/runtime/agentic_omega/sync_receipts.py
+++ b/runtime/agentic_omega/sync_receipts.py
@@ -45,6 +45,11 @@ class DualPersistenceRegistry:
     def __init__(self, ledger: AppendOnlyEventLedger) -> None:
         self.ledger = ledger
 
+    def _refresh_if_supported(self) -> None:
+        refresh = getattr(self.ledger, "refresh", None)
+        if callable(refresh):
+            refresh()
+
     @staticmethod
     def _status(github_commit_sha: str, notion_page_id: str) -> DualPersistenceStatus:
         github = bool(github_commit_sha.strip())
@@ -85,6 +90,7 @@ class DualPersistenceRegistry:
         return receipt
 
     def latest(self, change_id: str) -> DualPersistenceReceipt | None:
+        self._refresh_if_supported()
         for event in reversed(self.ledger.events):
             if event.get("event_type") != "DUAL_PERSISTENCE_RECEIPT":
                 continue

--- a/runtime/agentic_omega/sync_receipts.py
+++ b/runtime/agentic_omega/sync_receipts.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from .orchestrator import AppendOnlyEventLedger
+
+
+class DualPersistenceStatus(str, Enum):
+    COMPLETE = "COMPLETE"
+    GITHUB_ONLY = "GITHUB_ONLY"
+    NOTION_ONLY = "NOTION_ONLY"
+    INCOMPLETE = "INCOMPLETE"
+
+
+@dataclass(frozen=True)
+class DualPersistenceReceipt:
+    receipt_id: str
+    change_id: str
+    github_commit_sha: str
+    notion_page_id: str
+    github_path: str = ""
+    notion_url: str = ""
+    created_at: str = ""
+    status: DualPersistenceStatus = DualPersistenceStatus.INCOMPLETE
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["status"] = self.status.value
+        return data
+
+
+class DualPersistenceRegistry:
+    """Auditable receipts for the GitHub + Notion synchronization law.
+
+    The registry does not perform connector writes itself and therefore never
+    claims persistence from intent alone. COMPLETE requires concrete identifiers
+    for both the GitHub commit and the Notion page.
+    """
+
+    def __init__(self, ledger: AppendOnlyEventLedger) -> None:
+        self.ledger = ledger
+
+    @staticmethod
+    def _status(github_commit_sha: str, notion_page_id: str) -> DualPersistenceStatus:
+        github = bool(github_commit_sha.strip())
+        notion = bool(notion_page_id.strip())
+        if github and notion:
+            return DualPersistenceStatus.COMPLETE
+        if github:
+            return DualPersistenceStatus.GITHUB_ONLY
+        if notion:
+            return DualPersistenceStatus.NOTION_ONLY
+        return DualPersistenceStatus.INCOMPLETE
+
+    def record(
+        self,
+        *,
+        change_id: str,
+        github_commit_sha: str = "",
+        notion_page_id: str = "",
+        github_path: str = "",
+        notion_url: str = "",
+        detail: str = "",
+    ) -> DualPersistenceReceipt:
+        change_id = change_id.strip()
+        if not change_id:
+            raise ValueError("change_id is required")
+        receipt = DualPersistenceReceipt(
+            receipt_id=uuid.uuid4().hex,
+            change_id=change_id,
+            github_commit_sha=github_commit_sha.strip(),
+            notion_page_id=notion_page_id.strip(),
+            github_path=github_path.strip(),
+            notion_url=notion_url.strip(),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            status=self._status(github_commit_sha, notion_page_id),
+            detail=detail,
+        )
+        self.ledger.append("DUAL_PERSISTENCE_RECEIPT", receipt.to_dict())
+        return receipt
+
+    def latest(self, change_id: str) -> DualPersistenceReceipt | None:
+        for event in reversed(self.ledger.events):
+            if event.get("event_type") != "DUAL_PERSISTENCE_RECEIPT":
+                continue
+            payload = event.get("payload", {})
+            if payload.get("change_id") != change_id:
+                continue
+            return DualPersistenceReceipt(
+                receipt_id=str(payload["receipt_id"]),
+                change_id=str(payload["change_id"]),
+                github_commit_sha=str(payload.get("github_commit_sha") or ""),
+                notion_page_id=str(payload.get("notion_page_id") or ""),
+                github_path=str(payload.get("github_path") or ""),
+                notion_url=str(payload.get("notion_url") or ""),
+                created_at=str(payload.get("created_at") or ""),
+                status=DualPersistenceStatus(str(payload["status"])),
+                detail=str(payload.get("detail") or ""),
+            )
+        return None
+
+    def require_complete(self, change_id: str) -> DualPersistenceReceipt:
+        receipt = self.latest(change_id)
+        if receipt is None:
+            raise RuntimeError(f"no dual-persistence receipt for change: {change_id}")
+        if receipt.status is not DualPersistenceStatus.COMPLETE:
+            raise RuntimeError(
+                f"dual persistence incomplete for {change_id}: {receipt.status.value}"
+            )
+        return receipt

--- a/runtime/agentic_omega/test_capability_evidence.py
+++ b/runtime/agentic_omega/test_capability_evidence.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from runtime.agentic_omega import (
+    AppendOnlyEventLedger,
+    CapabilityEvidenceRegistry,
+    CapabilitySource,
+    CapabilityStatus,
+    RouteDescriptor,
+)
+
+
+def test_route_fingerprint_ignores_credentials_but_tracks_capability_route() -> None:
+    first = RouteDescriptor(
+        provider="OpenAI",
+        base_url="https://api.example.test/v1/",
+        model="model-a",
+        headers={"Authorization": "Bearer secret-one", "x-beta": "context-1m"},
+        options={"reasoning": "high"},
+    )
+    rotated_key = RouteDescriptor(
+        provider="openai",
+        base_url="https://api.example.test/v1",
+        model="model-a",
+        headers={"Authorization": "Bearer secret-two", "x-beta": "context-1m"},
+        options={"reasoning": "high"},
+    )
+    changed_beta = RouteDescriptor(
+        provider="openai",
+        base_url="https://api.example.test/v1",
+        model="model-a",
+        headers={"Authorization": "Bearer secret-two", "x-beta": "different"},
+        options={"reasoning": "high"},
+    )
+    changed_model = RouteDescriptor(
+        provider="openai",
+        base_url="https://api.example.test/v1",
+        model="model-b",
+        headers={"Authorization": "Bearer secret-two", "x-beta": "context-1m"},
+        options={"reasoning": "high"},
+    )
+    assert first.fingerprint() == rotated_key.fingerprint()
+    assert first.fingerprint() != changed_beta.fingerprint()
+    assert first.fingerprint() != changed_model.fingerprint()
+
+
+def test_unknown_or_failed_capability_fails_closed() -> None:
+    registry = CapabilityEvidenceRegistry(AppendOnlyEventLedger())
+    route = RouteDescriptor(provider="test", model="m")
+    assert registry.boolean_allows(route=route, capability="tool_calling") is False
+    assert registry.at_least(route=route, capability="context_window_tokens", threshold=1000) is False
+    registry.record(
+        route=route,
+        capability="tool_calling",
+        value=True,
+        status=CapabilityStatus.FAILED,
+        source=CapabilitySource.PROBE,
+    )
+    assert registry.boolean_allows(route=route, capability="tool_calling") is False
+
+
+def test_confirmed_numeric_capability_is_route_scoped() -> None:
+    ledger = AppendOnlyEventLedger()
+    registry = CapabilityEvidenceRegistry(ledger)
+    route = RouteDescriptor(provider="test", model="m1", options={"beta": "large"})
+    other = RouteDescriptor(provider="test", model="m1", options={"beta": "small"})
+    registry.record(
+        route=route,
+        capability="context_window_tokens",
+        value=1_000_000,
+        status=CapabilityStatus.CONFIRMED,
+        source=CapabilitySource.PROVIDER_METADATA,
+        valid_until="2099-01-01T00:00:00+00:00",
+    )
+    assert registry.at_least(route=route, capability="context_window_tokens", threshold=1_000_000)
+    assert registry.at_least(route=other, capability="context_window_tokens", threshold=1_000_000) is False
+
+
+def test_owner_assertion_requires_owner_ack_source() -> None:
+    registry = CapabilityEvidenceRegistry(AppendOnlyEventLedger())
+    route = RouteDescriptor(provider="test", model="m")
+    with pytest.raises(ValueError):
+        registry.record(
+            route=route,
+            capability="tool_calling",
+            value=True,
+            status=CapabilityStatus.ASSERTED,
+            source=CapabilitySource.PROVIDER_METADATA,
+        )
+    registry.record(
+        route=route,
+        capability="tool_calling",
+        value=True,
+        status=CapabilityStatus.ASSERTED,
+        source=CapabilitySource.OWNER_ACK,
+        valid_until="2099-01-01T00:00:00+00:00",
+    )
+    assert registry.boolean_allows(route=route, capability="tool_calling") is True
+
+
+def test_stale_capability_fails_when_freshness_is_required() -> None:
+    registry = CapabilityEvidenceRegistry(AppendOnlyEventLedger())
+    route = RouteDescriptor(provider="test", model="m")
+    registry.record(
+        route=route,
+        capability="tool_calling",
+        value=True,
+        status=CapabilityStatus.CONFIRMED,
+        source=CapabilitySource.LOCAL_HEALTH,
+        valid_until="2020-01-01T00:00:00+00:00",
+    )
+    assert registry.boolean_allows(route=route, capability="tool_calling", require_fresh=True) is False
+    assert registry.boolean_allows(route=route, capability="tool_calling", require_fresh=False) is True
+
+
+def test_credential_values_are_not_persisted_in_route_identity() -> None:
+    ledger = AppendOnlyEventLedger()
+    registry = CapabilityEvidenceRegistry(ledger)
+    route = RouteDescriptor(
+        provider="test",
+        model="m",
+        headers={"Authorization": "Bearer DO_NOT_PERSIST", "x-beta": "ok"},
+    )
+    registry.record(
+        route=route,
+        capability="tool_calling",
+        value=True,
+        status=CapabilityStatus.CONFIRMED,
+        source=CapabilitySource.LOCAL_HEALTH,
+    )
+    serialized = str(ledger.events)
+    assert "DO_NOT_PERSIST" not in serialized
+    assert "routeFingerprint" in serialized

--- a/runtime/agentic_omega/test_sync_receipts.py
+++ b/runtime/agentic_omega/test_sync_receipts.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from runtime.agentic_omega import (
+    AppendOnlyEventLedger,
+    DualPersistenceRegistry,
+    DualPersistenceStatus,
+)
+
+
+def test_sync_receipt_is_not_complete_from_intent_or_one_destination() -> None:
+    registry = DualPersistenceRegistry(AppendOnlyEventLedger())
+    incomplete = registry.record(change_id="change-1")
+    github_only = registry.record(change_id="change-1", github_commit_sha="abc123")
+    assert incomplete.status is DualPersistenceStatus.INCOMPLETE
+    assert github_only.status is DualPersistenceStatus.GITHUB_ONLY
+    with pytest.raises(RuntimeError):
+        registry.require_complete("change-1")
+
+
+def test_sync_receipt_complete_requires_concrete_github_and_notion_ids() -> None:
+    registry = DualPersistenceRegistry(AppendOnlyEventLedger())
+    receipt = registry.record(
+        change_id="change-2",
+        github_commit_sha="abc123",
+        notion_page_id="notion-page-123",
+        github_path="CURRENT_CANON/test.md",
+        notion_url="https://notion.test/page",
+    )
+    assert receipt.status is DualPersistenceStatus.COMPLETE
+    assert registry.require_complete("change-2").receipt_id == receipt.receipt_id
+
+
+def test_latest_receipt_can_upgrade_prior_partial_state() -> None:
+    registry = DualPersistenceRegistry(AppendOnlyEventLedger())
+    registry.record(change_id="change-3", github_commit_sha="abc123")
+    registry.record(
+        change_id="change-3",
+        github_commit_sha="abc123",
+        notion_page_id="notion-page-123",
+    )
+    latest = registry.latest("change-3")
+    assert latest is not None
+    assert latest.status is DualPersistenceStatus.COMPLETE


### PR DESCRIPTION
## Scope

Materializes the last two governance layers announced for Agentic Runtime Ω.

### Capability Evidence Ω
- Exact route fingerprint: provider + base URL + model + non-secret headers/beta + options.
- Credential headers excluded from persistence/fingerprint identity.
- Statuses: confirmed / asserted / unprobeable / failed.
- Only confirmed/asserted can authorize; asserted requires owner_ack.
- Unknown/failed/unprobeable fail closed.
- Optional valid_until freshness gate.
- Boolean and numeric at-least capability checks are route-scoped.

### Dual-Persistence Receipt Ω
- Append-only GitHub + Notion synchronization receipts.
- COMPLETE only when concrete github_commit_sha + notion_page_id are both present.
- GITHUB_ONLY / NOTION_ONLY / INCOMPLETE are first-class non-complete states.
- Registry never claims connector writes from intent.

### Durable concurrency
- Capability/sync read paths refresh DurableAgenticLedger before latest-event selection.

### API / security
New `/v1/agentic-omega/v2/governance` router with capability evidence/check and sync receipt endpoints. Governance writes require existing ATLAS_AGENT_CONTROL_TOKEN. Returned route identity contains no credential headers.

### Validation
CI expands again with capability registry, dual-persistence, and governance API tests while rerunning all v1/v2/v2.1/v2.2 suites.

### Invariants
No majority voting; Falsifiers veto absolute; external evidence candidate-only; unknown capability never authorizes; READY_FOR_EXECUTION_GATE is not BUY/SELL; broker separate; evolution proposal-only; CORE-00 untouched.