### PR TITLE
Wire Agent Infrastructure Ω encrypted secret gates

### DIFF
--- a/.github/workflows/agent-infrastructure-secrets-check.yml
+++ b/.github/workflows/agent-infrastructure-secrets-check.yml
@@ -1,0 +1,45 @@
+name: Agent Infrastructure Ω — Secrets Gate
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'CURRENT_CANON/AGENT_INFRASTRUCTURE_OMEGA.md'
+      - '.github/workflows/agent-infrastructure-secrets-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  secrets-gate:
+    runs-on: ubuntu-latest
+    env:
+      FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+      MEM0_API_KEY: ${{ secrets.MEM0_API_KEY }}
+      ATLAS_N8N_SECRET: ${{ secrets.ATLAS_N8N_SECRET }}
+      ATLAS_AGENT_CONTROL_TOKEN: ${{ secrets.ATLAS_AGENT_CONTROL_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate required secret presence without disclosure
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in FIRECRAWL_API_KEY MEM0_API_KEY ATLAS_N8N_SECRET ATLAS_AGENT_CONTROL_TOKEN; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Missing ATLAS secret::$name is not configured in GitHub Actions secrets"
+              missing=1
+            else
+              echo "$name=CONFIGURED" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then exit 1; fi
+
+      - name: Security invariant
+        shell: bash
+        run: |
+          echo 'Secrets are consumed only from GitHub Actions encrypted secrets.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'No secret values are printed or persisted as artifacts.' >> "$GITHUB_STEP_SUMMARY"

--- a/config/agent-infrastructure.env.example
+++ b/config/agent-infrastructure.env.example
@@ -1,0 +1,12 @@
+# ATLAS Ω Agent Infrastructure — environment contract
+# VALUES MUST NEVER BE COMMITTED. Configure them in the runtime secret store.
+
+FIRECRAWL_API_KEY=
+MEM0_API_KEY=
+ATLAS_N8N_SECRET=
+ATLAS_AGENT_CONTROL_TOKEN=
+
+# Optional provider endpoints. Keep defaults/configuration non-secret where possible.
+# FIRECRAWL_BASE_URL=
+# MEM0_BASE_URL=
+# N8N_BASE_URL=

--- a/docs/ATLAS_OS/AGENT_INFRASTRUCTURE_SECRETS.md
+++ b/docs/ATLAS_OS/AGENT_INFRASTRUCTURE_SECRETS.md
@@ -1,0 +1,32 @@
+# ATLAS Ω — Agent Infrastructure Secret Contract
+
+Required encrypted runtime secrets:
+
+- `FIRECRAWL_API_KEY`
+- `MEM0_API_KEY`
+- `ATLAS_N8N_SECRET`
+- `ATLAS_AGENT_CONTROL_TOKEN`
+
+## Rules
+
+1. Never commit values to the repository, `.env` files, examples, logs, issues, PRs or artifacts.
+2. GitHub Actions consumes these values only through `${{ secrets.NAME }}`.
+3. Production runtimes (for example Render) require the same relevant variables in their own encrypted environment/secret store; GitHub Actions secrets do not automatically become production environment variables.
+4. `ATLAS_N8N_SECRET` must be shared only between the ATLAS backend and the authorized n8n workflow endpoint.
+5. `ATLAS_AGENT_CONTROL_TOKEN` is independent and must not reuse the n8n secret.
+6. Rotate any credential suspected to have been exposed.
+7. Provider ingestion remains non-canonical until Evidence Director Ω classification and provenance gates pass.
+8. Falsifiers Ω retains independent absolute veto.
+
+## GitHub gate
+
+`.github/workflows/agent-infrastructure-secrets-check.yml` verifies presence of all four GitHub Actions secrets without printing their values. A missing secret fails the gate explicitly.
+
+## Deployment state semantics
+
+- `CODE_READY`: adapters/workflows reference secret names correctly.
+- `GITHUB_SECRETS_READY`: all four encrypted repository secrets exist and the secrets gate passes.
+- `RUNTIME_READY`: production runtime has the required encrypted variables.
+- `LIVE_CERTIFIED`: provider connectivity and ATLAS governance integration tests pass against the live runtime.
+
+Do not report `LIVE_CERTIFIED` merely because code has merged.


### PR DESCRIPTION
Closed under ATLAS v1 simplification. This secret-wiring layer depends on external services and is not required for the canonical GitHub+Notion continuity core. Reopen only if those providers are deliberately selected for deployment.