### PR TITLE
Complete Firecrawl Search Ω v2

### DIFF
--- a/CURRENT_CANON/FIRECRAWL_WEB_INGESTION_ADAPTER_OMEGA.md
+++ b/CURRENT_CANON/FIRECRAWL_WEB_INGESTION_ADAPTER_OMEGA.md
@@ -1,26 +1,43 @@
 # FIRECRAWL WEB INGESTION ADAPTER Ω
 
 Status: ACTIVE CANON
-Date: 2026-08-19
+Date: 2026-08-20
 
 ## Purpose
 
-Add Firecrawl as an acquisition/normalization adapter for public web evidence used by ATLAS Ω. Firecrawl is infrastructure, NOT a source of truth and NOT an investment-decision engine.
+Firecrawl is the public-web discovery/acquisition adapter for ATLAS Ω. It is infrastructure, NOT a source of truth and NOT an investment-decision engine.
 
 ## Pipeline
 
-URL(s) -> Firecrawl Adapter Ω -> Evidence Normalizer Ω -> Evidence Director Ω -> FACT/HYPOTHESIS/INTERPRETATION/NOISE -> Evidence Store -> specialist ATLAS engines -> Falsifiers Ω -> Decision.
+Query/URL(s) -> Firecrawl Adapter Ω -> Evidence Normalizer Ω -> Evidence Director Ω -> FACT/HYPOTHESIS/INTERPRETATION/NOISE -> Evidence Store -> specialist ATLAS engines -> Falsifiers Ω -> Decision.
 
 No Firecrawl output may bypass Evidence Director Ω or Falsifiers Ω.
 
-## Supported acquisition modes
+## Active acquisition and discovery modes
 
 1. Single URL scrape through Firecrawl v2 `/scrape`.
-2. Explicit multi-URL batch through v2 `/batch/scrape`.
-3. Markdown output for LLM-readable evidence.
-4. Structured JSON extraction against an ATLAS schema.
-5. Screenshot acquisition when visual evidence is materially useful.
-6. Cache-aware retrieval using `maxAge`; freshness must be chosen by evidence type rather than accepted blindly.
+2. Search + optional full-content scrape through Firecrawl v2 `/search` and `scrapeOptions`.
+3. Search sources: `web`, `news`, `images`.
+4. Search categories: `github`, `research`, `pdf`, `developer`.
+5. Domain controls through `includeDomains` OR `excludeDomains`; never both in one request.
+6. Location/country controls for geographically scoped discovery.
+7. Time filtering through `tbs` where supported by Firecrawl; it MUST NOT be assumed to filter every source type equally.
+8. Markdown extraction by default for acquired textual evidence; links and screenshots are optional.
+9. Cache-aware acquisition using `maxAge`; freshness is chosen by evidence type.
+10. Explicit multi-URL batch through v2 `/batch/scrape` remains an approved adapter capability for evidence sets, even when a deployment exposes it separately from the `/v1/evidence/web/search` route.
+11. Structured JSON extraction against an ATLAS schema remains an approved downstream normalization mode.
+
+Search and scrape in one call is preferred when ATLAS needs full content from all discovered results. A two-step search -> rank/filter -> scrape pattern is preferred when only selected results merit extraction cost.
+
+## Search semantics
+
+Search results are discovery candidates, not verified facts. Search rank, description/snippet, highlights, category and result position MUST NOT be interpreted as evidence quality, source authority or investment conviction.
+
+Every result is normalized independently. Provenance MUST remain per-result even when Firecrawl returns grouped results from one request.
+
+A search result without scraped content may be marked `DISCOVERED`; it is not equivalent to verified evidence. When full-content acquisition was requested but content/provenance is missing, the result is `INGESTION_INCOMPLETE`.
+
+Partial acquisition is preserved. One failed result MUST NOT poison valid independent results, and valid results MUST NOT hide failed ones. Aggregate status may therefore be `OK`, `PARTIAL`, `NO_RESULTS` or `INGESTION_INCOMPLETE`.
 
 ## ATLAS Structured Evidence Schema
 
@@ -37,7 +54,8 @@ Minimum normalized record:
   "publication_date": null,
   "retrieved_at": "",
   "freshness_class": "LIVE|DAILY|QUARTERLY|EVERGREEN",
