### PR TITLE
Size-Neutral Return Ranking Ω — remove hidden megacap bias

### DIFF
--- a/CURRENT_CANON/MEGACAP_RETURN_CEILING_OMEGA.md
+++ b/CURRENT_CANON/MEGACAP_RETURN_CEILING_OMEGA.md
@@ -1,105 +1,50 @@
 # MEGACAP RETURN CEILING Ω
 
-Status: ACTIVE CANON
-Date: 2026-08-19
+**Status:** SUPERSEDED AS A SCORING RULE  
+**Original date:** 2026-08-19  
+**Superseded:** 2026-08-20  
+**Active replacement:** `CURRENT_CANON/SIZE_NEUTRAL_RETURN_RANKING_OMEGA.md`
 
-## Purpose
-Prevent ATLAS from confusing an excellent company, an improved entry price, or a fundamental BUY with a maximum-forward-return opportunity.
+## Governance change
 
-## Core separation
-ATLAS MUST score these independently:
+The prior rule correctly separated Business Quality, Entry Price and Expected Return, but its mechanical `SIZE / MEGACAP CEILING Ω` could introduce an unwanted size bias into cross-sectional return rankings.
 
-1. BUSINESS QUALITY Ω — quality, moat, FCF, ROIC/economic proof, durability.
-2. ENTRY PRICE Ω — valuation versus history, fundamentals and recent drawdown.
-3. EXPECTED RETURN Ω — plausible 3–6Y annualized and cumulative return from today's enterprise/equity value.
-4. FORWARD ASYMMETRY Ω — upside distribution versus downside/falsification risk.
-5. SIZE / MEGACAP CEILING Ω — mathematical burden imposed by current market capitalization.
+By explicit user instruction, ATLAS now applies **Size-Neutral Return Ranking Ω**:
 
-A BUY in dimensions 1–2 MUST NOT automatically become a MAX RETURN BUY.
+- every ticker starts at **0/1000**;
+- market capitalization gives **0 bonus and 0 penalty**;
+- generic quality/prestige gives **0 baseline points**;
+- megacaps are neither excluded nor mechanically downgraded;
+- smaller companies receive no small-cap bonus;
+- normalized economics, expected return, revisions, money rotation, momentum, specialist engines, risk and falsifiers decide the ranking;
+- market-cap bucket is revealed only **after the score is frozen**.
 
-## Megacap gate
-Trigger MEGACAP_RETURN_CEILING when market capitalization is already extremely large (default diagnostic threshold: >= $500B; HIGH severity >= $1T).
+## What survives from this module
 
-For triggered companies, ATLAS must explicitly calculate scenario market caps:
-- 2x current equity value
-- 3x current equity value
-- 5x current equity value
+The following ideas remain valid as diagnostics and are incorporated into the replacement canon:
 
-These are not price targets. They are feasibility checks.
+- **QUALITY ≠ EXPECTED RETURN.**
+- **PRICE ≠ RETURN EVIDENCE.**
+- **BUY ≠ MAX RETURN BUY.**
+- 2x / 3x / 5x implied equity-value arithmetic may be used as a feasibility check.
+- Revenue/FCF/earnings required by a valuation scenario should be tested explicitly.
 
-The engine then asks:
-- What revenue, FCF and earnings would support each scenario?
-- What terminal multiple is implicitly required?
-- Is that scale plausible within 3–6 years?
-- Would the resulting market capitalization require an implausibly large share of the relevant profit pool / economy / index?
+However, scenario market capitalization **must not itself deduct ranking points**. A negative scoring consequence must be supported by traceable evidence through:
 
-## Classification
-Allowed outputs:
+- Expected Return / Valuation Ω;
+- Growth Saturation Ω;
+- incremental ROIC / FCF economics;
+- TAM/profit-pool constraints;
+- risk or falsifiers.
 
-- BUY — MAX RETURN: quality + price + expected return + asymmetry all pass; size does not materially cap upside.
-- BUY — COMPOUNDER: attractive business and entry, but current scale lowers plausible multiple-expansion / multibagger potential.
-- BUY — DEFENSIVE/QUALITY: attractive preservation/quality characteristics; expected return is secondary.
-- HOLD / WATCH / REJECT.
+## Historical calibration — Broadcom
 
-Never label a security MAX RETURN BUY solely because it has fallen substantially from a previous high.
+The earlier AVGO calibration remains useful only as a valuation-feasibility example. ATLAS may ask whether a 2x/3x/5x equity value is economically plausible, but AVGO cannot be penalized simply because its starting market capitalization is already large.
 