-  "evidence_class": "FACT|HYPOTHESIS|INTERPRETATION|NOISE",
+  "evidence_class": "FACT|HYPOTHESIS|INTERPRETATION|NOISE|UNCLASSIFIED",
+  "verification": "PENDING",
   "metric": null,
   "period": null,
   "value": null,
@@ -56,66 +74,80 @@ Financial extraction may additionally populate revenue, EPS, CFO, FCF, CAPEX, ma
 
 ## Evidence gates
 
-### Gate F0 — URL provenance
-Reject evidence without recoverable source URL/domain.
+### Gate F0 — Provenance
+Reject evidence without recoverable source URL/domain. Discovery without provenance is `INGESTION_INCOMPLETE`.
 
 ### Gate F1 — Source classification
-Primary sources (SEC/regulator/company IR/official filings) outrank secondary reporting. Firecrawl extraction quality does not upgrade source authority.
+Primary sources (regulators, SEC, company IR, official filings and other authoritative first-party evidence) outrank secondary reporting. Firecrawl extraction quality and search rank do not upgrade authority.
 
 ### Gate F2 — Temporal validity
-Every time-sensitive fact requires a publication/period check. Cached content is forbidden as evidence for intraday/current-state questions unless its timestamp satisfies the requested freshness.
+Every time-sensitive fact requires publication/period validation. Cached content is forbidden as evidence for intraday/current-state questions unless its timestamp satisfies requested freshness. `tbs` is a discovery filter, not proof of the publication timestamp.
 
 ### Gate F3 — Extraction integrity
-Structured JSON is a parsing aid, not proof. Material figures should be cross-checked against the underlying markdown/page and, for high-consequence investment decisions, against primary evidence when available.
+Markdown/structured parsing is an acquisition aid, not proof. Material figures should be checked against underlying content and, for high-consequence investment decisions, against primary evidence when available.
 
 ### Gate F4 — Conflict handling
-Conflicting values are preserved as contradictions and routed to Evidence Director Ω. Do not silently choose the convenient value.
+Conflicting values are preserved as contradictions and routed to Evidence Director Ω. Never silently choose the convenient value.
 
 ### Gate F5 — Decision isolation
-Firecrawl output cannot directly emit BUY/HOLD/SELL, Quality Ω, Expected Return Ω, Forward Asymmetry Ω, Money Rotation Ω or valuation conclusions. Specialist engines must derive those conclusions.
+Firecrawl output cannot directly emit BUY/HOLD/SELL, Quality Ω, Expected Return Ω, Forward Asymmetry Ω, Money Rotation Ω, Clinical Evidence Shock Ω, valuation conclusions or portfolio actions. Specialist engines derive those conclusions only after evidence gates.
+
+### Gate F6 — Search-result isolation
+Snippets, descriptions, highlights, positions, categories and result counts are discovery metadata. They cannot by themselves satisfy a factual evidence gate.
 
 ## Freshness policy
 
-- Intraday market/flow evidence: do not rely on ordinary cached scrape as the primary real-time feed.
-- Breaking corporate disclosures: force fresh acquisition or use authoritative live/primary source connectors.
-- Earnings/filings: cache only when the filing itself is immutable and provenance is preserved.
-- Evergreen documentation: cache is preferred for efficiency.
+- `LIVE`: adapter cache ceiling 0 ms; use for current-state acquisition where Firecrawl is appropriate. Firecrawl is not the primary market-price/flow feed.
+- `DAILY`: adapter cache ceiling 300,000 ms.
+- `QUARTERLY`: adapter cache ceiling 86,400,000 ms.
+- `EVERGREEN`: adapter cache ceiling 172,800,000 ms.
+- User/requested `maxAge` can tighten these ceilings but cannot loosen them.
+- Breaking corporate disclosures: force fresh acquisition or use authoritative live/primary connectors.
+- Earnings/filings: cache only when the document itself is immutable and provenance is preserved.
+- Evergreen documentation: caching is preferred for efficiency.
 
-Firecrawl v2 currently supports `maxAge` caching; its documented default is two days, so ATLAS MUST override/default consciously for time-sensitive evidence.
+## Domain and search policy
 
-## Batch policy
-
-Batch scrape is appropriate for explicit evidence sets such as multiple IR pages, filings or supplier/customer pages. Batch convenience must not collapse provenance: every returned document remains an independent evidence object with its own URL, timestamp, authority and confidence.
+- `includeDomains` and `excludeDomains` are mutually exclusive.
+- Domain filters accept domains, not arbitrary URLs/paths.
+- Prefer primary-domain allowlists when a specialist requires authoritative evidence.
+- `research` is a discovery lane for academic/research sources; it does not waive evidence verification.
+- `github` and `developer` are discovery lanes for software/code evidence; repository content remains subject to provenance, version and authority checks.
+- `pdf` identifies document-format candidates; PDF format itself conveys no authority.
+- `images` are discovery objects and require independent verification before visual claims enter Evidence Store.
 
 ## Security / compliance
 
 - API key only through environment secret `FIRECRAWL_API_KEY`; never commit it.
+- Direct `/scrape` URLs must pass public-network validation; localhost/private/reserved destinations are forbidden.
+- Search domain filters reject local/private-style domains and malformed URL-like values.
 - Do not scrape authenticated/private sources unless explicitly authorized and compatible with applicable terms and controls.
 - Respect robots/site policies, contractual restrictions and data-protection requirements.
-- For sensitive acquisition, disable storage/cache where appropriate; zero-data-retention is an optional Firecrawl capability subject to account availability.
+- For sensitive acquisition, disable storage/cache where appropriate; zero-data-retention is optional subject to account capability.
 - Never use anti-bot capability as authorization to defeat access controls.
 
-## Adapter interface (reference)
+## Adapter interface
 
 ```python
 class FirecrawlWebIngestionAdapter:
     def scrape(self, url, *, formats, freshness_policy, schema=None): ...
+    def search(self, query, *, sources, categories, domains, location, time_filter, scrape_options=None): ...
     def batch_scrape(self, urls, *, formats, freshness_policy, schema=None): ...
     def normalize(self, firecrawl_response): ...
     def validate_provenance(self, evidence): ...
     def route_to_evidence_director(self, evidence): ...
 ```
 
-Implementation must use the current Firecrawl v2 contract rather than hard-coding assumptions from social-media examples.
+Implementation must use the current Firecrawl v2 contract rather than hard-coding assumptions from email/social-media examples.
 
 ## Failure semantics
 
-429/rate-limit, timeout, extraction failure, blocked page, malformed JSON, stale cache, missing provenance or contradictory evidence => `INGESTION_INCOMPLETE`, never fabricated completion.
+429/rate-limit, timeout, extraction failure, blocked page, malformed JSON, stale cache, missing provenance or contradictory evidence => `INGESTION_INCOMPLETE` at the affected evidence-object level, never fabricated completion.
 
-`INGESTION_INCOMPLETE` is a valid ATLAS outcome and cannot be converted into positive evidence.
+`PARTIAL`, `NO_RESULTS` and `INGESTION_INCOMPLETE` are valid ATLAS outcomes and cannot be converted into positive evidence.
 
 ## Canonical rule
 
-> Firecrawl makes web evidence easier to acquire and normalize. It does not make the evidence true.
+> Firecrawl makes public-web evidence easier to discover, acquire and normalize. It does not make the evidence true.
 
 Evidence authority, freshness, contradiction resolution and investment inference remain responsibilities of ATLAS Ω.

--- a/api/firecrawl_ingestion.py
+++ b/api/firecrawl_ingestion.py
@@ -9,20 +9,56 @@ from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 router = APIRouter(prefix="/v1/evidence/web", tags=["evidence", "firecrawl"])
 
 FIRECRAWL_API_URL = os.getenv("FIRECRAWL_API_URL", "https://api.firecrawl.dev/v2").rstrip("/")
 FIRECRAWL_TIMEOUT_SECONDS = float(os.getenv("FIRECRAWL_TIMEOUT_SECONDS", "45"))
 
+Freshness = Literal["LIVE", "DAILY", "QUARTERLY", "EVERGREEN"]
+SearchSource = Literal["web", "news", "images"]
+SearchCategory = Literal["github", "research", "pdf", "developer"]
+
 
 class ScrapeRequest(BaseModel):
     url: str
     ticker: str | None = None