-## Drawdown rule
-A drawdown is PRICE INFORMATION, not RETURN EVIDENCE.
+If its normalized economics and expected return beat smaller companies, it ranks above them. If a smaller company offers stronger evidence-backed forward asymmetry, the smaller company ranks above AVGO.
 
-Example:
-Peak $495 -> price $380 = materially improved entry price.
-It does NOT prove that $380 offers exceptional 3–6Y expected return.
-Expected return must be recomputed from current fundamentals, valuation, growth runway and current market capitalization.
+## Active law
 
-## Canonical calibration case — Broadcom (AVGO), 2026-08-19
-Observed user price snapshot: approximately $380 and approximately $1.81T market capitalization.
-
-Fundamental evidence remains exceptional: Broadcom Q2 FY2026 reported $22.187B revenue (+48% YoY), $10.262B FCF (+60% YoY), $10.8B AI semiconductor revenue (+143% YoY), and guided Q3 revenue to approximately $29.4B (+84% YoY) with AI semiconductor revenue expected at approximately $16B (>200% YoY).
-
-ATLAS interpretation:
-- BUSINESS QUALITY: PASS / elite.
-- ECONOMIC PROOF: PASS.
-- AI CAPEX CAPTURE: PASS.
-- ENTRY PRICE at ~$380 versus prior ~$495 high: materially improved.
-- EXPECTED RETURN: must remain independent.
-- MEGACAP RETURN CEILING: HIGH because equity value is already around $1.8T in the supplied snapshot.
-
-Feasibility arithmetic at $1.81T starting market cap:
-- 2x = ~$3.62T
-- 3x = ~$5.43T
-- 5x = ~$9.05T
-
-Therefore AVGO may legitimately be a BUY while NOT being a MAX RETURN BUY.
-Canonical classification for this case: BUY — COMPOUNDER / MEGACAP, subject to live valuation and falsifier updates.
-
-## Ranking consequence
-When ATLAS is asked for companies with the highest plausible 3–6Y capital multiplication, a megacap can rank below a smaller company even when the megacap has superior Quality Ω.
-
-Quality rank != Expected Return rank.
-Price attractiveness != Expected Return rank.
-Past drawdown != Forward asymmetry.
-
-## Portfolio consequence
-Do not reject megacaps automatically. Their role may be:
-- high-confidence compounder,
-- portfolio anchor,
-- economic-proof benchmark,
-- lower-risk participation in a structural theme.
-
-But ATLAS must not let their quality score crowd out smaller companies with stronger evidence-backed Forward Asymmetry Ω when the objective is maximum 3–6Y return.
-
-## Required output fields
-For any triggered megacap analysis, display:
-- Quality Ω
-- Entry Price Ω
-- Current market cap
-- 2x / 3x / 5x implied market caps
-- Expected Return Ω
-- Forward Asymmetry Ω
-- Megacap Ceiling severity
-- Final class: MAX RETURN BUY / COMPOUNDER BUY / QUALITY BUY / HOLD / WATCH / REJECT
-
-## Constitutional rule
-PRICE ≠ EVIDENCE.
-QUALITY ≠ EXPECTED RETURN.
-BUY ≠ MAX RETURN BUY.
+**SIZE IS METADATA, NOT SCORE.**  
+**GROWTH SATURATION REQUIRES ECONOMIC EVIDENCE.**  
+**FALSIFIERS Ω REMAINS AN ABSOLUTE VETO.**