-    freshness: Literal["LIVE", "DAILY", "QUARTERLY", "EVERGREEN"] = "DAILY"
+    freshness: Freshness = "DAILY"
     max_age_ms: int | None = Field(default=None, ge=0)
     include_screenshot: bool = False
+
+
+class SearchRequest(BaseModel):
+    query: str = Field(min_length=1, max_length=500)
+    ticker: str | None = None
+    freshness: Freshness = "DAILY"
+    limit: int = Field(default=5, ge=1, le=25)
+    sources: list[SearchSource] = Field(default_factory=lambda: ["web"])
+    categories: list[SearchCategory] = Field(default_factory=list)
+    include_domains: list[str] = Field(default_factory=list, max_length=20)
+    exclude_domains: list[str] = Field(default_factory=list, max_length=20)
+    location: str | None = Field(default=None, max_length=200)
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    tbs: str | None = Field(default=None, max_length=32)
+    scrape_content: bool = True
+    include_links: bool = False
+    include_screenshot: bool = False
+    max_age_ms: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def validate_filters(self) -> "SearchRequest":
+        if self.include_domains and self.exclude_domains:
+            raise ValueError("include_domains and exclude_domains are mutually exclusive")
+        if not self.sources and not self.categories:
+            raise ValueError("At least one source or category is required")
+        self.sources = list(dict.fromkeys(self.sources))
+        self.categories = list(dict.fromkeys(self.categories))
+        self.include_domains = [_validate_domain(item) for item in self.include_domains]
+        self.exclude_domains = [_validate_domain(item) for item in self.exclude_domains]
+        if self.country:
+            self.country = self.country.upper()
+        return self
 
 
 def _api_key() -> str:
@@ -30,6 +66,15 @@ def _api_key() -> str:
     if not key:
         raise HTTPException(status_code=503, detail="FIRECRAWL_API_KEY is not configured")
     return key
+
+
+def _validate_domain(raw_domain: str) -> str:
+    domain = raw_domain.strip().lower().rstrip(".")
+    if not domain or "://" in domain or "/" in domain or domain.startswith("."):
+        raise ValueError(f"Invalid search domain: {raw_domain}")
+    if domain in {"localhost", "localhost.localdomain"} or domain.endswith(".local"):
+        raise ValueError("Private/local search domains are forbidden")
+    return domain
 
 
 def _validate_public_url(raw_url: str) -> str:
@@ -51,16 +96,23 @@ def _validate_public_url(raw_url: str) -> str:
 
 
 def _max_age(freshness: str, requested: int | None) -> int:
-    # Current-state evidence must not silently inherit Firecrawl's ordinary cache.
     ceiling = {"LIVE": 0, "DAILY": 300_000, "QUARTERLY": 86_400_000, "EVERGREEN": 172_800_000}[freshness]
     return min(requested, ceiling) if requested is not None else ceiling
 
 
 def _source_type(url: str) -> str:
     host = (urlparse(url).hostname or "").lower()
-    if host.endswith("sec.gov") or host.endswith("gov"):
+    if host.endswith(".gov") or host == "sec.gov" or host.endswith(".sec.gov"):
         return "PRIMARY"
     return "UNKNOWN"
+
+
+def _guardrail() -> str:
+    return (
+        "Firecrawl is acquisition/discovery infrastructure only. Search rank, snippets, highlights and extracted content "
+        "are not verified evidence and may never directly emit BUY/HOLD/SELL or any ATLAS investment score. "
+        "Evidence Director must verify authority, period, units, freshness and contradictions before specialist engines use it."
+    )
 
 
 def _normalize(payload: dict[str, Any], request: ScrapeRequest) -> dict[str, Any]:
@@ -86,21 +138,71 @@ def _normalize(payload: dict[str, Any], request: ScrapeRequest) -> dict[str, Any
         "markdown": markdown,
         "screenshot": screenshot,
         "metadata": metadata,
-        "guardrail": "Firecrawl extraction is acquisition evidence only. Evidence Director must verify authority, period, units, freshness and contradictions before specialist engines may use it.",
+        "guardrail": _guardrail(),
     }
 
 