--- a/CURRENT_CANON/SIZE_NEUTRAL_RETURN_RANKING_OMEGA.md
+++ b/CURRENT_CANON/SIZE_NEUTRAL_RETURN_RANKING_OMEGA.md
@@ -1,0 +1,153 @@
+# SIZE-NEUTRAL RETURN RANKING Ω
+
+**Status:** ACTIVE CANON  
+**Effective date:** 2026-08-20  
+**Authority:** explicit user instruction  
+**Implementation:** `src/atlas/algorithm/size-neutral-return-ranking-omega.ts`
+
+## Purpose
+
+Remove hidden mega/hyper-cap and generic-quality bias from ATLAS Ω return rankings without penalizing large companies merely for being large.
+
+ATLAS must rank a dinosaur, elephant, parakeet and mosquito on the same evidence-backed return surface. If a mega/hyper-cap wins after neutralization, it wins legitimately. If a smaller company wins, it must win on economics and expected return rather than on a small-cap preference.
+
+## Constitutional law
+
+**MARKET CAP = 0 BONUS / 0 PENALTY.**  
+**GENERIC QUALITY LABEL = 0 BONUS.**  
+**EVERY TICKER STARTS AT 0/1000.**  
+**FALSIFIERS Ω = ABSOLUTE VETO.**
+
+No ticker receives baseline points because it is famous, liquid, institutionally owned, heavily covered, included in a major index, historically excellent or already known to ATLAS.
+
+## Universal 0–1000 surface
+
+Each company receives ten independent blocks of 0–100 points:
+
+1. **Economic Proof Ω** — verified conversion of demand into revenue/margins/economic output.
+2. **Cash Efficiency Ω** — normalized FCF margin, FCF/share growth, FCF yield and incremental ROIC rather than absolute dollars.
+3. **Growth Acceleration Ω** — percentage growth, acceleration/deceleration and operating leverage.
+4. **Expected Return / Valuation Ω** — forward return supported by valuation and economics, independent from prestige.
+5. **Consensus Dynamics / Revisions Ω** — evidence-backed estimate revisions and expectation change.
+6. **Money Rotation Ω** — relative/abnormal flow evidence, never raw market-cap or absolute-volume advantage.
+7. **Momentum / Breadth Ω** — relative strength, abnormal/relative volume and persistence versus own history/peers.
+8. **Historical Dislocation / Forward Asymmetry Ω** — evidence-backed upside/downside asymmetry and No-Chase discipline.
+9. **Specialist Engine Capture Ω** — applicable CAPEX, Successor, Robotics, AI Tollbooth, Clinical, Wave, Developer Activity and other specialist outputs integrated without style preselection.
+10. **Risk / Durability Ω** — balance-sheet, funding, concentration, governance, regulatory, cyclicality and durability evidence.
+
+Raw total = sum of the ten blocks. There are no baseline points. Range = **0–1000**.
+
+## Forbidden size/prestige proxies
+
+These variables may exist as metadata or research context but MUST NOT add points directly:
+
+- market capitalization;
+- generic `Quality` label or generic quality score;
+- absolute FCF dollars;
+- absolute traded volume;
+- analyst count / research coverage;
+- index weight / index membership;
+- fame / brand notoriety;
+- liquidity as a prestige proxy;
+- institutional ownership merely because it is large.
+
+If an implementation accepts a direct score contribution from one of these proxies, it violates this canon.
+
+## Required normalization
+
+Use economic ratios/rates rather than size-dependent absolutes whenever possible:
+
+- FCF → FCF margin, FCF/share growth, FCF yield;
+- ROIC → level + incremental ROIC;
+- revenue → percentage growth + acceleration;
+- buybacks → net buyback yield / per-share effect;
+- volume → relative/abnormal volume versus own history;
+- flows → verified fund/ETF/positioning evidence or normalized proxies, with `MARKET_CAP_CHANGE ≠ CAPITAL_FLOW` preserved;
+- backlog/RPO → growth, conversion quality and economics, not absolute backlog prestige.
+
+## Business Score vs Opportunity Score
+
+ATLAS MUST expose two diagnostics while keeping the final 0–1000 score neutral:
+
+- **Business Score:** current economic proof, cash efficiency, growth economics and durability.
+- **Opportunity Score:** expected return/valuation, revisions, money rotation, momentum/breadth, dislocation/asymmetry and specialist capture.
+
+A great company can have a lower Opportunity Score. A less mature company can have a higher Opportunity Score only if evidence supports the return asymmetry.
+
+**BEST COMPANY ≠ BEST INVESTMENT NOW.**
+
+## Growth Saturation Ω
+
+Growth Saturation Ω replaces any mechanical market-cap ceiling as a ranking penalty.
+
+It asks whether current economics make the growth embedded in valuation increasingly difficult to sustain. It may penalize the **Growth Acceleration** block only when supported by evidence such as:
+
+- slowing percentage growth from an enlarged revenue base;
+- TAM penetration approaching a credible limit;
+- declining incremental ROIC;
+- deteriorating unit economics;
+- margin pressure required to sustain growth;
+- implausible revenue/FCF scale implied by current valuation and expected return.
+
+**Size alone is never sufficient evidence of saturation.** A $5T company and a $5B company with identical normalized economics receive identical ranking points.
+
+## Discovery / Successor Ω integration
+
+To avoid incumbent bias, discovery prioritizes evidence of acceleration rather than current scale:
+
+- revenue acceleration;
+- EPS/FCF revisions;
+- incremental ROIC;
+- operating leverage;
+- TAM capture;
+- new markets/products;
+- orders/backlog/RPO quality and conversion;
+- sponsorship/flow acceleration;
+- evidence that a new bottleneck/control point is emerging.
+
+This enables future leaders to compete before they become mega-caps.
+
+## Size classification — post-score only
+
+Only after the 0–1000 score is frozen may ATLAS reveal market capitalization and attach a diagnostic label:
+
+- **MOSQUITO:** < $10B
+- **PERIQUITO:** $10B–<$100B
+- **ELEFANTE:** $100B–<$1T
+- **DINOSAURIO:** >= $1T
+
+These buckets never alter the score or eligibility.
+
+## Bias audit
+
+Required sequence:
+
+`EVIDENCE → normalized economics → all applicable engines → 0–1000 score → FREEZE → reveal market cap → size-distribution audit`
+
+ATLAS should inspect whether the highest ranks are persistently concentrated in one size bucket. Concentration is not automatically an error. If mega-caps dominate, ATLAS must be able to show that the result comes from expected return/economic evidence rather than residual size proxies.
+
+## Evidence gate
+
+A high score with incomplete traceability remains diagnostic. Confirmed ranking eligibility requires traceable evidence. AI output is never evidence.
+
+## Falsifiers Ω
+
+Falsifiers remain an independent absolute veto. A company may retain a high diagnostic 0–1000 score while being ineligible for BUY/ranking action because a falsifier is active. The score must not erase the veto and the veto must not erase diagnostic information.
+
+## Relationship to MEGACAP RETURN CEILING Ω
+
+This canon **supersedes the mechanical size-penalty / market-cap-ceiling ranking rule** in `MEGACAP_RETURN_CEILING_OMEGA.md`.
+
+Scenario market-cap arithmetic (2x/3x/5x) may remain as a **diagnostic valuation feasibility check**, but it cannot deduct points merely because the starting market capitalization is large. Any negative scoring consequence must enter through Expected Return, Growth Saturation, valuation, incremental economics or risk with traceable evidence.
+
+## Canonical objective
+
+ATLAS does not ask:
+
+> Which company is the biggest, safest or most famous?
+
+ATLAS asks:
+
+> Where does one unit of capital receive the strongest evidence-backed combination of future growth, FCF/ROIC conversion, revisions, capital sponsorship, valuation and catalysts after risk and falsifiers?
+
+**Dinosaurio vs elefante vs periquito vs mosquito is an audit label, not an investment preference.**