-async def _scrape(request: ScrapeRequest) -> dict[str, Any]:
-    url = _validate_public_url(request.url)
-    formats: list[Any] = ["markdown"]
-    if request.include_screenshot:
-        formats.append("screenshot")
-    body = {"url": url, "formats": formats, "maxAge": _max_age(request.freshness, request.max_age_ms)}
+def _result_url(item: dict[str, Any]) -> str | None:
+    candidate = item.get("url") or item.get("sourceURL")
+    if isinstance(candidate, str) and candidate.startswith(("http://", "https://")):
+        return candidate
+    return None
+
+
+def _normalize_search_item(item: dict[str, Any], group: str, request: SearchRequest) -> dict[str, Any]:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    source_url = _result_url(item) or _result_url(metadata) or ""
+    markdown = item.get("markdown") if isinstance(item.get("markdown"), str) else None
+    screenshot = item.get("screenshot") if isinstance(item.get("screenshot"), str) else None
+    links = item.get("links") if isinstance(item.get("links"), list) else None
+    is_image = group == "images"
+    image_url = item.get("imageUrl") if isinstance(item.get("imageUrl"), str) else None
+    has_acquired_content = bool(markdown or screenshot or links)
+    if is_image:
+        status = "DISCOVERED" if image_url and source_url else "INGESTION_INCOMPLETE"
+    elif request.scrape_content:
+        status = "OK" if source_url and has_acquired_content else "INGESTION_INCOMPLETE"
+    else:
+        status = "DISCOVERED" if source_url else "INGESTION_INCOMPLETE"
+    publication_date = (
+        metadata.get("publishedTime")
+        or metadata.get("published_time")
+        or item.get("date")
+        or item.get("publishedTime")
+    )
+    return {
+        "ticker": request.ticker.upper().strip() if request.ticker else None,
+        "status": status,
+        "adapter": "FIRECRAWL_V2_SEARCH",
+        "resultGroup": group,
+        "category": item.get("category"),
+        "position": item.get("position"),
+        "sourceUrl": source_url or None,
+        "sourceDomain": urlparse(source_url).hostname if source_url else None,
+        "sourceTitle": item.get("title") or metadata.get("title"),
+        "sourceType": _source_type(source_url) if source_url else "UNKNOWN",
+        "publicationDate": publication_date,
+        "retrievedAt": datetime.now(timezone.utc).isoformat(),
+        "freshnessClass": request.freshness,
+        "evidenceClass": "UNCLASSIFIED",
+        "verification": "PENDING",
+        "description": item.get("description") or item.get("snippet"),
+        "highlights": item.get("highlights"),
+        "markdown": markdown,
+        "links": links,
+        "screenshot": screenshot,
+        "imageUrl": image_url,
+        "metadata": metadata,
+        "guardrail": _guardrail(),
+    }
+
+
+async def _post_firecrawl(endpoint: str, body: dict[str, Any]) -> dict[str, Any]:
     headers = {"Authorization": f"Bearer {_api_key()}", "Content-Type": "application/json"}
     timeout = httpx.Timeout(FIRECRAWL_TIMEOUT_SECONDS, connect=10.0)
     try:
         async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
-            response = await client.post(f"{FIRECRAWL_API_URL}/scrape", json=body, headers=headers)
+            response = await client.post(f"{FIRECRAWL_API_URL}/{endpoint.lstrip('/')}", json=body, headers=headers)
     except httpx.RequestError as exc:
         raise HTTPException(status_code=502, detail={"status": "INGESTION_INCOMPLETE", "reason": exc.__class__.__name__}) from exc
     if response.status_code == 429:
@@ -113,10 +215,96 @@ async def _scrape(request: ScrapeRequest) -> dict[str, Any]:
         raise HTTPException(status_code=502, detail={"status": "INGESTION_INCOMPLETE", "reason": "MALFORMED_FIRECRAWL_JSON"}) from exc
     if not isinstance(payload, dict) or payload.get("success") is False:
         raise HTTPException(status_code=502, detail={"status": "INGESTION_INCOMPLETE", "reason": "FIRECRAWL_UNSUCCESSFUL"})