--- a/src/atlas/algorithm/atlas-primary-engine-hierarchy.ts
+++ b/src/atlas/algorithm/atlas-primary-engine-hierarchy.ts
@@ -1,5 +1,5 @@
 export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
-  version: '2026-08-20-v4.3',
+  version: '2026-08-20-v4.4',
   primaryEngine: 'PRINCIPAL_OMEGA',
   primaryRole: 'structural_selection_quality_growth_asymmetry',
   refinementEngines: [
@@ -10,7 +10,7 @@ export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
     'INSTITUTIONAL_CAPITAL_ROTATION_OMEGA_V1_1', 'INSTITUTIONAL_CONVERGENCE_OMEGA_V1', 'MONEY_ROTATION_OMEGA',
     'ENERGY_ROTATION_OMEGA', 'EUROPEAN_FRAGMENTATION_ENERGY_SECURITY_OMEGA_V1_1', 'EU_FISCAL_STRESS_OMEGA_V1',
     'CHINA_INDUSTRIAL_DISPLACEMENT_OMEGA_V1', 'GOOD_COMPANIES_CHEAP_OMEGA', 'HISTORICAL_DISLOCATION_OMEGA',
-    'SPECIALIZED_ENGINES_OMEGA',
+    'SPECIALIZED_ENGINES_OMEGA', 'SIZE_NEUTRAL_RETURN_RANKING_OMEGA_V1',
   ] as const,
   conditionalSpecializedEngines: [
     'AI_DEMAND_MONETIZATION_PROOF_OMEGA_V1',
@@ -23,7 +23,8 @@ export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
   auxiliaryLayers: ['WINNER_PRESERVATION_OMEGA_V1', 'OPTIONALITY_RESERVE_OMEGA_V1', 'CAPITAL_SAFETY_LEVERAGE_DISCIPLINE_OMEGA_V1'] as const,
   transversalGates: [
     'ANTI_DELUSION_CORE_OMEGA', 'EVIDENCE_INTEGRITY_OMEGA', 'SOURCE_AUTHENTICITY_OMEGA', 'QUANTITATIVE_INTEGRITY_OMEGA',
-    'TEMPORAL_NORMALIZATION_OMEGA', 'SYSTEMIC_CASCADE_OMEGA_V1', 'FALSIFIER_VETO_OMEGA_V1', 'DECISION_SAFETY_GATE_OMEGA',
+    'TEMPORAL_NORMALIZATION_OMEGA', 'SIZE_NEUTRALITY_AUDIT_OMEGA_V1', 'SYSTEMIC_CASCADE_OMEGA_V1',
+    'FALSIFIER_VETO_OMEGA_V1', 'DECISION_SAFETY_GATE_OMEGA',
   ] as const,
   rules: [
     'PRINCIPAL OMEGA remains the structural selection engine.',
@@ -31,6 +32,9 @@ export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
     'FALSIFIER VETO is independent and absolute: a confirmed structural falsifier overrides E-Proof, valuation and Expected Return.',
     'Unverified evidence cannot be promoted to a confirmed falsifier.',
     'Price is not evidence and a trigger is not a falsifier.',
+    'SIZE-NEUTRAL RETURN RANKING starts every ticker at 0/1000; market cap and generic quality provide zero bonus and zero penalty.',
+    'Market-cap bucket is assigned only after score freeze; size distribution is an audit output, never a score input.',
+    'Growth Saturation may reduce expected-return opportunity only from economic evidence, never from size alone.',
     'AI DEMAND MONETIZATION PROOF must normalize run-rate versus realized TTM revenue and distinguish usage from paying/economically valuable demand.',
     'AI DEMAND MONETIZATION PROOF feeds demand/utilization evidence into AI CAPEX PAYBACK without double-counting.',
     'NEOCLOUD CUSTOMER ACCEPTANCE GATE is mandatory between Deployment and Revenue Recognition for material neocloud deployments; contract or deployment alone remains capped at E2.',
@@ -88,6 +92,8 @@ export const ATLAS_CANONICAL_DECISION_SEQUENCE = [
   'SYSTEMIC_CASCADE_OMEGA_V1',
   'WINNER_PRESERVATION_OMEGA_V1',
   'OPTIONALITY_RESERVE_OMEGA_V1',
+  'SIZE_NEUTRAL_RETURN_RANKING_OMEGA_V1',
+  'SIZE_NEUTRALITY_AUDIT_OMEGA_V1',
   'FALSIFIER_VETO_OMEGA_V1',
   'DECISION_SAFETY_GATE_OMEGA',
   'DECISION_LOG_OMEGA',

--- a/src/atlas/algorithm/size-neutral-return-ranking-omega.test.ts
+++ b/src/atlas/algorithm/size-neutral-return-ranking-omega.test.ts
@@ -1,0 +1,132 @@
+import {
+  auditFrozenRankingBySize,
+  evaluateSizeNeutralReturn,
+  type SizeNeutralReturnInput,
+} from './size-neutral-return-ranking-omega';
+
+const base: SizeNeutralReturnInput = {
+  ticker: 'BASE',
+  evidenceTraceable: true,
+  evidenceIds: ['filing-q2', 'cashflow-q2'],
+  economicProof: 90,
+  cashEfficiency: 88,
+  growthAcceleration: 86,
+  expectedReturnValuation: 84,
+  consensusRevisions: 82,
+  moneyRotation: 80,
+  momentumBreadth: 78,
+  dislocationAsymmetry: 76,
+  specialistEngineCapture: 74,
+  riskDurability: 72,
+};
+
+describe('Size-Neutral Return Ranking Omega', () => {
+  it('starts from zero and sums ten universal blocks to a 0..1000 score', () => {
+    const zero = evaluateSizeNeutralReturn({
+      ...base,
+      ticker: 'ZERO',
+      economicProof: 0,
+      cashEfficiency: 0,
+      growthAcceleration: 0,
+      expectedReturnValuation: 0,
+      consensusRevisions: 0,
+      moneyRotation: 0,
+      momentumBreadth: 0,
+      dislocationAsymmetry: 0,
+      specialistEngineCapture: 0,
+      riskDurability: 0,
+    });
+    const perfect = evaluateSizeNeutralReturn({
+      ...base,
+      ticker: 'PERFECT',
+      economicProof: 100,
+      cashEfficiency: 100,
+      growthAcceleration: 100,
+      expectedReturnValuation: 100,
+      consensusRevisions: 100,
+      moneyRotation: 100,
+      momentumBreadth: 100,
+      dislocationAsymmetry: 100,
+      specialistEngineCapture: 100,
+      riskDurability: 100,
+    });
+    expect(zero.score).toBe(0);
+    expect(perfect.score).toBe(1000);
+  });
+
+  it('gives identical scores to a mosquito and dinosaur with identical economics', () => {
+    const mosquito = evaluateSizeNeutralReturn({ ...base, ticker: 'SMALL', marketCapUsd: 5e9 });
+    const dinosaur = evaluateSizeNeutralReturn({ ...base, ticker: 'MEGA', marketCapUsd: 5e12 });
+    expect(mosquito.score).toBe(dinosaur.score);
+    expect(mosquito.businessScore).toBe(dinosaur.businessScore);
+    expect(mosquito.opportunityScore).toBe(dinosaur.opportunityScore);
+    expect(mosquito.sizeBucket).toBe('MOSQUITO');
+    expect(dinosaur.sizeBucket).toBe('DINOSAURIO');
+    expect(mosquito.sizeWasUsedInScore).toBe(false);
+    expect(dinosaur.sizeWasUsedInScore).toBe(false);
+  });
+
+  it('blocks hidden prestige and market-cap scoring proxies', () => {
+    expect(() => evaluateSizeNeutralReturn({
+      ...base,
+      marketCapScore: 100,
+    } as SizeNeutralReturnInput)).toThrow('SIZE_NEUTRALITY_VIOLATION:marketCapScore');
+
+    expect(() => evaluateSizeNeutralReturn({
+      ...base,
+      qualityScore: 100,
+    } as SizeNeutralReturnInput)).toThrow('SIZE_NEUTRALITY_VIOLATION:qualityScore');
+  });
+
+  it('uses Growth Saturation Omega only when economics justify it', () => {
+    const unsaturated = evaluateSizeNeutralReturn({ ...base, growthAcceleration: 90 });
+    const saturated = evaluateSizeNeutralReturn({
+      ...base,
+      growthAcceleration: 90,
+      growthSaturationPenalty: 30,
+    });
+    expect(unsaturated.growthAccelerationAdjusted).toBe(90);
+    expect(saturated.growthAccelerationAdjusted).toBe(60);
+    expect(saturated.score).toBe(unsaturated.score - 30);
+  });
+
+  it('keeps Falsifiers Omega as an absolute veto without erasing diagnostics', () => {
+    const result = evaluateSizeNeutralReturn({
+      ...base,
+      falsifierVeto: true,
+      falsifierReasons: ['accounting evidence invalidated'],
+    });
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.verdict).toBe('FALSIFIER_VETO');
+    expect(result.eligibleForRanking).toBe(false);
+  });
+
+  it('requires traceable evidence before a score can enter the confirmed ranking', () => {
+    const result = evaluateSizeNeutralReturn({
+      ...base,
+      evidenceTraceable: false,
+      evidenceIds: [],
+    });
+    expect(result.verdict).toBe('EVIDENCE_PENDING');
+    expect(result.eligibleForRanking).toBe(false);
+  });
+
+  it('audits size distribution only after frozen scores and never adjusts them', () => {
+    const results = [
+      evaluateSizeNeutralReturn({ ...base, ticker: 'M1', marketCapUsd: 4e9 }),
+      evaluateSizeNeutralReturn({ ...base, ticker: 'P1', marketCapUsd: 40e9 }),
+      evaluateSizeNeutralReturn({ ...base, ticker: 'E1', marketCapUsd: 400e9 }),
+      evaluateSizeNeutralReturn({ ...base, ticker: 'D1', marketCapUsd: 4e12 }),
+    ];
+    const before = results.map((result) => result.score);
+    const audit = auditFrozenRankingBySize(results);
+    const after = results.map((result) => result.score);
+
+    expect(before).toEqual(after);
+    expect(audit.bySize.MOSQUITO).toBe(1);
+    expect(audit.bySize.PERIQUITO).toBe(1);
+    expect(audit.bySize.ELEFANTE).toBe(1);
+    expect(audit.bySize.DINOSAURIO).toBe(1);
+    expect(audit.neutralityInvariant).toBe(true);
+  });
+});

--- a/src/atlas/algorithm/size-neutral-return-ranking-omega.ts
+++ b/src/atlas/algorithm/size-neutral-return-ranking-omega.ts
@@ -1,0 +1,242 @@
+export type SizeBucket = 'MOSQUITO' | 'PERIQUITO' | 'ELEFANTE' | 'DINOSAURIO' | 'UNKNOWN';
+
+export type ReturnRankingVerdict =
+  | 'RANK_ELIGIBLE'
+  | 'EVIDENCE_PENDING'
+  | 'FALSIFIER_VETO';
+
+export interface SizeNeutralReturnInput {
+  ticker: string;
+  evidenceTraceable: boolean;
+  evidenceIds: string[];
+
+  // Ten universal 0..100 blocks. Every security starts at zero.
+  economicProof: number;
+  cashEfficiency: number;
+  growthAcceleration: number;
+  expectedReturnValuation: number;
+  consensusRevisions: number;
+  moneyRotation: number;
+  momentumBreadth: number;
+  dislocationAsymmetry: number;
+  specialistEngineCapture: number;
+  riskDurability: number;
+
+  // Economic saturation only. This is NOT a market-cap penalty.
+  growthSaturationPenalty?: number;
+
+  // Absolute veto remains independent from the score.
+  falsifierVeto?: boolean;
+  falsifierReasons?: string[];
+
+  // Metadata used only AFTER the score is frozen.
+  marketCapUsd?: number | null;
+}
+
+export interface SizeNeutralReturnResult {
+  ticker: string;
+  score: number;
+  businessScore: number;
+  opportunityScore: number;
+  growthAccelerationAdjusted: number;
+  scoreFrozen: true;
+  verdict: ReturnRankingVerdict;
+  eligibleForRanking: boolean;
+  sizeBucket: SizeBucket;
+  sizeWasUsedInScore: false;
+  falsifierVeto: boolean;
+  reasons: string[];
+  blocks: Readonly<Record<string, number>>;
+}
+
+const FORBIDDEN_SCORE_PROXIES = new Set([
+  'marketCapScore',
+  'marketCapBonus',
+  'marketCapPenalty',
+  'qualityScore',
+  'qualityLabelScore',
+  'fameScore',
+  'brandScore',
+  'analystCountScore',
+  'indexWeightScore',
+  'liquidityScore',
+  'absoluteFcfScore',
+  'absoluteVolumeScore',
+]);
+
+function clamp100(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+/**
+ * Runtime guard against reintroducing megacap/quality bias through hidden proxies.
+ * Market cap itself is allowed only as post-score metadata.
+ */
+export function assertNoSizeOrPrestigeScoreProxy(input: SizeNeutralReturnInput): void {
+  for (const key of Object.keys(input as unknown as Record<string, unknown>)) {
+    if (FORBIDDEN_SCORE_PROXIES.has(key)) {
+      throw new Error(`SIZE_NEUTRALITY_VIOLATION:${key}`);
+    }
+  }
+}
+
+/**
+ * Size labels are diagnostic metadata. They are assigned only after the score is frozen.
+ */
+export function classifySizeAfterScoring(marketCapUsd?: number | null): SizeBucket {
+  if (marketCapUsd == null || !Number.isFinite(marketCapUsd) || marketCapUsd < 0) return 'UNKNOWN';
+  if (marketCapUsd >= 1_000_000_000_000) return 'DINOSAURIO';
+  if (marketCapUsd >= 100_000_000_000) return 'ELEFANTE';
+  if (marketCapUsd >= 10_000_000_000) return 'PERIQUITO';
+  return 'MOSQUITO';
+}
+
+/**
+ * Size-Neutral Return Ranking Ω
+ *
+ * Constitutional invariants:
+ * - score starts at 0, never at a quality/fame baseline;
+ * - market cap gives 0 bonus and 0 penalty;
+ * - absolute FCF/volume, analyst coverage and index weight never score directly;
+ * - normalized economics and expected return do score;
+ * - Growth Saturation Ω is an economics penalty, not a size penalty;
+ * - Falsifiers Ω remains an absolute veto independent from diagnostic score.
+ */
+export function evaluateSizeNeutralReturn(
+  input: SizeNeutralReturnInput,
+): SizeNeutralReturnResult {
+  assertNoSizeOrPrestigeScoreProxy(input);
+
+  const growthSaturationPenalty = clamp100(input.growthSaturationPenalty ?? 0);
+  const growthAccelerationAdjusted = Math.max(
+    0,
+    clamp100(input.growthAcceleration) - growthSaturationPenalty,
+  );
+
+  const blocks = Object.freeze({
+    economicProof: clamp100(input.economicProof),
+    cashEfficiency: clamp100(input.cashEfficiency),
+    growthAcceleration: growthAccelerationAdjusted,
+    expectedReturnValuation: clamp100(input.expectedReturnValuation),
+    consensusRevisions: clamp100(input.consensusRevisions),
+    moneyRotation: clamp100(input.moneyRotation),
+    momentumBreadth: clamp100(input.momentumBreadth),
+    dislocationAsymmetry: clamp100(input.dislocationAsymmetry),
+    specialistEngineCapture: clamp100(input.specialistEngineCapture),
+    riskDurability: clamp100(input.riskDurability),
+  });
+
+  // 10 independent 0..100 blocks => 0..1000. No baseline points exist.
+  const score = Math.round(Object.values(blocks).reduce((sum, value) => sum + value, 0));
+
+  // Business and opportunity are diagnostics, not additive bonuses.
+  const businessScore = Math.round(mean([
+    blocks.economicProof,
+    blocks.cashEfficiency,
+    blocks.growthAcceleration,
+    blocks.riskDurability,
+  ]));
+  const opportunityScore = Math.round(mean([
+    blocks.expectedReturnValuation,
+    blocks.consensusRevisions,
+    blocks.moneyRotation,
+    blocks.momentumBreadth,
+    blocks.dislocationAsymmetry,
+    blocks.specialistEngineCapture,
+  ]));
+
+  // Score is frozen before market-cap metadata is inspected.
+  const scoreFrozen = true as const;
+  const sizeBucket = classifySizeAfterScoring(input.marketCapUsd);
+
+  const falsifierVeto = input.falsifierVeto === true;
+  const evidenceOk = input.evidenceTraceable && input.evidenceIds.length >= 2;
+  const verdict: ReturnRankingVerdict = falsifierVeto
+    ? 'FALSIFIER_VETO'
+    : evidenceOk
+      ? 'RANK_ELIGIBLE'
+      : 'EVIDENCE_PENDING';
+
+  const reasons: string[] = [
+    'All securities start at 0/1000; there is no size, fame, index-membership or generic-quality baseline.',
+    'Market capitalization is assigned only as a post-score diagnostic bucket.',
+    'Final ranking targets evidence-backed expected return adjusted for risk, not company prestige.',
+  ];
+
+  if (growthSaturationPenalty > 0) {
+    reasons.push(
+      `Growth Saturation Ω reduced the growth-acceleration block by ${growthSaturationPenalty} points based on economics, not size.`,
+    );
+  }
+
+  if (!evidenceOk) {
+    reasons.push('Traceable evidence gate is incomplete; score remains diagnostic and cannot rank as confirmed.');
+  }
+
+  if (falsifierVeto) {
+    reasons.push('Falsifiers Ω veto is absolute and overrides ranking eligibility without erasing the diagnostic score.');
+    for (const reason of input.falsifierReasons ?? []) reasons.push(`FALSIFIER: ${reason}`);
+  }
+
+  return {
+    ticker: input.ticker,
+    score,
+    businessScore,
+    opportunityScore,
+    growthAccelerationAdjusted,
+    scoreFrozen,
+    verdict,
+    eligibleForRanking: verdict === 'RANK_ELIGIBLE',
+    sizeBucket,
+    sizeWasUsedInScore: false,
+    falsifierVeto,
+    reasons,
+    blocks,
+  };
+}
+
+export interface SizeNeutralityAudit {
+  total: number;
+  bySize: Record<SizeBucket, number>;
+  meanScoreBySize: Partial<Record<SizeBucket, number>>;
+  neutralityInvariant: true;
+  note: string;
+}
+
+/**
+ * Post-ranking audit only. It NEVER changes a score.
+ * Used to detect residual concentration by size after all scores are frozen.
+ */
+export function auditFrozenRankingBySize(
+  results: SizeNeutralReturnResult[],
+): SizeNeutralityAudit {
+  const buckets: SizeBucket[] = ['MOSQUITO', 'PERIQUITO', 'ELEFANTE', 'DINOSAURIO', 'UNKNOWN'];
+  const bySize = Object.fromEntries(buckets.map((bucket) => [bucket, 0])) as Record<SizeBucket, number>;
+  const scores = new Map<SizeBucket, number[]>();
+
+  for (const result of results) {
+    bySize[result.sizeBucket] += 1;
+    const values = scores.get(result.sizeBucket) ?? [];
+    values.push(result.score);
+    scores.set(result.sizeBucket, values);
+  }
+
+  const meanScoreBySize: Partial<Record<SizeBucket, number>> = {};
+  for (const [bucket, values] of scores.entries()) {
+    meanScoreBySize[bucket] = Math.round(mean(values));
+  }
+
+  return {
+    total: results.length,
+    bySize,
+    meanScoreBySize,
+    neutralityInvariant: true,
+    note: 'Size distribution is observed only after scoring. No bucket receives a bonus, penalty or exclusion.',
+  };
+}


### PR DESCRIPTION
Implements the canonical Size-Neutral Return Ranking Ω requested for ATLAS.

Changes:
- all securities start at 0/1000 across ten universal 0–100 blocks;
- market cap is post-score metadata only: 0 bonus / 0 penalty;
- generic quality, fame, analyst coverage, index weight, absolute FCF/volume and liquidity prestige proxies are forbidden as direct scoring inputs;
- adds Business Score vs Opportunity Score diagnostics;
- adds Growth Saturation Ω as an economics-based penalty, never a size penalty;
- preserves Falsifiers Ω as an independent absolute veto;
- adds post-freeze dinosaur/elephant/parakeet/mosquito size audit;
- supersedes the mechanical scoring consequence of MEGACAP RETURN CEILING Ω while retaining 2x/3x/5x feasibility arithmetic as a diagnostic;
- wires the new engine and neutrality audit into ATLAS primary hierarchy v4.4;
- adds invariance tests proving identical economics produce identical scores at $5B and $5T market caps.

No portfolio mutation and no direct trade execution are introduced.