-    return _normalize(payload, request)
+    return payload
+
+
+async def _scrape(request: ScrapeRequest) -> dict[str, Any]:
+    url = _validate_public_url(request.url)
+    formats: list[Any] = ["markdown"]
+    if request.include_screenshot:
+        formats.append("screenshot")
+    body = {"url": url, "formats": formats, "maxAge": _max_age(request.freshness, request.max_age_ms)}
+    return _normalize(await _post_firecrawl("scrape", body), request)
+
+
+def _search_body(request: SearchRequest) -> dict[str, Any]:
+    body: dict[str, Any] = {"query": request.query.strip(), "limit": request.limit}
+    if request.sources:
+        body["sources"] = request.sources
+    if request.categories:
+        body["categories"] = request.categories
+    if request.include_domains:
+        body["includeDomains"] = request.include_domains
+    if request.exclude_domains:
+        body["excludeDomains"] = request.exclude_domains
+    if request.location:
+        body["location"] = request.location.strip()
+    if request.country:
+        body["country"] = request.country
+    if request.tbs:
+        body["tbs"] = request.tbs.strip()
+    if request.scrape_content:
+        formats: list[Any] = ["markdown"]
+        if request.include_links:
+            formats.append("links")
+        if request.include_screenshot:
+            formats.append("screenshot")
+        body["scrapeOptions"] = {
+            "formats": formats,
+            "maxAge": _max_age(request.freshness, request.max_age_ms),
+        }
+    return body
+
+
+async def _search(request: SearchRequest) -> dict[str, Any]:
+    payload = await _post_firecrawl("search", _search_body(request))
+    data = payload.get("data")
+    groups: dict[str, list[dict[str, Any]]] = {}
+    if isinstance(data, list):
+        groups["web"] = [item for item in data if isinstance(item, dict)]
+    elif isinstance(data, dict):
+        for group, raw_items in data.items():
+            if isinstance(raw_items, list):
+                groups[str(group)] = [item for item in raw_items if isinstance(item, dict)]
+    else:
+        raise HTTPException(status_code=502, detail={"status": "INGESTION_INCOMPLETE", "reason": "MALFORMED_SEARCH_DATA"})
+
+    normalized: dict[str, list[dict[str, Any]]] = {
+        group: [_normalize_search_item(item, group, request) for item in items]
+        for group, items in groups.items()
+    }
+    flattened = [item for items in normalized.values() for item in items]
+    incomplete = sum(1 for item in flattened if item["status"] == "INGESTION_INCOMPLETE")
+    if not flattened:
+        overall_status = "NO_RESULTS"
+    elif incomplete == len(flattened):
+        overall_status = "INGESTION_INCOMPLETE"
+    elif incomplete:
+        overall_status = "PARTIAL"
+    else:
+        overall_status = "OK"
+    return {
+        "status": overall_status,
+        "adapter": "FIRECRAWL_V2_SEARCH",
+        "query": request.query.strip(),
+        "ticker": request.ticker.upper().strip() if request.ticker else None,
+        "freshnessClass": request.freshness,
+        "requestedSources": request.sources,
+        "requestedCategories": request.categories,
+        "resultCount": len(flattened),
+        "incompleteCount": incomplete,
+        "results": normalized,
+        "guardrail": _guardrail(),
+    }
 
 
 @router.post("/scrape")
 async def scrape_web_evidence(request: ScrapeRequest) -> dict[str, Any]:
-    """Acquire public web evidence; never emits an investment decision."""
+    """Acquire one public URL; never emits an investment decision."""
     return await _scrape(request)
+
+
+@router.post("/search")
+async def search_web_evidence(request: SearchRequest) -> dict[str, Any]:
+    """Discover and optionally acquire public evidence; never emits an investment decision."""
+    return await _search(request)


### PR DESCRIPTION
Completes the existing Firecrawl evidence acquisition adapter with search+scrape, source/category filters, temporal/geographic/domain controls, per-result provenance normalization, partial-failure semantics, and updated ACTIVE CANON documentation. Scope is limited to api/firecrawl_ingestion.py and CURRENT_CANON/FIRECRAWL_WEB_INGESTION_ADAPTER_OMEGA.md.