### PR TITLE
Fix: restore selected OpenTerminalUI on current main

### DIFF
--- a/CURRENT_CANON/MOBILE_TERMINAL_UI_OMEGA.md
+++ b/CURRENT_CANON/MOBILE_TERMINAL_UI_OMEGA.md
@@ -1,0 +1,216 @@
+# ATLAS Ω MOBILE TERMINAL UI
+
+Status: ACTIVE DESIGN CANON
+Date: 2026-08-20
+
+## Objective
+
+ATLAS Ω Mobile is a dense professional investment terminal rather than a card-first consumer finance app.
+
+OpenTerminalUI remains the primary UX reference for terminal-shell behavior: persistent navigation, GO/command search, workspaces, compact information density and responsive desktop/mobile framing. ATLAS does not vendor or copy upstream source code; the implementation is original React Native code governed by ATLAS evidence and execution rules.
+
+## Portfolio-first rule
+
+The first useful surface after opening the application is the portfolio.
+
+When Trading 212 read access and a locally stored ATLAS broker-control session are available, HOME automatically loads:
+
+- account summary;
+- invested capital;
+- available cash;
+- P/L when supplied upstream;
+- current positions;
+- broker mode and environment.
+
+Portfolio polling is bounded and must respect upstream rate limits. The Trading 212 API key and secret remain server-side. Only the ATLAS broker-control token may be stored on-device, and it must use encrypted SecureStore rather than plain application storage.
+
+Money values use the account currency supplied upstream. If the provider does not supply a valid ISO currency code, ATLAS renders the numeric value without inventing a currency.
+
+If broker credentials/session are unavailable, HOME renders `BROKER GATE` / `LOCAL SESSION GATE`; it must never fabricate a portfolio.
+
+## Global index tape
+
+A world-index tape is persistent terminal chrome and is visible across workspaces.
+
+Canonical curated universe:
+
+- S&P 500
+- Nasdaq 100
+- Dow Jones
+- Russell 2000
+- Euro Stoxx 50
+- DAX
+- FTSE 100
+- CAC 40
+- IBEX 35
+- Nikkei 225
+- Hang Seng
+- Shanghai Composite
+- KOSPI
+- ASX 200
+- Sensex
+- Bovespa
+- TSX Composite
+
+Primary contract: FinancialData.Net `index-quotes`, proxied server-side through `/v1/mobile/indices`. Client refresh hint: 15 seconds unless provider/rate-limit policy requires slower cadence.
+
+Missing symbols remain `MISSING`; ATLAS must not synthesize an index from ETF/future proxies without an explicit separate contract.
+
+## Persistent terminal shell
+
+Chrome:
+
+- ATLAS Ω brand / Investment Terminal identity;
+- GO Bar for ticker and function routing;
+- global index tape;
+- horizontal function strip on mobile;
+- left function rail on wide screens;
+- bottom navigation on mobile;
+- responsive workspace frame.
+
+Canonical functions:
+
+- HOME / Cockpit
+- MKT / Markets
+- PORT / Portfolio
+- AUD / Auditar
+- WL / Watchlist
+- RES / Resultados
+- OPP / Opportunities
+- Ω / ATLAS
+- SCR / Screener
+- RSR / Research
+- CAL / Catalysts
+- NEWS / News
+- ORD / Orders
+- RSK / Risk
+- SEC / Security Hub
+- T212 / Broker Ω
+- SYS / System
+
+## AUD / Auditar
+
+Dedicated ticker-first audit surface.
+
+Current executable snapshot:
+
+- company/quote quantitative bundle;
+- Global CAPEX Chain Ω profile;
+- provider/provenance;
+- explicit engine gates for engines not yet callable from mobile.
+
+AUD accepts a ticker passed from Watchlist/terminal routes so the audit queue preserves context instead of forcing repeated symbol entry.
+
+Audit results can be saved to the local Result Journal. A saved snapshot is historical evidence of what was observed at that time; it is not retroactively rewritten because price later changed.
+
+## WL / Watchlist
+
+Persistent local candidate memory for:
+
+- candidates;
+- no-chase names;
+- catalysts;
+- re-audit queue;
+- future alert linkage.
+
+Adding to Watchlist never means BUY.
+
+## RES / Result Journal
+
+Persistent local journal of saved audit snapshots.
+
+Each record stores at minimum:
+
+- ticker;
+- timestamp;
+- provider;
+- company/sector identity;
+- observed price/valuation fields when available;
+- CAPEX Ω state when available;
+- explicit note that the snapshot is not the canonical thesis.
+
+Local persistence is operational memory, not the canonical Evidence Store. Server-side durable evidence persistence remains a separate architecture concern.
+
+## OPP / Opportunities
+
+Ranks possible opportunities without collapsing distinct questions:
+
+- Wave Detection Ω;
+- Money Rotation Ω;
+- Return / Valuation Ω;
+- GREEN / no-chase / entry discipline.
+
+A great company, a current capital receiver and an executable entry are separate states.
+
+## CAL / Catalysts
+
+Surface for earnings, guidance, clinical/FDA, macro events, investor days and thesis-changing dates. Calendar items remain `DATA GATE` until a certified event feed exists.
+
+## NEWS / News
+
+Firecrawl Search Ω is the acquisition layer. News passes source hierarchy, materiality and evidence classification before affecting any investment engine.
+
+AI output and news headlines are never evidence by themselves.
+
+## Remaining workspaces
+
+### Markets
+
+Global index tape, Money Rotation Ω, movers/breadth and Macro Regime.
+
+### ATLAS Ω
+
+Investment Committee Ω, Evidence Director, specialist engine grid, contradictions and Falsifiers Ω.
+
+### Screener
+
+Universe construction, GREEN Ω, Return Ω, rankings and filters. Passing a screener is never equivalent to BUY.
+
+### Research
+
+Firecrawl Search Ω, primary-source evidence, Clinical Evidence Shock Ω, CAPEX Chain Ω and thesis state.
+
+### Orders
+
+Trading 212 monitor/ticket/history with execution-safety gates. Demo/paper remains default and live execution remains fail-closed.
+
+### Risk
+
+Sector/factor/currency/region exposure, concentration, drawdown, correlation and regime stress when validated feeds exist.
+
+### Security Hub
+
+Ticker-first company analysis using current provider and CAPEX-chain APIs without fabricated scores.
+
+## Data rendering rule
+
+A complete UI surface may exist before its data source is certified. In that case the surface MUST display `DATA GATE`, `BROKER GATE`, `ENGINE GATE`, `INGESTION_INCOMPLETE` or an equivalent explicit state.
+
+It is forbidden to populate professional-looking terminal widgets with fabricated values that could be mistaken for live evidence.
+
+## Separation of concerns
+
+The UI is not a decision engine.
+
+Terminal shell -> data/evidence adapters -> Evidence Director Ω -> specialist engines -> Falsifiers Ω -> decision -> execution gate.
+
+Changing the visual system must not alter investment-engine contracts, broker safety gates, evidence hierarchy or credential handling.
+
+## Implementation status
+
+Implemented on branch `atlas/openterminal-mobile-shell`:
+
+- persistent responsive terminal shell;
+- GO Bar / command palette;
+- global live-index API + terminal tape;
+- portfolio-first HOME with Trading 212 auto-read session;
+- account-currency-aware portfolio values;
+- encrypted broker-control token storage;
+- AUDIT surface with ticker handoff;
+- persistent WATCHLIST;
+- persistent RESULT JOURNAL;
+- Opportunities, Catalysts and News workspaces;
+- Markets, ATLAS, Screener, Research, Orders and Risk workspaces;
+- existing Analyze, Portfolio, Broker and Settings routes preserved.
+
+Every live-data surface remains subject to provider credential/subscription and runtime certification gates.

--- a/api/mobile_v2.py
+++ b/api/mobile_v2.py
@@ -21,6 +21,26 @@ PORTFOLIO_36 = [
     "CRDO", "WISE", "RBRK", "NXT", "WST", "FTAI", "PLMR", "SE", "NVDA",
 ]
 
+GLOBAL_INDEX_UNIVERSE: list[tuple[str, str, str]] = [
+    ("^GSPC", "S&P 500", "USA"),
+    ("^NDX", "Nasdaq 100", "USA"),
+    ("^DJI", "Dow Jones", "USA"),
+    ("^RUT", "Russell 2000", "USA"),
+    ("^STOXX50E", "Euro Stoxx 50", "Europa"),
+    ("^GDAXI", "DAX", "Alemania"),
+    ("^FTSE", "FTSE 100", "Reino Unido"),
+    ("^FCHI", "CAC 40", "Francia"),
+    ("^IBEX", "IBEX 35", "España"),
+    ("^N225", "Nikkei 225", "Japón"),
+    ("^HSI", "Hang Seng", "Hong Kong"),
+    ("000001.SS", "Shanghai Composite", "China"),
+    ("^KS11", "KOSPI", "Corea del Sur"),
+    ("^AXJO", "ASX 200", "Australia"),
+    ("^BSESN", "Sensex", "India"),
+    ("^BVSP", "Bovespa", "Brasil"),
+    ("^GSPTSE", "TSX Composite", "Canadá"),
+]
+
 
 def _symbol(value: str) -> str:
     symbol = value.strip().upper()
@@ -56,6 +76,19 @@ def _pick(record: dict[str, Any], *names: str) -> Any:
         candidate = normalized.get(_key(name))
         if candidate not in (None, ""):
             return candidate
+    return None
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.replace(",", ""))
+        except ValueError:
+            return None
     return None
 
 
@@ -199,12 +232,57 @@ async def mobile_health() -> dict[str, Any]:
     return {
         "ok": True,
         "service": "atlas-mobile-v2",
-        "version": "1.0.1",
+        "version": "1.1.0",
         "financialdatanet_configured": bool(FDN_API_KEY),
         "finnhub_configured": bool(legacy.FINNHUB_TOKEN),
         "preferred_provider": "FinancialData.Net" if FDN_API_KEY else ("Finnhub" if legacy.FINNHUB_TOKEN else "none"),
         "apiKeyExposed": False,
         "generatedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/indices")
+async def mobile_indices() -> dict[str, Any]:
+    identifiers = ",".join(symbol for symbol, _, _ in GLOBAL_INDEX_UNIVERSE)
+    payload = await _fdn_get("index-quotes", {"identifiers": identifiers})
+    rows = _records(payload)
+    by_symbol: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        raw_symbol = _pick(row, "trading_symbol", "tradingSymbol", "symbol", "identifier")
+        if isinstance(raw_symbol, str) and raw_symbol.strip():
+            by_symbol[raw_symbol.strip().upper()] = row
+
+    items: list[dict[str, Any]] = []
+    for symbol, fallback_name, region in GLOBAL_INDEX_UNIVERSE:
+        row = by_symbol.get(symbol.upper(), {})
+        price = _number(_pick(row, "price", "lastPrice", "last_price", "close"))
+        change = _number(_pick(row, "change", "priceChange", "absoluteChange"))
+        percentage_change = _number(_pick(row, "percentage_change", "percentageChange", "percentChange", "changePercent"))
+        items.append({
+            "symbol": symbol,
+            "name": _pick(row, "index_name", "indexName", "name") or fallback_name,
+            "region": region,
+            "price": price,
+            "change": change,
+            "percentageChange": percentage_change,
+            "time": _pick(row, "time", "timestamp", "dateTime", "datetime"),
+            "status": "OK" if price is not None else "MISSING",
+        })
+
+    if not any(item["status"] == "OK" for item in items):
+        raise HTTPException(status_code=502, detail="FinancialData.Net index-quotes returned no usable major-index quotes; verify Premium access")
+
+    return {
+        "provider": "FinancialData.Net",
+        "providerMode": "index-quotes-realtime",
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "refreshHintSeconds": 15,
+        "items": items,
+        "guardrails": [
+            "Index quotes are market data, not evidence of capital flow by themselves.",
+            "Missing index quotes remain MISSING and are not synthesized from ETFs or futures.",
+            "Client refresh cadence is intentionally bounded to protect provider limits.",
+        ],
     }
 
 

--- a/api/test_mobile_v2.py
+++ b/api/test_mobile_v2.py
@@ -12,6 +12,16 @@ def test_portfolio_snapshot_is_36_and_unique():
     assert "NVDA" in mobile_v2.PORTFOLIO_36
 
 
+def test_global_index_universe_is_curated_and_unique():
+    symbols = [symbol for symbol, _, _ in mobile_v2.GLOBAL_INDEX_UNIVERSE]
+    assert "^GSPC" in symbols
+    assert "^NDX" in symbols
+    assert "^IBEX" in symbols
+    assert "^N225" in symbols
+    assert len(symbols) == len(set(symbols))
+    assert len(symbols) >= 15
+
+
 def test_summary_normalizer_handles_official_financialdatanet_keys():
     sections = {
         "company": [{"registrant_name": "MICROSOFT CORP", "industry": "Information technology", "market_cap": 2800000000000}],
@@ -57,6 +67,44 @@ async def test_fdn_bundle_uses_documented_year_period(monkeypatch):
     assert period_calls
     assert all(params["period"] == "year" for _, params in period_calls)
     assert ("stock-quotes", {"identifiers": "MSFT"}) in calls
+
+
+@pytest.mark.asyncio
+async def test_mobile_indices_normalizes_provider_rows_and_preserves_missing(monkeypatch):
+    monkeypatch.setattr(mobile_v2, "FDN_API_KEY", "configured")
+
+    async def fake_get(endpoint: str, params: dict[str, object]):
+        assert endpoint == "index-quotes"
+        assert "^GSPC" in str(params["identifiers"])
+        return [
+            {
+                "trading_symbol": "^GSPC",
+                "index_name": "S&P 500",
+                "time": "2026-08-20 10:00:00",
+                "price": 7000.25,
+                "change": 25.5,
+                "percentage_change": 0.37,
+            },
+            {
+                "trading_symbol": "^NDX",
+                "index_name": "Nasdaq 100",
+                "time": "2026-08-20 10:00:00",
+                "price": 26000.0,
+                "change": -50.0,
+                "percentage_change": -0.19,
+            },
+        ]
+
+    monkeypatch.setattr(mobile_v2, "_fdn_get", fake_get)
+    payload = await mobile_v2.mobile_indices()
+    assert payload["provider"] == "FinancialData.Net"
+    assert payload["refreshHintSeconds"] == 15
+    spx = next(item for item in payload["items"] if item["symbol"] == "^GSPC")
+    ndx = next(item for item in payload["items"] if item["symbol"] == "^NDX")
+    ibex = next(item for item in payload["items"] if item["symbol"] == "^IBEX")
+    assert spx["status"] == "OK" and spx["price"] == 7000.25
+    assert ndx["percentageChange"] == -0.19
+    assert ibex["status"] == "MISSING" and ibex["price"] is None
 
 
 @pytest.mark.asyncio

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,22 +1,15 @@
-import { Stack } from 'expo-router';
+import { Slot } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+
+import { TerminalShell } from '../core/ui/TerminalShell';
 
 export default function RootLayout() {
   return (
     <>
       <StatusBar style="light" />
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          contentStyle: { backgroundColor: '#07090d' },
-          animation: 'fade',
-        }}
-      >
-        <Stack.Screen name="index" />
-        <Stack.Screen name="analyze" />
-        <Stack.Screen name="portfolio" />
-        <Stack.Screen name="settings" />
-      </Stack>
+      <TerminalShell>
+        <Slot />
+      </TerminalShell>
     </>
   );
 }

--- a/mobile/app/audit.tsx
+++ b/mobile/app/audit.tsx
@@ -1,0 +1,203 @@
+import { useMemo, useState } from 'react';
+import { router, useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { CapexChainApi, CapexChainPayload } from '../core/api/capexChainApi';
+import { CompanyPayload, MobileApi } from '../core/api/mobileApi';
+import { AuditResultStore, WatchlistStore } from '../core/storage/localStore';
+
+export default function AuditScreen() {
+  const params = useLocalSearchParams<{ ticker?: string }>();
+  const initialTicker = typeof params.ticker === 'string' ? params.ticker.trim().toUpperCase() : '';
+  const [ticker, setTicker] = useState(initialTicker);
+  const [company, setCompany] = useState<CompanyPayload | null>(null);
+  const [capex, setCapex] = useState<CapexChainPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const symbol = useMemo(() => ticker.trim().toUpperCase(), [ticker]);
+
+  const run = async () => {
+    if (!symbol) return;
+    setLoading(true);
+    setStatus(null);
+    const [companyResult, capexResult] = await Promise.allSettled([
+      MobileApi.company(symbol),
+      CapexChainApi.profile(symbol),
+    ]);
+    const nextCompany = companyResult.status === 'fulfilled' ? companyResult.value : null;
+    const nextCapex = capexResult.status === 'fulfilled' ? capexResult.value : null;
+    setCompany(nextCompany);
+    setCapex(nextCapex);
+    if (!nextCompany) {
+      setStatus(companyResult.status === 'rejected' && companyResult.reason instanceof Error ? companyResult.reason.message : 'No hay datos utilizables.');
+    }
+    setLoading(false);
+  };
+
+  const save = async () => {
+    if (!company) return;
+    const summary = company.summary;
+    const now = new Date().toISOString();
+    await AuditResultStore.save({
+      id: `${company.symbol}-${now}`,
+      ticker: company.symbol,
+      createdAt: now,
+      provider: company.provider,
+      companyName: summary.name || company.symbol,
+      sector: textValue(summary.sector) || textValue(summary.industry),
+      price: numberValue(summary.price),
+      marketCap: numberValue(summary.marketCap),
+      pe: numberValue(summary.pe),
+      capexPosition: capex ? `${capex.state}${typeof capex.capexPositionScore === 'number' ? ` · ${capex.capexPositionScore}` : ''}` : null,
+      note: 'Snapshot rápido de auditoría. No sustituye Investment Committee Ω ni convierte evidencia parcial en BUY/SELL.',
+    });
+    setStatus('Resultado guardado en RESULTADOS.');
+  };
+
+  const addWatch = async () => {
+    if (!symbol) return;
+    await WatchlistStore.add(symbol);
+    setStatus(`${symbol} añadido a WATCHLIST.`);
+  };
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+      <View style={styles.header}>
+        <Text style={styles.code}>AUD</Text>
+        <View style={styles.headerText}>
+          <Text style={styles.eyebrow}>ATLAS TERMINAL · AUDIT</Text>
+          <Text style={styles.title}>Auditar</Text>
+        </View>
+      </View>
+
+      <Text style={styles.description}>Pantalla dedicada para lanzar una auditoría ticker-first. Ejecuta el snapshot cuantitativo disponible y Global CAPEX Chain Ω; los motores no conectados siguen apareciendo como gates, no como resultados inventados.</Text>
+
+      <View style={styles.inputRow}>
+        <TextInput
+          value={ticker}
+          onChangeText={setTicker}
+          autoCapitalize="characters"
+          autoCorrect={false}
+          placeholder="TSM / ASML / ARVN"
+          placeholderTextColor="#4c5b60"
+          style={styles.input}
+          returnKeyType="search"
+          onSubmitEditing={() => { void run(); }}
+        />
+        <Pressable onPress={() => { void run(); }} style={({ pressed }) => [styles.run, pressed && styles.pressed]}>
+          <Text style={styles.runText}>RUN AUDIT</Text>
+        </Pressable>
+      </View>
+
+      {loading ? <View style={styles.loading}><ActivityIndicator color="#53efbd" /><Text style={styles.muted}>Consultando evidencia…</Text></View> : null}
+      {status ? <Text style={styles.status}>{status}</Text> : null}
+
+      <View style={styles.engineGrid}>
+        <Engine label="Company / Quote" state={company ? 'READY' : 'DATA GATE'} />
+        <Engine label="Global CAPEX Chain Ω" state={capex ? 'READY' : 'DATA GATE'} />
+        <Engine label="GREEN Ω" state="ENGINE GATE" />
+        <Engine label="Retorno Ω" state="ENGINE GATE" />
+        <Engine label="Money Rotation Ω" state="ENGINE GATE" />
+        <Engine label="Falsifiers Ω" state="ENGINE GATE" />
+      </View>
+
+      {company ? (
+        <View style={styles.panel}>
+          <View style={styles.panelTop}>
+            <View>
+              <Text style={styles.symbol}>{company.symbol}</Text>
+              <Text style={styles.name}>{company.summary.name || company.symbol}</Text>
+            </View>
+            <Text style={styles.provider}>{company.provider}</Text>
+          </View>
+          <View style={styles.metrics}>
+            <Metric label="PRICE" value={formatNumber(company.summary.price)} />
+            <Metric label="MARKET CAP" value={formatCompact(company.summary.marketCap)} />
+            <Metric label="P/E" value={formatNumber(company.summary.pe)} />
+            <Metric label="SECTOR" value={textValue(company.summary.sector) || textValue(company.summary.industry) || 'N/D'} />
+          </View>
+          {capex ? (
+            <View style={styles.capexLine}>
+              <Text style={styles.capexLabel}>CAPEX Ω</Text>
+              <Text style={styles.capexValue}>{capex.state} · position {capex.capexPositionScore ?? 'N/D'} · structural {capex.structuralOpportunityScore ?? 'N/D'}</Text>
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+
+      {company ? (
+        <View style={styles.actions}>
+          <Pressable onPress={() => { void save(); }} style={({ pressed }) => [styles.action, pressed && styles.pressed]}><Text style={styles.actionText}>GUARDAR RESULTADO</Text></Pressable>
+          <Pressable onPress={() => { void addWatch(); }} style={({ pressed }) => [styles.action, pressed && styles.pressed]}><Text style={styles.actionText}>+ WATCHLIST</Text></Pressable>
+          <Pressable onPress={() => router.push(`/analyze?ticker=${encodeURIComponent(company.symbol)}` as never)} style={({ pressed }) => [styles.action, pressed && styles.pressed]}><Text style={styles.actionText}>SECURITY HUB →</Text></Pressable>
+        </View>
+      ) : null}
+
+      <View style={styles.rule}>
+        <Text style={styles.ruleTitle}>AUDIT RULE</Text>
+        <Text style={styles.ruleText}>Guardar un snapshot conserva lo observado y su proveedor. No convierte el snapshot en tesis canónica ni reemplaza evidencia primaria, contradicciones o Falsifiers Ω.</Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+function Engine({ label, state }: { label: string; state: string }) {
+  const ready = state === 'READY';
+  return <View style={styles.engine}><Text style={styles.engineLabel}>{label}</Text><Text style={[styles.engineState, ready && styles.engineReady]}>{state}</Text></View>;
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return <View style={styles.metric}><Text style={styles.metricLabel}>{label}</Text><Text style={styles.metricValue}>{value}</Text></View>;
+}
+
+function numberValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') { const parsed = Number(value); return Number.isFinite(parsed) ? parsed : null; }
+  return null;
+}
+function textValue(value: unknown): string | null { return typeof value === 'string' && value.trim() ? value.trim() : null; }
+function formatNumber(value: unknown): string { const n = numberValue(value); return n === null ? 'N/D' : n.toLocaleString('es-ES', { maximumFractionDigits: 2 }); }
+function formatCompact(value: unknown): string { const n = numberValue(value); return n === null ? 'N/D' : new Intl.NumberFormat('es-ES', { notation: 'compact', maximumFractionDigits: 2 }).format(n); }
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#050708' },
+  content: { paddingHorizontal: 12, paddingTop: 14, paddingBottom: 28, gap: 12 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 12, borderBottomWidth: 1, borderBottomColor: '#1b272c', paddingBottom: 12 },
+  code: { width: 48, height: 48, textAlign: 'center', textAlignVertical: 'center', borderWidth: 1, borderColor: '#2f725b', backgroundColor: '#071510', color: '#54efbd', fontFamily: 'monospace', fontWeight: '900' },
+  headerText: { flex: 1 },
+  eyebrow: { color: '#5e7379', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1.1 },
+  title: { color: '#eff5f3', fontFamily: 'monospace', fontSize: 24, fontWeight: '900', marginTop: 3 },
+  description: { color: '#8c9a9f', fontSize: 12, lineHeight: 18 },
+  inputRow: { flexDirection: 'row', gap: 8 },
+  input: { flex: 1, minWidth: 0, borderWidth: 1, borderColor: '#26383e', backgroundColor: '#080d0f', color: '#edf5f2', paddingHorizontal: 12, minHeight: 46, fontFamily: 'monospace' },
+  run: { justifyContent: 'center', borderWidth: 1, borderColor: '#2f725b', backgroundColor: '#071510', paddingHorizontal: 12 },
+  runText: { color: '#54efbd', fontFamily: 'monospace', fontSize: 9, fontWeight: '900' },
+  loading: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  muted: { color: '#77878c', fontFamily: 'monospace', fontSize: 10 },
+  status: { color: '#9fd9c7', borderLeftWidth: 2, borderLeftColor: '#2f725b', paddingLeft: 9, fontSize: 11 },
+  engineGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 7 },
+  engine: { width: '48%', minWidth: 145, borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#080d0f', padding: 10, gap: 5 },
+  engineLabel: { color: '#c3cfcc', fontSize: 10, fontWeight: '800' },
+  engineState: { color: '#856e44', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  engineReady: { color: '#4de7b4' },
+  panel: { borderWidth: 1, borderColor: '#22343a', backgroundColor: '#070c0e', padding: 12, gap: 12 },
+  panelTop: { flexDirection: 'row', justifyContent: 'space-between', gap: 10 },
+  symbol: { color: '#f1f6f4', fontFamily: 'monospace', fontSize: 22, fontWeight: '900' },
+  name: { color: '#718187', fontSize: 11, marginTop: 3 },
+  provider: { color: '#5be6ba', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  metrics: { flexDirection: 'row', flexWrap: 'wrap', gap: 7 },
+  metric: { minWidth: 120, flexGrow: 1, borderTopWidth: 1, borderTopColor: '#1b292e', paddingTop: 8 },
+  metricLabel: { color: '#506067', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' },
+  metricValue: { color: '#dbe5e2', fontFamily: 'monospace', fontSize: 11, fontWeight: '800', marginTop: 4 },
+  capexLine: { borderTopWidth: 1, borderTopColor: '#1b292e', paddingTop: 9 },
+  capexLabel: { color: '#52e6b7', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  capexValue: { color: '#93a29f', fontSize: 10, marginTop: 4 },
+  actions: { flexDirection: 'row', flexWrap: 'wrap', gap: 7 },
+  action: { borderWidth: 1, borderColor: '#2b4540', backgroundColor: '#08110e', paddingVertical: 10, paddingHorizontal: 11 },
+  actionText: { color: '#a8ddd0', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  pressed: { opacity: 0.68 },
+  rule: { borderTopWidth: 1, borderTopColor: '#1a2428', paddingTop: 12 },
+  ruleTitle: { color: '#4fe8b6', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 },
+  ruleText: { color: '#718087', fontSize: 10, lineHeight: 16, marginTop: 5 },
+});

--- a/mobile/app/broker.tsx
+++ b/mobile/app/broker.tsx
@@ -3,6 +3,7 @@ import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 
 import { BrokerApi, BrokerEnvelope, BrokerStatus } from '../core/api/brokerApi';
+import { BrokerSession } from '../core/security/brokerSession';
 
 export default function BrokerScreen() {
   const [status, setStatus] = useState<BrokerStatus | null>(null);
@@ -14,6 +15,7 @@ export default function BrokerScreen() {
   const [instruments, setInstruments] = useState<BrokerEnvelope | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sessionSaved, setSessionSaved] = useState(false);
 
   const loadStatus = async () => {
     try {
@@ -23,7 +25,15 @@ export default function BrokerScreen() {
     }
   };
 
-  useEffect(() => { void loadStatus(); }, []);
+  useEffect(() => {
+    void loadStatus();
+    void BrokerSession.getControlToken().then((token) => {
+      if (token) {
+        setControlToken(token);
+        setSessionSaved(true);
+      }
+    });
+  }, []);
 
   const syncPrivate = async () => {
     if (!controlToken.trim()) {
@@ -43,8 +53,26 @@ export default function BrokerScreen() {
     const failures = [accountResult, positionsResult, ordersResult]
       .filter((item): item is PromiseRejectedResult => item.status === 'rejected')
       .map((item) => item.reason instanceof Error ? item.reason.message : String(item.reason));
+    const success = [accountResult, positionsResult, ordersResult].some((item) => item.status === 'fulfilled');
+    if (success) {
+      try {
+        await BrokerSession.saveControlToken(controlToken);
+        setSessionSaved(true);
+      } catch (cause) {
+        failures.push(cause instanceof Error ? cause.message : String(cause));
+      }
+    }
     if (failures.length) setError(failures.join('\n'));
     setLoading(false);
+  };
+
+  const forgetSession = async () => {
+    await BrokerSession.clearControlToken();
+    setControlToken('');
+    setSessionSaved(false);
+    setAccount(null);
+    setPositions(null);
+    setOrders(null);
   };
 
   const search = async () => {
@@ -63,38 +91,28 @@ export default function BrokerScreen() {
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
-      <Pressable accessibilityRole="button" accessibilityLabel="Volver" onPress={() => router.back()} style={styles.back}><Text style={styles.backText}>← Inicio</Text></Pressable>
+      <Pressable accessibilityRole="button" accessibilityLabel="Volver" onPress={() => router.back()} style={styles.back}><Text style={styles.backText}>← Terminal</Text></Pressable>
       <Text style={styles.eyebrow}>BROKER Ω · TRADING 212</Text>
       <Text style={styles.title}>Cuenta conectada</Text>
-      <Text style={styles.subtitle}>Bridge server-side. La APK no contiene tu API key ni tu API secret de Trading 212. Esta pantalla es de lectura y verificación.</Text>
+      <Text style={styles.subtitle}>Bridge server-side. La APK no contiene tu API key ni tu API secret de Trading 212. El token de control puede guardarse cifrado en SecureStore para cargar la cartera automáticamente al abrir ATLAS.</Text>
 
       <View style={styles.card}>
         <Row label="Bridge" value={status ? 'ONLINE' : 'CONECTANDO'} good={Boolean(status)} />
         <Row label="Entorno" value={status ? `${status.environment.toUpperCase()} · ${status.mode}` : '—'} />
         <Row label="Credenciales" value={status?.credentialsConfigured ? 'CONFIGURADAS' : 'PENDIENTES EN SERVIDOR'} good={status?.credentialsConfigured} />
         <Row label="Lectura" value={status?.readReady ? 'LISTA' : 'BLOQUEADA'} good={status?.readReady} />
+        <Row label="Sesión local" value={sessionSaved ? 'CIFRADA EN DISPOSITIVO' : 'NO GUARDADA'} good={sessionSaved} />
         <Row label="Órdenes live" value={status?.liveExecutionLocked === false ? 'HABILITADAS' : 'BLOQUEADAS'} good={status?.liveExecutionLocked !== false} />
       </View>
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>ACCESO PRIVADO</Text>
-        <TextInput
-          accessibilityLabel="Token de control ATLAS Broker"
-          value={controlToken}
-          onChangeText={setControlToken}
-          secureTextEntry
-          autoCapitalize="none"
-          autoCorrect={false}
-          placeholder="ATLAS_BROKER_CONTROL_TOKEN"
-          placeholderTextColor="#64748b"
-          style={styles.input}
-        />
-        <Pressable accessibilityRole="button" accessibilityLabel="Sincronizar cuenta" onPress={() => { void syncPrivate(); }} style={({ pressed }) => [styles.button, pressed && styles.pressed]}>
-          <Text style={styles.buttonText}>SINCRONIZAR CUENTA</Text>
-        </Pressable>
+        <TextInput accessibilityLabel="Token de control ATLAS Broker" value={controlToken} onChangeText={setControlToken} secureTextEntry autoCapitalize="none" autoCorrect={false} placeholder="ATLAS_BROKER_CONTROL_TOKEN" placeholderTextColor="#64748b" style={styles.input} />
+        <Pressable accessibilityRole="button" accessibilityLabel="Sincronizar cuenta" onPress={() => { void syncPrivate(); }} style={({ pressed }) => [styles.button, pressed && styles.pressed]}><Text style={styles.buttonText}>SINCRONIZAR + GUARDAR SESIÓN</Text></Pressable>
+        {sessionSaved ? <Pressable onPress={() => { void forgetSession(); }} style={({ pressed }) => [styles.forgetButton, pressed && styles.pressed]}><Text style={styles.forgetText}>OLVIDAR TOKEN LOCAL</Text></Pressable> : null}
       </View>
 
-      {loading ? <View style={styles.loading}><ActivityIndicator color="#7dd3fc" /><Text style={styles.muted}>Consultando Trading 212…</Text></View> : null}
+      {loading ? <View style={styles.loading}><ActivityIndicator color="#53efbd" /><Text style={styles.muted}>Consultando Trading 212…</Text></View> : null}
       {error ? <Text style={styles.error}>{error}</Text> : null}
 
       {account ? <JsonCard title="ACCOUNT SUMMARY" envelope={account} /> : null}
@@ -103,82 +121,30 @@ export default function BrokerScreen() {
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>INSTRUMENTOS TRADING 212</Text>
-        <TextInput
-          accessibilityLabel="Buscar instrumento Trading 212"
-          value={query}
-          onChangeText={setQuery}
-          autoCapitalize="characters"
-          autoCorrect={false}
-          placeholder="AAPL / ASML / TSM"
-          placeholderTextColor="#64748b"
-          style={styles.input}
-          returnKeyType="search"
-          onSubmitEditing={() => { void search(); }}
-        />
-        <Pressable accessibilityRole="button" accessibilityLabel="Buscar instrumento" onPress={() => { void search(); }} style={({ pressed }) => [styles.secondaryButton, pressed && styles.pressed]}>
-          <Text style={styles.secondaryText}>BUSCAR TICKER EXACTO T212</Text>
-        </Pressable>
+        <TextInput accessibilityLabel="Buscar instrumento Trading 212" value={query} onChangeText={setQuery} autoCapitalize="characters" autoCorrect={false} placeholder="AAPL / ASML / TSM" placeholderTextColor="#64748b" style={styles.input} returnKeyType="search" onSubmitEditing={() => { void search(); }} />
+        <Pressable accessibilityRole="button" accessibilityLabel="Buscar instrumento" onPress={() => { void search(); }} style={({ pressed }) => [styles.secondaryButton, pressed && styles.pressed]}><Text style={styles.secondaryText}>BUSCAR TICKER EXACTO T212</Text></Pressable>
         {instruments ? <Text style={styles.jsonText}>{prettyJson(instruments.data)}</Text> : null}
       </View>
 
       <View style={styles.guardrailCard}>
         <Text style={styles.guardrailTitle}>EXECUTION GUARDRAIL</Text>
-        <Text style={styles.guardrailText}>La infraestructura market/limit/stop/stop-limit está preparada en el backend, pero esta pantalla no ofrece botones de ejecución. LIVE permanece bloqueado por defecto y nunca se activa por una señal de inversión automáticamente.</Text>
+        <Text style={styles.guardrailText}>SecureStore guarda sólo el token de control local. Las credenciales de Trading 212 permanecen server-side. LIVE sigue fail-closed y ninguna señal ATLAS puede ejecutar una orden automáticamente.</Text>
       </View>
     </ScrollView>
   );
 }
 
-function Row({ label, value, good }: { label: string; value: string; good?: boolean }) {
-  return <View style={styles.row}><Text style={styles.label}>{label}</Text><Text style={[styles.value, good === true && styles.good, good === false && styles.warn]}>{value}</Text></View>;
-}
-
-function JsonCard({ title, envelope }: { title: string; envelope: BrokerEnvelope }) {
-  return (
-    <View style={styles.card}>
-      <Text style={styles.cardTitle}>{title}</Text>
-      <Text style={styles.rate}>Rate remaining: {envelope.rateLimit?.remaining ?? 'N/D'} · reset: {envelope.rateLimit?.reset ?? 'N/D'}</Text>
-      <Text style={styles.jsonText}>{prettyJson(envelope.data)}</Text>
-    </View>
-  );
-}
-
-function prettyJson(value: unknown): string {
-  try {
-    const text = JSON.stringify(value, null, 2);
-    return text.length > 6000 ? `${text.slice(0, 6000)}\n…` : text;
-  } catch {
-    return String(value);
-  }
-}
+function Row({ label, value, good }: { label: string; value: string; good?: boolean }) { return <View style={styles.row}><Text style={styles.label}>{label}</Text><Text style={[styles.value, good === true && styles.good, good === false && styles.warn]}>{value}</Text></View>; }
+function JsonCard({ title, envelope }: { title: string; envelope: BrokerEnvelope }) { return <View style={styles.card}><Text style={styles.cardTitle}>{title}</Text><Text style={styles.rate}>Rate remaining: {envelope.rateLimit?.remaining ?? 'N/D'} · reset: {envelope.rateLimit?.reset ?? 'N/D'}</Text><Text style={styles.jsonText}>{prettyJson(envelope.data)}</Text></View>; }
+function prettyJson(value: unknown): string { try { const text = JSON.stringify(value, null, 2); return text.length > 6000 ? `${text.slice(0, 6000)}\n…` : text; } catch { return String(value); } }
 
 const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#07090d' },
-  content: { paddingTop: 54, paddingHorizontal: 18, paddingBottom: 44, gap: 12 },
-  back: { alignSelf: 'flex-start', paddingVertical: 8, paddingRight: 14 },
-  backText: { color: '#7dd3fc', fontWeight: '800' },
-  eyebrow: { color: '#7dd3fc', fontWeight: '900', fontSize: 12, letterSpacing: 1.1 },
-  title: { color: '#f8fafc', fontSize: 31, fontWeight: '900' },
-  subtitle: { color: '#94a3b8', lineHeight: 21 },
-  card: { backgroundColor: '#0f141c', borderRadius: 16, borderWidth: 1, borderColor: '#223047', padding: 14, gap: 10 },
-  cardTitle: { color: '#cbd5e1', fontWeight: '900', fontSize: 11, letterSpacing: 1 },
-  row: { gap: 3, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: '#253044', paddingBottom: 8 },
-  label: { color: '#64748b', fontSize: 11, fontWeight: '800', textTransform: 'uppercase' },
-  value: { color: '#e2e8f0', fontWeight: '800' },
-  good: { color: '#34d399' },
-  warn: { color: '#fbbf24' },
-  input: { backgroundColor: '#070a0f', borderRadius: 12, borderWidth: 1, borderColor: '#334155', color: '#f8fafc', paddingHorizontal: 14, paddingVertical: 13 },
-  button: { backgroundColor: '#0ea5e9', paddingVertical: 14, borderRadius: 12, alignItems: 'center' },
-  buttonText: { color: '#03111a', fontWeight: '900' },
-  secondaryButton: { borderWidth: 1, borderColor: '#0ea5e9', paddingVertical: 13, borderRadius: 12, alignItems: 'center' },
-  secondaryText: { color: '#7dd3fc', fontWeight: '900' },
-  pressed: { opacity: 0.7 },
-  loading: { flexDirection: 'row', alignItems: 'center', gap: 9, padding: 8 },
-  muted: { color: '#94a3b8' },
-  error: { color: '#fca5a5', backgroundColor: '#241318', padding: 13, borderRadius: 12 },
-  rate: { color: '#64748b', fontSize: 11 },
-  jsonText: { color: '#cbd5e1', fontFamily: 'monospace', fontSize: 11, lineHeight: 16 },
-  guardrailCard: { backgroundColor: '#111827', borderRadius: 14, padding: 14, gap: 7 },
-  guardrailTitle: { color: '#a5b4fc', fontWeight: '900', fontSize: 11, letterSpacing: 1 },
-  guardrailText: { color: '#cbd5e1', lineHeight: 19 },
+  screen: { flex: 1, backgroundColor: '#050708' }, content: { paddingTop: 18, paddingHorizontal: 12, paddingBottom: 34, gap: 12 },
+  back: { alignSelf: 'flex-start', paddingVertical: 6, paddingRight: 14 }, backText: { color: '#65ddb9', fontFamily: 'monospace', fontWeight: '800', fontSize: 9 },
+  eyebrow: { color: '#5f7379', fontFamily: 'monospace', fontWeight: '900', fontSize: 8, letterSpacing: 1.1 }, title: { color: '#eff5f3', fontFamily: 'monospace', fontSize: 26, fontWeight: '900' }, subtitle: { color: '#819097', lineHeight: 18, fontSize: 11 },
+  card: { backgroundColor: '#080d0f', borderWidth: 1, borderColor: '#213138', padding: 12, gap: 10 }, cardTitle: { color: '#b8c5c1', fontFamily: 'monospace', fontWeight: '900', fontSize: 8, letterSpacing: 1 },
+  row: { gap: 3, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: '#1b292e', paddingBottom: 8 }, label: { color: '#526168', fontSize: 8, fontFamily: 'monospace', fontWeight: '800', textTransform: 'uppercase' }, value: { color: '#dce6e2', fontFamily: 'monospace', fontWeight: '800', fontSize: 9 }, good: { color: '#4de7b4' }, warn: { color: '#ddb95f' },
+  input: { backgroundColor: '#050809', borderWidth: 1, borderColor: '#2c3a40', color: '#eef5f3', paddingHorizontal: 12, paddingVertical: 12, fontFamily: 'monospace' }, button: { backgroundColor: '#0b2b21', borderWidth: 1, borderColor: '#2f725b', paddingVertical: 13, alignItems: 'center' }, buttonText: { color: '#65e9bd', fontFamily: 'monospace', fontWeight: '900', fontSize: 9 }, forgetButton: { borderWidth: 1, borderColor: '#55383a', paddingVertical: 10, alignItems: 'center' }, forgetText: { color: '#c78084', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, secondaryButton: { borderWidth: 1, borderColor: '#315b75', paddingVertical: 12, alignItems: 'center' }, secondaryText: { color: '#8bc8eb', fontFamily: 'monospace', fontWeight: '900', fontSize: 8 },
+  pressed: { opacity: 0.68 }, loading: { flexDirection: 'row', alignItems: 'center', gap: 9, padding: 8 }, muted: { color: '#7e8c91', fontFamily: 'monospace', fontSize: 9 }, error: { color: '#e79a9a', backgroundColor: '#1d0e10', padding: 11, fontSize: 10 }, rate: { color: '#56656b', fontSize: 8, fontFamily: 'monospace' }, jsonText: { color: '#b8c6c2', fontFamily: 'monospace', fontSize: 9, lineHeight: 14 },
+  guardrailCard: { backgroundColor: '#0b1013', borderTopWidth: 1, borderTopColor: '#223039', padding: 12, gap: 7 }, guardrailTitle: { color: '#8ba9c0', fontFamily: 'monospace', fontWeight: '900', fontSize: 8, letterSpacing: 1 }, guardrailText: { color: '#7e8d92', lineHeight: 16, fontSize: 10 },
 });

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,258 +1,172 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { router } from 'expo-router';
 import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 
+import { BrokerApi, BrokerEnvelope, BrokerStatus } from '../core/api/brokerApi';
 import { MobileApi, MobileHealth } from '../core/api/mobileApi';
-
-const MARKET_TAPE = [
-  { symbol: 'SPX', state: 'LIVE', meta: 'US Large Cap' },
-  { symbol: 'NDX', state: 'LIVE', meta: 'AI / Growth' },
-  { symbol: 'STOXX', state: 'WATCH', meta: 'Europe Receiver' },
-  { symbol: 'GOLD', state: 'FLOW', meta: 'Macro Hedge' },
-  { symbol: 'BRENT', state: 'RISK', meta: 'Energy Gate' },
-];
-
-const COMMANDS = ['AUDIT TICKER', 'PORTFOLIO FIRST', 'WATCHLIST', 'RESULTS', 'SYSTEM'];
+import { BrokerSession } from '../core/security/brokerSession';
 
 export default function HomeScreen() {
   const [health, setHealth] = useState<MobileHealth | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [brokerStatus, setBrokerStatus] = useState<BrokerStatus | null>(null);
+  const [account, setAccount] = useState<BrokerEnvelope | null>(null);
+  const [positions, setPositions] = useState<BrokerEnvelope | null>(null);
+  const [portfolioError, setPortfolioError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
   const load = async () => {
-    setError(null);
-    try {
-      setHealth(await MobileApi.health());
-    } catch (cause) {
-      setHealth(null);
-      setError(cause instanceof Error ? cause.message : String(cause));
+    const [healthResult, brokerStatusResult, token] = await Promise.allSettled([
+      MobileApi.health(),
+      BrokerApi.status(),
+      BrokerSession.getControlToken(),
+    ]);
+    setHealth(healthResult.status === 'fulfilled' ? healthResult.value : null);
+    setBrokerStatus(brokerStatusResult.status === 'fulfilled' ? brokerStatusResult.value : null);
+
+    const controlToken = token.status === 'fulfilled' ? token.value : null;
+    if (!controlToken) {
+      setAccount(null);
+      setPositions(null);
+      setPortfolioError(null);
+      return;
     }
+
+    const [accountResult, positionsResult] = await Promise.allSettled([
+      BrokerApi.account(controlToken),
+      BrokerApi.positions(controlToken),
+    ]);
+    setAccount(accountResult.status === 'fulfilled' ? accountResult.value : null);
+    setPositions(positionsResult.status === 'fulfilled' ? positionsResult.value : null);
+    const failure = accountResult.status === 'rejected' ? accountResult.reason : positionsResult.status === 'rejected' ? positionsResult.reason : null;
+    setPortfolioError(failure instanceof Error ? failure.message : failure ? String(failure) : null);
   };
 
-  useEffect(() => { void load(); }, []);
+  useEffect(() => {
+    let mounted = true;
+    const safeLoad = async () => { if (mounted) await load(); };
+    void safeLoad();
+    const timer = setInterval(() => { void safeLoad(); }, 30000);
+    return () => { mounted = false; clearInterval(timer); };
+  }, []);
 
-  const refresh = async () => {
-    setRefreshing(true);
-    await load();
-    setRefreshing(false);
-  };
-
+  const refresh = async () => { setRefreshing(true); await load(); setRefreshing(false); };
   const online = health?.ok === true;
-  const provider = health?.preferred_provider || 'Conectando';
-  const systemState = useMemo(() => (online ? 'ONLINE' : health ? 'DEGRADED' : 'CONNECTING'), [online, health]);
 
   return (
-    <ScrollView
-      style={styles.screen}
-      contentContainerStyle={styles.content}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => { void refresh(); }} tintColor="#38bdf8" />}
-    >
-      <View style={styles.terminalTopBar}>
-        <View>
-          <Text style={styles.product}>ATLAS Ω TERMINAL</Text>
-          <Text style={styles.version}>OPEN TERMINAL UI · MOBILE DESK</Text>
-        </View>
-        <View style={[styles.statusPill, online ? styles.statusPillOnline : styles.statusPillWarn]}>
-          <Text style={styles.statusPillText}>{systemState}</Text>
-        </View>
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content} refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => { void refresh(); }} tintColor="#45e8b4" />}>
+      <View style={styles.pageHeader}>
+        <View><Text style={styles.eyebrow}>ATLAS Ω · TERMINAL COCKPIT</Text><Text style={styles.title}>Portfolio First</Text></View>
+        <View style={[styles.engineBadge, online ? styles.engineOnline : styles.engineOffline]}><View style={[styles.engineDot, online ? styles.dotOnline : styles.dotOffline]} /><Text style={styles.engineText}>{online ? 'ENGINE ONLINE' : 'DEGRADED'}</Text></View>
       </View>
 
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.tape}>
-        {MARKET_TAPE.map((item) => (
-          <View key={item.symbol} style={styles.tapeCell}>
-            <Text style={styles.tapeSymbol}>{item.symbol}</Text>
-            <Text style={styles.tapeState}>{item.state}</Text>
-            <Text style={styles.tapeMeta}>{item.meta}</Text>
-          </View>
-        ))}
-      </ScrollView>
+      <LivePortfolio account={account} positions={positions} brokerStatus={brokerStatus} error={portfolioError} />
 
-      <View style={styles.commandBar}>
-        <Text style={styles.commandPrompt}>⌘</Text>
-        <View style={styles.commandTextWrap}>
-          <Text style={styles.commandTitle}>Command Center</Text>
-          <Text style={styles.commandSub}>Portfolio First · Audit · Watchlist · Resultados · Sistema</Text>
-        </View>
+      <View style={styles.statusStrip}>
+        <StatusCell label="DATA" value={health?.preferred_provider || 'CONNECTING'} tone={health?.financialdatanet_configured ? 'good' : 'warn'} />
+        <StatusCell label="T212" value={brokerStatus?.readReady ? `${brokerStatus.mode} READY` : 'BROKER GATE'} tone={brokerStatus?.readReady ? 'good' : 'warn'} />
+        <StatusCell label="REFRESH" value="30s PORT · 15s INDEX" tone="neutral" />
       </View>
 
-      <View style={styles.providerPanel}>
-        <View style={styles.panelHeaderRow}>
-          <Text style={styles.panelTitle}>DATA ENGINE</Text>
-          {!health && !error ? <ActivityIndicator color="#38bdf8" /> : null}
-        </View>
-        <Text style={styles.panelMain}>{online ? 'Motor conectado al backend real' : health ? 'Motor degradado' : 'Conectando con backend'}</Text>
-        <Text style={styles.panelMuted}>Proveedor preferido: {provider}</Text>
-        {health ? (
-          <View style={styles.providerRow}>
-            <Badge label="FinancialData.Net" active={health.financialdatanet_configured} />
-            <Badge label="Finnhub fallback" active={health.finnhub_configured} />
-          </View>
-        ) : null}
-        {error ? <Text style={styles.error}>Backend no disponible: {error}</Text> : null}
+      <SectionHeader code="01" title="Primary Workspaces" />
+      <View style={styles.tiles}>
+        <WorkspaceTile code="AUD" title="Auditar" meta="Run · engines · evidence gates" route="/audit" />
+        <WorkspaceTile code="WL" title="Watchlist" meta="Candidates · no-chase · alerts" route="/watchlist" />
+        <WorkspaceTile code="RES" title="Resultados" meta="Saved snapshots · history" route="/results" />
+        <WorkspaceTile code="OPP" title="Opportunities" meta="Wave · rotation · priority" route="/workspace/opportunities" />
+        <WorkspaceTile code="MKT" title="Markets" meta="Global indices · macro · movers" route="/workspace/markets" />
+        <WorkspaceTile code="Ω" title="ATLAS" meta="Committee · engines · falsifiers" route="/workspace/atlas" />
       </View>
 
-      <View style={styles.sectionRow}>
-        <Text style={styles.sectionTitle}>Portfolio First</Text>
-        <Text style={styles.sectionHint}>Abrir → auditar → decidir</Text>
+      <SectionHeader code="02" title="Decision Stack" />
+      <View style={styles.stack}>
+        <PriorityRow rank="01" title="Audit queue" detail="Ticker → evidence → specialist engines → contradictions → falsifiers." state="ACTIVE" route="/audit" />
+        <PriorityRow rank="02" title="Market rotation" detail="Current-flow questions route through Money Rotation Ω before quality filters." state="ACTIVE" route="/workspace/markets" />
+        <PriorityRow rank="03" title="Catalysts" detail="Earnings, FDA, macro events and thesis-changing evidence." state="ACTIVE" route="/workspace/catalysts" />
+        <PriorityRow rank="04" title="Execution" detail="Trading 212 stays paper-first; live execution remains fail-closed." state="GATED" route="/workspace/orders" />
       </View>
 
-      <Pressable accessibilityRole="button" accessibilityLabel="Portfolio First" onPress={() => router.push('/portfolio')} style={({ pressed }) => [styles.mainDeck, pressed && styles.pressed]}>
-        <View style={styles.deckHeader}>
-          <View>
-            <Text style={styles.deckKicker}>LIVE DESK</Text>
-            <Text style={styles.deckTitle}>Cartera 36</Text>
-          </View>
-          <Text style={styles.deckAction}>OPEN</Text>
-        </View>
-        <View style={styles.metricsGrid}>
-          <Metric label="Evidence" value="REAL" tone="blue" />
-          <Metric label="Trading" value="T212" tone="cyan" />
-          <Metric label="Risk" value="GATED" tone="amber" />
-        </View>
-        <Text style={styles.deckNote}>Snapshot de cartera primero. Sin scores inventados; cada ticker entra después en Evidence Director Ω.</Text>
+      <Pressable onPress={() => router.push('/analyze' as never)} style={({ pressed }) => [styles.securityHub, pressed && styles.pressed]}>
+        <View style={styles.securityCode}><Text style={styles.securityCodeText}>SEC</Text></View>
+        <View style={styles.securityText}><Text style={styles.securityTitle}>Security Hub</Text><Text style={styles.securityMeta}>Abrir ficha profunda de cualquier ticker desde la GO Bar o aquí.</Text></View>
+        <Text style={styles.arrow}>→</Text>
       </Pressable>
 
-      <View style={styles.moduleGrid}>
-        <ModuleCard
-          label="Audit Console"
-          eyebrow="Ticker / Company"
-          body="Análisis con datos reales, EDD y Global CAPEX Chain Ω."
-          action="AUDIT"
-          route="/analyze"
-        />
-        <ModuleCard
-          label="Watchlist"
-          eyebrow="Universe / Candidates"
-          body="Candidatos, vigilancia y disponibilidad operativa sin promover por narrativa."
-          action="WATCH"
-          route="/portfolio"
-        />
-        <ModuleCard
-          label="Resultados"
-          eyebrow="Runs / Outputs"
-          body="Panel de resultados y trazabilidad para comparar auditorías."
-          action="OPEN"
-          route="/settings"
-        />
-        <ModuleCard
-          label="Broker Ω"
-          eyebrow="Trading 212 bridge"
-          body="Bridge, cuenta, posiciones y órdenes. Ejecución live bloqueada por defecto."
-          action="CHECK"
-          route="/broker"
-        />
-      </View>
-
-      <View style={styles.evidencePanel}>
-        <Text style={styles.panelTitle}>EVIDENCE STACK</Text>
-        <EvidenceRow left="FACT" right="Backend real, proveedores y trazas" />
-        <EvidenceRow left="HYPOTHESIS" right="Watchlist y auditorías en revisión" />
-        <EvidenceRow left="INTERPRETATION" right="Lectura ATLAS, nunca prueba primaria" />
-        <EvidenceRow left="NOISE" right="Precio corto plazo y narrativa aislada" />
-      </View>
-
-      <View style={styles.quickStrip}>
-        {COMMANDS.map((command) => <Text key={command} style={styles.quickCommand}>{command}</Text>)}
-      </View>
+      <View style={styles.ruleBar}><Text style={styles.ruleCode}>RULE</Text><Text style={styles.ruleText}>PORTFOLIO FIRST · EVIDENCE &gt; NARRATIVE · MISSING DATA = GATE · PRICE ≠ EVIDENCE</Text></View>
     </ScrollView>
   );
 }
 
-function Badge({ label, active }: { label: string; active: boolean }) {
+function LivePortfolio({ account, positions, brokerStatus, error }: { account: BrokerEnvelope | null; positions: BrokerEnvelope | null; brokerStatus: BrokerStatus | null; error: string | null }) {
+  const accountRow = objectRow(account?.data);
+  const rows = normalizeRows(positions?.data);
+  const total = pickNumber(accountRow, 'total', 'equity', 'accountValue', 'value');
+  const cash = pickNumber(accountRow, 'free', 'cash', 'availableCash', 'freeCash');
+  const invested = pickNumber(accountRow, 'invested', 'investedValue');
+  const ppl = pickNumber(accountRow, 'ppl', 'profitLoss', 'unrealizedPpl', 'result');
+  const currency = pickText(accountRow, 'currency', 'currencyCode', 'currency_code');
+
+  if (!account && !positions) {
+    return (
+      <View style={styles.portfolioGate}>
+        <View style={styles.portfolioGateTop}><Text style={styles.portfolioLabel}>LIVE PORTFOLIO · TRADING 212</Text><Text style={styles.gateBadge}>{brokerStatus?.readReady ? 'LOCAL SESSION GATE' : 'BROKER GATE'}</Text></View>
+        <Text style={styles.portfolioGateText}>{error || (brokerStatus?.readReady ? 'Conecta una vez el token de control en Broker Ω; quedará cifrado en el dispositivo y la cartera se cargará automáticamente al abrir ATLAS.' : 'Trading 212 todavía no está listo en el servidor.')}</Text>
+        <Pressable onPress={() => router.push('/broker' as never)} style={styles.connectButton}><Text style={styles.connectText}>OPEN BROKER Ω →</Text></Pressable>
+      </View>
+    );
+  }
+
   return (
-    <View style={[styles.badge, active ? styles.badgeOn : styles.badgeOff]}>
-      <Text style={styles.badgeText}>{label}: {active ? 'OK' : 'pendiente'}</Text>
+    <View style={styles.portfolioPanel}>
+      <View style={styles.portfolioTop}><View><Text style={styles.portfolioLabel}>LIVE PORTFOLIO · TRADING 212</Text><Text style={styles.portfolioSub}>{brokerStatus?.environment.toUpperCase()} · {brokerStatus?.mode} · {currency || 'ACCOUNT CCY'} · AUTO REFRESH 30s</Text></View><Text style={styles.liveBadge}>LIVE</Text></View>
+      <View style={styles.portfolioMetrics}>
+        <PortfolioMetric label="TOTAL" value={formatMoney(total, currency)} />
+        <PortfolioMetric label="INVESTED" value={formatMoney(invested, currency)} />
+        <PortfolioMetric label="CASH" value={formatMoney(cash, currency)} />
+        <PortfolioMetric label="P/L" value={formatSignedMoney(ppl, currency)} tone={ppl !== null && ppl < 0 ? 'bad' : ppl !== null && ppl > 0 ? 'good' : 'neutral'} />
+      </View>
+      <View style={styles.positionsHeader}><Text style={[styles.positionHead, styles.positionFlex]}>POSITION</Text><Text style={styles.positionHead}>QTY</Text><Text style={styles.positionHead}>P/L</Text></View>
+      {rows.slice(0, 8).map((row, index) => {
+        const symbol = pickText(row, 'ticker', 'instrument', 'symbol') || `POS ${index + 1}`;
+        const qty = pickNumber(row, 'quantity', 'qty');
+        const rowPpl = pickNumber(row, 'ppl', 'profitLoss', 'result', 'unrealizedPpl');
+        return <View key={`${symbol}-${index}`} style={styles.positionRow}><Text style={[styles.positionSymbol, styles.positionFlex]}>{symbol}</Text><Text style={styles.positionValue}>{formatNumber(qty)}</Text><Text style={[styles.positionValue, rowPpl !== null && rowPpl > 0 ? styles.good : rowPpl !== null && rowPpl < 0 ? styles.bad : null]}>{formatSignedMoney(rowPpl, currency)}</Text></View>;
+      })}
+      {rows.length > 8 ? <Pressable onPress={() => router.push('/portfolio' as never)}><Text style={styles.morePositions}>+ {rows.length - 8} MORE POSITIONS →</Text></Pressable> : null}
     </View>
   );
 }
 
-function Metric({ label, value, tone }: { label: string; value: string; tone: 'blue' | 'cyan' | 'amber' }) {
-  return (
-    <View style={styles.metricBox}>
-      <Text style={styles.metricLabel}>{label}</Text>
-      <Text style={[styles.metricValue, tone === 'blue' ? styles.toneBlue : tone === 'cyan' ? styles.toneCyan : styles.toneAmber]}>{value}</Text>
-    </View>
-  );
-}
+function SectionHeader({ code, title }: { code: string; title: string }) { return <View style={styles.sectionHeader}><Text style={styles.sectionCode}>{code}</Text><Text style={styles.sectionTitle}>{title}</Text><View style={styles.sectionLine} /></View>; }
+function StatusCell({ label, value, tone }: { label: string; value: string; tone: 'good' | 'warn' | 'neutral' }) { return <View style={styles.statusCell}><Text style={styles.statusLabel}>{label}</Text><Text style={[styles.statusValue, tone === 'good' ? styles.good : tone === 'warn' ? styles.warn : styles.neutral]} numberOfLines={1}>{value}</Text></View>; }
+function PortfolioMetric({ label, value, tone = 'neutral' }: { label: string; value: string; tone?: 'good' | 'bad' | 'neutral' }) { return <View style={styles.portfolioMetric}><Text style={styles.portfolioMetricLabel}>{label}</Text><Text style={[styles.portfolioMetricValue, tone === 'good' ? styles.good : tone === 'bad' ? styles.bad : null]}>{value}</Text></View>; }
+function PriorityRow({ rank, title, detail, state, route }: { rank: string; title: string; detail: string; state: 'ACTIVE' | 'GATED'; route: string }) { return <Pressable onPress={() => router.push(route as never)} style={({ pressed }) => [styles.priorityRow, pressed && styles.pressed]}><Text style={styles.rank}>{rank}</Text><View style={styles.priorityText}><Text style={styles.priorityTitle}>{title}</Text><Text style={styles.priorityDetail}>{detail}</Text></View><View style={[styles.stateBadge, state === 'ACTIVE' ? styles.stateActive : styles.stateGated]}><Text style={styles.stateText}>{state}</Text></View></Pressable>; }
+function WorkspaceTile({ code, title, meta, route }: { code: string; title: string; meta: string; route: string }) { return <Pressable onPress={() => router.push(route as never)} style={({ pressed }) => [styles.tile, pressed && styles.pressed]}><Text style={styles.tileCode}>{code}</Text><Text style={styles.tileTitle}>{title}</Text><Text style={styles.tileMeta}>{meta}</Text><Text style={styles.tileArrow}>OPEN →</Text></Pressable>; }
 
-function ModuleCard({ label, eyebrow, body, action, route }: { label: string; eyebrow: string; body: string; action: string; route: '/analyze' | '/portfolio' | '/settings' | '/broker' }) {
-  return (
-    <Pressable accessibilityRole="button" accessibilityLabel={label} onPress={() => router.push(route)} style={({ pressed }) => [styles.moduleCard, pressed && styles.pressed]}>
-      <Text style={styles.moduleEyebrow}>{eyebrow}</Text>
-      <Text style={styles.moduleTitle}>{label}</Text>
-      <Text style={styles.moduleBody}>{body}</Text>
-      <Text style={styles.moduleAction}>{action} →</Text>
-    </Pressable>
-  );
+function objectRow(value: unknown): Record<string, unknown> { return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}; }
+function normalizeRows(value: unknown): Array<Record<string, unknown>> { if (Array.isArray(value)) return value.filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === 'object' && !Array.isArray(row)); const row = objectRow(value); for (const key of ['items', 'positions', 'data', 'results']) { const nested = row[key]; if (Array.isArray(nested)) return normalizeRows(nested); } return []; }
+function normalizedKey(value: string): string { return value.toLowerCase().replace(/[^a-z0-9]/g, ''); }
+function pickNumber(row: Record<string, unknown>, ...names: string[]): number | null { const normalized = new Map(Object.entries(row).map(([key, value]) => [normalizedKey(key), value])); for (const name of names) { const value = normalized.get(normalizedKey(name)); if (typeof value === 'number' && Number.isFinite(value)) return value; if (typeof value === 'string') { const parsed = Number(value); if (Number.isFinite(parsed)) return parsed; } } return null; }
+function pickText(row: Record<string, unknown>, ...names: string[]): string | null { const normalized = new Map(Object.entries(row).map(([key, value]) => [normalizedKey(key), value])); for (const name of names) { const value = normalized.get(normalizedKey(name)); if (typeof value === 'string' && value.trim()) return value.trim(); } return null; }
+function formatMoney(value: number | null, currency: string | null): string {
+  if (value === null) return 'N/D';
+  const code = currency?.trim().toUpperCase();
+  if (!code || !/^[A-Z]{3}$/.test(code)) return value.toLocaleString('es-ES', { maximumFractionDigits: 2 });
+  try { return new Intl.NumberFormat('es-ES', { style: 'currency', currency: code, maximumFractionDigits: 2 }).format(value); }
+  catch { return `${value.toLocaleString('es-ES', { maximumFractionDigits: 2 })} ${code}`; }
 }
-
-function EvidenceRow({ left, right }: { left: string; right: string }) {
-  return (
-    <View style={styles.evidenceRow}>
-      <Text style={styles.evidenceLeft}>{left}</Text>
-      <Text style={styles.evidenceRight}>{right}</Text>
-    </View>
-  );
-}
+function formatSignedMoney(value: number | null, currency: string | null): string { if (value === null) return 'N/D'; const formatted = formatMoney(Math.abs(value), currency); return `${value > 0 ? '+' : value < 0 ? '−' : ''}${formatted}`; }
+function formatNumber(value: number | null): string { return value === null ? '—' : value.toLocaleString('es-ES', { maximumFractionDigits: 4 }); }
 
 const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: '#05070a' },
-  content: { paddingTop: 48, paddingHorizontal: 14, paddingBottom: 36, gap: 12 },
-  terminalTopBar: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
-  product: { color: '#e5f4ff', fontSize: 22, fontWeight: '900', letterSpacing: -0.4 },
-  version: { color: '#38bdf8', fontSize: 10, fontWeight: '900', letterSpacing: 1.5, marginTop: 3 },
-  statusPill: { borderWidth: 1, borderRadius: 999, paddingVertical: 7, paddingHorizontal: 10 },
-  statusPillOnline: { borderColor: '#14532d', backgroundColor: '#062b1d' },
-  statusPillWarn: { borderColor: '#713f12', backgroundColor: '#24180a' },
-  statusPillText: { color: '#e2e8f0', fontSize: 10, fontWeight: '900', letterSpacing: 0.8 },
-  tape: { gap: 8, paddingVertical: 2 },
-  tapeCell: { minWidth: 104, borderColor: '#1f2a37', borderWidth: 1, backgroundColor: '#07111b', paddingVertical: 10, paddingHorizontal: 10, borderRadius: 12 },
-  tapeSymbol: { color: '#f8fafc', fontSize: 14, fontWeight: '900' },
-  tapeState: { color: '#22d3ee', fontSize: 11, fontWeight: '900', marginTop: 2 },
-  tapeMeta: { color: '#64748b', fontSize: 10, marginTop: 2 },
-  commandBar: { flexDirection: 'row', alignItems: 'center', borderWidth: 1, borderColor: '#1d4ed8', backgroundColor: '#08111f', borderRadius: 14, padding: 13, gap: 11 },
-  commandPrompt: { color: '#38bdf8', fontSize: 20, fontWeight: '900' },
-  commandTextWrap: { flex: 1 },
-  commandTitle: { color: '#f8fafc', fontWeight: '900', fontSize: 14 },
-  commandSub: { color: '#94a3b8', marginTop: 2, fontSize: 11 },
-  providerPanel: { backgroundColor: '#0b1119', borderColor: '#1e293b', borderWidth: 1, borderRadius: 16, padding: 14, gap: 8 },
-  panelHeaderRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  panelTitle: { color: '#93c5fd', fontSize: 11, fontWeight: '900', letterSpacing: 1.1 },
-  panelMain: { color: '#f8fafc', fontSize: 17, fontWeight: '900' },
-  panelMuted: { color: '#94a3b8', fontSize: 12 },
-  providerRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  badge: { borderRadius: 999, paddingVertical: 7, paddingHorizontal: 10, borderWidth: 1 },
-  badgeOn: { backgroundColor: '#0d2a22', borderColor: '#1e6b53' },
-  badgeOff: { backgroundColor: '#221b14', borderColor: '#5f472c' },
-  badgeText: { color: '#dbeafe', fontSize: 11, fontWeight: '800' },
-  error: { color: '#fca5a5', lineHeight: 19, fontSize: 12 },
-  sectionRow: { flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'space-between', marginTop: 4 },
-  sectionTitle: { color: '#f8fafc', fontWeight: '900', fontSize: 18, letterSpacing: -0.3 },
-  sectionHint: { color: '#64748b', fontSize: 11, fontWeight: '700' },
-  mainDeck: { backgroundColor: '#0a1220', borderColor: '#1d4ed8', borderWidth: 1, borderRadius: 18, padding: 15, gap: 12 },
-  deckHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  deckKicker: { color: '#38bdf8', fontSize: 10, fontWeight: '900', letterSpacing: 1.2 },
-  deckTitle: { color: '#ffffff', fontSize: 28, fontWeight: '900', letterSpacing: -0.8 },
-  deckAction: { color: '#05070a', backgroundColor: '#38bdf8', borderRadius: 999, overflow: 'hidden', paddingVertical: 7, paddingHorizontal: 11, fontWeight: '900', fontSize: 11 },
-  metricsGrid: { flexDirection: 'row', gap: 8 },
-  metricBox: { flex: 1, borderWidth: 1, borderColor: '#263244', backgroundColor: '#070d15', borderRadius: 12, padding: 10 },
-  metricLabel: { color: '#64748b', fontSize: 10, fontWeight: '800', textTransform: 'uppercase' },
-  metricValue: { fontSize: 17, fontWeight: '900', marginTop: 4 },
-  toneBlue: { color: '#93c5fd' },
-  toneCyan: { color: '#22d3ee' },
-  toneAmber: { color: '#fbbf24' },
-  deckNote: { color: '#cbd5e1', fontSize: 12, lineHeight: 18 },
-  moduleGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
-  moduleCard: { width: '48.5%', minHeight: 164, backgroundColor: '#091018', borderColor: '#1e293b', borderWidth: 1, borderRadius: 16, padding: 13, gap: 7 },
-  moduleEyebrow: { color: '#38bdf8', fontSize: 9, fontWeight: '900', letterSpacing: 0.7, textTransform: 'uppercase' },
-  moduleTitle: { color: '#f8fafc', fontSize: 18, fontWeight: '900', letterSpacing: -0.3 },
-  moduleBody: { color: '#94a3b8', fontSize: 11, lineHeight: 16, flex: 1 },
-  moduleAction: { color: '#e0f2fe', fontWeight: '900', fontSize: 11 },
-  evidencePanel: { backgroundColor: '#0b1119', borderColor: '#1e293b', borderWidth: 1, borderRadius: 16, padding: 14, gap: 9 },
-  evidenceRow: { flexDirection: 'row', gap: 10, borderTopWidth: 1, borderTopColor: '#162032', paddingTop: 8 },
-  evidenceLeft: { width: 104, color: '#f8fafc', fontWeight: '900', fontSize: 11 },
-  evidenceRight: { flex: 1, color: '#94a3b8', fontSize: 11, lineHeight: 16 },
-  quickStrip: { flexDirection: 'row', flexWrap: 'wrap', gap: 7, marginTop: 2 },
-  quickCommand: { color: '#7dd3fc', borderColor: '#1e3a8a', borderWidth: 1, borderRadius: 999, paddingHorizontal: 8, paddingVertical: 5, fontSize: 9, fontWeight: '900' },
-  pressed: { opacity: 0.72 },
+  screen: { flex: 1, backgroundColor: '#050708' }, content: { paddingHorizontal: 10, paddingTop: 12, paddingBottom: 22, gap: 10 },
+  pageHeader: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingBottom: 10, borderBottomWidth: 1, borderBottomColor: '#1a262b' }, eyebrow: { color: '#607278', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1.1 }, title: { color: '#eef5f2', fontFamily: 'monospace', fontSize: 24, fontWeight: '900', marginTop: 2 },
+  engineBadge: { marginLeft: 'auto', minHeight: 30, flexDirection: 'row', alignItems: 'center', gap: 6, borderWidth: 1, paddingHorizontal: 8 }, engineOnline: { borderColor: '#23634f', backgroundColor: '#07150f' }, engineOffline: { borderColor: '#5e3535', backgroundColor: '#170b0b' }, engineDot: { width: 6, height: 6, borderRadius: 99 }, dotOnline: { backgroundColor: '#38e7aa' }, dotOffline: { backgroundColor: '#ef7676' }, engineText: { color: '#b9c9c3', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' },
+  portfolioGate: { borderWidth: 1, borderColor: '#514724', backgroundColor: '#111006', padding: 12, gap: 9 }, portfolioGateTop: { flexDirection: 'row', alignItems: 'center', gap: 8 }, portfolioLabel: { flex: 1, color: '#dce7e3', fontFamily: 'monospace', fontSize: 9, fontWeight: '900' }, gateBadge: { color: '#dfc66b', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, portfolioGateText: { color: '#8e896a', fontSize: 10, lineHeight: 15 }, connectButton: { alignSelf: 'flex-start', borderWidth: 1, borderColor: '#645b2d', paddingHorizontal: 10, paddingVertical: 7 }, connectText: { color: '#dfc66b', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  portfolioPanel: { borderWidth: 1, borderColor: '#285b4a', backgroundColor: '#06100c', padding: 11, gap: 10 }, portfolioTop: { flexDirection: 'row', alignItems: 'center', gap: 8 }, portfolioSub: { color: '#4f6e63', fontFamily: 'monospace', fontSize: 7, marginTop: 3 }, liveBadge: { color: '#4ce8b5', borderWidth: 1, borderColor: '#2b6b55', paddingHorizontal: 6, paddingVertical: 3, fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, portfolioMetrics: { flexDirection: 'row', flexWrap: 'wrap', gap: 7 }, portfolioMetric: { minWidth: 100, flexGrow: 1, borderTopWidth: 1, borderTopColor: '#163126', paddingTop: 7 }, portfolioMetricLabel: { color: '#476359', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, portfolioMetricValue: { color: '#e5eeeb', fontFamily: 'monospace', fontSize: 13, fontWeight: '900', marginTop: 3 }, positionsHeader: { flexDirection: 'row', gap: 7, borderTopWidth: 1, borderTopColor: '#163126', paddingTop: 7 }, positionHead: { width: 70, color: '#486158', fontFamily: 'monospace', fontSize: 7, fontWeight: '900', textAlign: 'right' }, positionFlex: { flex: 1, textAlign: 'left' }, positionRow: { minHeight: 28, flexDirection: 'row', alignItems: 'center', gap: 7, borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: '#11251d' }, positionSymbol: { color: '#cbd8d4', fontFamily: 'monospace', fontSize: 9, fontWeight: '900' }, positionValue: { width: 70, color: '#95a49f', fontFamily: 'monospace', fontSize: 8, textAlign: 'right' }, morePositions: { color: '#69caaa', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', marginTop: 3 },
+  statusStrip: { flexDirection: 'row', borderWidth: 1, borderColor: '#1a282d', backgroundColor: '#080d0f' }, statusCell: { flex: 1, minWidth: 0, paddingHorizontal: 8, paddingVertical: 8, borderRightWidth: 1, borderRightColor: '#172328' }, statusLabel: { color: '#506168', fontFamily: 'monospace', fontSize: 6, fontWeight: '900', letterSpacing: 0.7 }, statusValue: { marginTop: 3, fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, good: { color: '#49e8b7' }, bad: { color: '#e47c83' }, warn: { color: '#e0b761' }, neutral: { color: '#87969b' },
+  sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: 7, marginTop: 4 }, sectionCode: { color: '#41e6b2', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, sectionTitle: { color: '#bdc9c6', fontFamily: 'monospace', fontSize: 9, fontWeight: '900', textTransform: 'uppercase', letterSpacing: 0.8 }, sectionLine: { flex: 1, height: 1, backgroundColor: '#1a262b' },
+  tiles: { flexDirection: 'row', flexWrap: 'wrap', gap: 7 }, tile: { width: '48.8%', minHeight: 108, borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#080d0f', padding: 9 }, tileCode: { color: '#45e7b3', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, tileTitle: { color: '#e3ebe8', fontFamily: 'monospace', fontSize: 13, fontWeight: '900', marginTop: 8 }, tileMeta: { color: '#697980', fontSize: 9, lineHeight: 13, marginTop: 4 }, tileArrow: { color: '#739188', fontFamily: 'monospace', fontSize: 7, fontWeight: '900', marginTop: 'auto', paddingTop: 8 },
+  stack: { borderWidth: 1, borderColor: '#1a282d', backgroundColor: '#070b0d' }, priorityRow: { minHeight: 62, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 8, paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: '#152126' }, rank: { width: 21, color: '#52636a', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, priorityText: { flex: 1, minWidth: 0 }, priorityTitle: { color: '#dce6e2', fontFamily: 'monospace', fontSize: 10, fontWeight: '900' }, priorityDetail: { color: '#6c7c82', fontSize: 9, lineHeight: 13, marginTop: 3 }, stateBadge: { borderWidth: 1, paddingHorizontal: 5, paddingVertical: 3 }, stateActive: { borderColor: '#245f4d', backgroundColor: '#07140f' }, stateGated: { borderColor: '#5d4c2d', backgroundColor: '#171208' }, stateText: { color: '#aab8b4', fontFamily: 'monospace', fontSize: 6, fontWeight: '900' },
+  securityHub: { minHeight: 62, flexDirection: 'row', alignItems: 'center', gap: 9, borderWidth: 1, borderColor: '#2a654f', backgroundColor: '#07140f', padding: 9 }, securityCode: { width: 37, height: 30, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: '#2d6f57' }, securityCodeText: { color: '#53edbd', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, securityText: { flex: 1 }, securityTitle: { color: '#e8f1ed', fontFamily: 'monospace', fontSize: 10, fontWeight: '900' }, securityMeta: { color: '#708078', fontSize: 9, marginTop: 3 }, arrow: { color: '#4ce9b7', fontFamily: 'monospace', fontSize: 14 },
+  ruleBar: { minHeight: 38, flexDirection: 'row', alignItems: 'center', gap: 8, borderTopWidth: 1, borderTopColor: '#1a262b', marginTop: 3 }, ruleCode: { color: '#4ae8b6', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, ruleText: { flex: 1, color: '#65767c', fontFamily: 'monospace', fontSize: 7, lineHeight: 11 }, pressed: { opacity: 0.66 },
 });

--- a/mobile/app/results.tsx
+++ b/mobile/app/results.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { AuditResultRecord, AuditResultStore } from '../core/storage/localStore';
+
+export default function ResultsScreen() {
+  const [rows, setRows] = useState<AuditResultRecord[]>([]);
+  const load = async () => setRows(await AuditResultStore.list());
+  useEffect(() => { void load(); }, []);
+
+  const remove = async (id: string) => setRows(await AuditResultStore.remove(id));
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.header}>
+        <Text style={styles.code}>RES</Text>
+        <View style={styles.headerText}><Text style={styles.eyebrow}>ATLAS TERMINAL · RESULT JOURNAL</Text><Text style={styles.title}>Resultados</Text></View>
+      </View>
+      <Text style={styles.description}>Historial persistente de snapshots guardados desde AUDIT. Cada registro conserva ticker, momento, proveedor y métricas observadas; no reescribe retroactivamente la evidencia.</Text>
+
+      <View style={styles.summaryRow}>
+        <Summary label="SAVED" value={String(rows.length)} />
+        <Summary label="UNIQUE" value={String(new Set(rows.map((row) => row.ticker)).size)} />
+        <Summary label="LATEST" value={rows[0] ? rows[0].ticker : '—'} />
+      </View>
+
+      {rows.length ? rows.map((row) => (
+        <View key={row.id} style={styles.card}>
+          <View style={styles.top}>
+            <Pressable onPress={() => router.push(`/analyze?ticker=${encodeURIComponent(row.ticker)}` as never)} style={styles.flex}>
+              <Text style={styles.symbol}>{row.ticker}</Text>
+              <Text numberOfLines={1} style={styles.company}>{row.companyName}</Text>
+            </Pressable>
+            <Text style={styles.time}>{formatDate(row.createdAt)}</Text>
+          </View>
+          <View style={styles.metrics}>
+            <Metric label="PRICE" value={formatNumber(row.price)} />
+            <Metric label="MKT CAP" value={formatCompact(row.marketCap)} />
+            <Metric label="P/E" value={formatNumber(row.pe)} />
+            <Metric label="CAPEX Ω" value={row.capexPosition || 'N/D'} />
+          </View>
+          <View style={styles.metaRow}><Text style={styles.meta}>{row.provider} · {row.sector || 'sector N/D'}</Text><Pressable onPress={() => { void remove(row.id); }}><Text style={styles.delete}>DELETE</Text></Pressable></View>
+          <Text style={styles.note}>{row.note}</Text>
+        </View>
+      )) : (
+        <View style={styles.empty}><Text style={styles.emptyTitle}>NO HAY RESULTADOS GUARDADOS</Text><Text style={styles.emptyText}>Ejecuta AUDIT y pulsa GUARDAR RESULTADO.</Text><Pressable onPress={() => router.push('/audit' as never)} style={styles.openAudit}><Text style={styles.openAuditText}>ABRIR AUDIT →</Text></Pressable></View>
+      )}
+
+      <View style={styles.rule}><Text style={styles.ruleTitle}>IMMUTABILITY RULE</Text><Text style={styles.ruleText}>El journal es histórico: un movimiento posterior del precio no modifica lo que ATLAS observó cuando se guardó el snapshot.</Text></View>
+    </ScrollView>
+  );
+}
+
+function Summary({ label, value }: { label: string; value: string }) { return <View style={styles.summary}><Text style={styles.summaryLabel}>{label}</Text><Text style={styles.summaryValue}>{value}</Text></View>; }
+function Metric({ label, value }: { label: string; value: string }) { return <View style={styles.metric}><Text style={styles.metricLabel}>{label}</Text><Text numberOfLines={1} style={styles.metricValue}>{value}</Text></View>; }
+function formatDate(value: string): string { const date = new Date(value); return Number.isNaN(date.getTime()) ? value : date.toLocaleString('es-ES', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' }); }
+function formatNumber(value: number | null): string { return value === null ? 'N/D' : value.toLocaleString('es-ES', { maximumFractionDigits: 2 }); }
+function formatCompact(value: number | null): string { return value === null ? 'N/D' : new Intl.NumberFormat('es-ES', { notation: 'compact', maximumFractionDigits: 2 }).format(value); }
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#050708' }, content: { paddingHorizontal: 12, paddingTop: 14, paddingBottom: 28, gap: 12 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 12, borderBottomWidth: 1, borderBottomColor: '#1b272c', paddingBottom: 12 }, code: { width: 48, height: 48, textAlign: 'center', textAlignVertical: 'center', borderWidth: 1, borderColor: '#675d32', backgroundColor: '#151206', color: '#e4cf69', fontFamily: 'monospace', fontWeight: '900' }, headerText: { flex: 1 }, eyebrow: { color: '#5e7379', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1.1 }, title: { color: '#eff5f3', fontFamily: 'monospace', fontSize: 24, fontWeight: '900', marginTop: 3 },
+  description: { color: '#8c9a9f', fontSize: 12, lineHeight: 18 }, summaryRow: { flexDirection: 'row', gap: 7 }, summary: { flex: 1, borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#080d0f', padding: 10 }, summaryLabel: { color: '#506067', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, summaryValue: { color: '#e3ece9', fontFamily: 'monospace', fontSize: 16, fontWeight: '900', marginTop: 4 },
+  card: { borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#070c0e', padding: 12, gap: 10 }, top: { flexDirection: 'row', gap: 8, alignItems: 'flex-start' }, flex: { flex: 1 }, symbol: { color: '#ecf4f1', fontFamily: 'monospace', fontSize: 17, fontWeight: '900' }, company: { color: '#6f7f84', fontSize: 10, marginTop: 2 }, time: { color: '#546268', fontFamily: 'monospace', fontSize: 8 }, metrics: { flexDirection: 'row', flexWrap: 'wrap', gap: 7 }, metric: { minWidth: 90, flexGrow: 1, borderTopWidth: 1, borderTopColor: '#172328', paddingTop: 7 }, metricLabel: { color: '#4e5c61', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, metricValue: { color: '#b9c6c2', fontFamily: 'monospace', fontSize: 9, fontWeight: '800', marginTop: 3 }, metaRow: { flexDirection: 'row', alignItems: 'center', gap: 8 }, meta: { flex: 1, color: '#5f6e73', fontSize: 9 }, delete: { color: '#b66f6f', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, note: { color: '#6c7a7f', fontSize: 9, lineHeight: 14 },
+  empty: { paddingVertical: 40, alignItems: 'center', borderWidth: 1, borderColor: '#172328', backgroundColor: '#070b0d' }, emptyTitle: { color: '#67777c', fontFamily: 'monospace', fontWeight: '900', fontSize: 10 }, emptyText: { color: '#4f5d62', fontSize: 10, marginTop: 5 }, openAudit: { marginTop: 14, borderWidth: 1, borderColor: '#2f725b', backgroundColor: '#071510', paddingHorizontal: 12, paddingVertical: 9 }, openAuditText: { color: '#54efbd', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  rule: { borderTopWidth: 1, borderTopColor: '#1a2428', paddingTop: 12 }, ruleTitle: { color: '#4fe8b6', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 }, ruleText: { color: '#718087', fontSize: 10, lineHeight: 16, marginTop: 5 },
+});

--- a/mobile/app/watchlist.tsx
+++ b/mobile/app/watchlist.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { router } from 'expo-router';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { WatchlistStore } from '../core/storage/localStore';
+
+export default function WatchlistScreen() {
+  const [rows, setRows] = useState<string[]>([]);
+  const [ticker, setTicker] = useState('');
+
+  const load = async () => setRows(await WatchlistStore.list());
+  useEffect(() => { void load(); }, []);
+
+  const add = async () => {
+    if (!ticker.trim()) return;
+    setRows(await WatchlistStore.add(ticker));
+    setTicker('');
+  };
+
+  const remove = async (symbol: string) => setRows(await WatchlistStore.remove(symbol));
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+      <View style={styles.header}>
+        <Text style={styles.code}>WL</Text>
+        <View style={styles.headerText}><Text style={styles.eyebrow}>ATLAS TERMINAL · WATCHLIST</Text><Text style={styles.title}>Watchlist</Text></View>
+      </View>
+      <Text style={styles.description}>Lista persistente local para candidatos, no-chase, catalizadores y nombres que deben volver a auditarse. El precio en vivo se conectará por el market feed; guardar un ticker no es una recomendación.</Text>
+
+      <View style={styles.addRow}>
+        <TextInput value={ticker} onChangeText={setTicker} autoCapitalize="characters" autoCorrect={false} placeholder="Añadir ticker" placeholderTextColor="#4f5e63" style={styles.input} returnKeyType="done" onSubmitEditing={() => { void add(); }} />
+        <Pressable onPress={() => { void add(); }} style={({ pressed }) => [styles.add, pressed && styles.pressed]}><Text style={styles.addText}>ADD</Text></Pressable>
+      </View>
+
+      <View style={styles.tableHeader}><Text style={[styles.h, styles.flex]}>SYMBOL</Text><Text style={styles.h}>AUDIT</Text><Text style={styles.h}>REMOVE</Text></View>
+      {rows.length ? rows.map((symbol) => (
+        <View key={symbol} style={styles.row}>
+          <Pressable onPress={() => router.push(`/analyze?ticker=${encodeURIComponent(symbol)}` as never)} style={styles.flex}>
+            <Text style={styles.symbol}>{symbol}</Text><Text style={styles.hint}>Security Hub</Text>
+          </Pressable>
+          <Pressable onPress={() => router.push(`/audit?ticker=${encodeURIComponent(symbol)}` as never)} style={styles.cellButton}><Text style={styles.cellText}>AUD</Text></Pressable>
+          <Pressable onPress={() => { void remove(symbol); }} style={styles.cellButton}><Text style={[styles.cellText, styles.removeText]}>×</Text></Pressable>
+        </View>
+      )) : <View style={styles.empty}><Text style={styles.emptyTitle}>WATCHLIST VACÍA</Text><Text style={styles.emptyText}>Añade un ticker aquí o desde la pantalla AUDIT.</Text></View>}
+
+      <View style={styles.rule}><Text style={styles.ruleTitle}>WATCHLIST RULE</Text><Text style={styles.ruleText}>Watchlist es memoria operativa. La prioridad real la determinan evidencia, motores aplicables, falsificadores y entrada.</Text></View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#050708' }, content: { paddingHorizontal: 12, paddingTop: 14, paddingBottom: 28, gap: 12 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 12, borderBottomWidth: 1, borderBottomColor: '#1b272c', paddingBottom: 12 },
+  code: { width: 48, height: 48, textAlign: 'center', textAlignVertical: 'center', borderWidth: 1, borderColor: '#315b75', backgroundColor: '#071019', color: '#8cccf3', fontFamily: 'monospace', fontWeight: '900' },
+  headerText: { flex: 1 }, eyebrow: { color: '#5e7379', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1.1 }, title: { color: '#eff5f3', fontFamily: 'monospace', fontSize: 24, fontWeight: '900', marginTop: 3 },
+  description: { color: '#8c9a9f', fontSize: 12, lineHeight: 18 }, addRow: { flexDirection: 'row', gap: 8 }, input: { flex: 1, minHeight: 44, borderWidth: 1, borderColor: '#26383e', backgroundColor: '#080d0f', color: '#eef5f3', paddingHorizontal: 12, fontFamily: 'monospace' },
+  add: { justifyContent: 'center', borderWidth: 1, borderColor: '#315b75', backgroundColor: '#071019', paddingHorizontal: 15 }, addText: { color: '#8cccf3', fontFamily: 'monospace', fontWeight: '900', fontSize: 9 }, pressed: { opacity: 0.67 },
+  tableHeader: { flexDirection: 'row', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: '#1b292e', paddingVertical: 6, gap: 8 }, h: { width: 56, color: '#4f6066', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, flex: { flex: 1 },
+  row: { minHeight: 54, flexDirection: 'row', alignItems: 'center', gap: 8, borderBottomWidth: 1, borderBottomColor: '#111a1e' }, symbol: { color: '#e9f1ef', fontFamily: 'monospace', fontWeight: '900', fontSize: 15 }, hint: { color: '#526167', fontSize: 9, marginTop: 2 },
+  cellButton: { width: 56, minHeight: 32, justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderColor: '#213138', backgroundColor: '#080d0f' }, cellText: { color: '#76d6b7', fontFamily: 'monospace', fontSize: 9, fontWeight: '900' }, removeText: { color: '#d98c8c', fontSize: 16 },
+  empty: { paddingVertical: 35, alignItems: 'center', borderWidth: 1, borderColor: '#172328', backgroundColor: '#070b0d' }, emptyTitle: { color: '#67777c', fontFamily: 'monospace', fontWeight: '900', fontSize: 10 }, emptyText: { color: '#4f5d62', fontSize: 10, marginTop: 5 },
+  rule: { borderTopWidth: 1, borderTopColor: '#1a2428', paddingTop: 12 }, ruleTitle: { color: '#4fe8b6', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 }, ruleText: { color: '#718087', fontSize: 10, lineHeight: 16, marginTop: 5 },
+});

--- a/mobile/app/workspace/[module].tsx
+++ b/mobile/app/workspace/[module].tsx
@@ -1,0 +1,128 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+type PanelState = 'READY' | 'DATA GATE' | 'BROKER GATE';
+type ModuleSpec = { title: string; code: string; description: string; panels: Array<{ title: string; detail: string; state: PanelState }>; primary?: { label: string; route: string } };
+
+const MODULES: Record<string, ModuleSpec> = {
+  markets: {
+    title: 'Markets', code: 'MKT',
+    description: 'Mercados mundiales, índices en tiempo real, macro, movers y rotación. El tape global consume FinancialData.Net index-quotes cuando la suscripción Premium está disponible.',
+    panels: [
+      { title: 'Global Index Tape', detail: 'S&P 500, Nasdaq 100, Dow, Russell, Euro Stoxx, DAX, FTSE, CAC, IBEX, Nikkei, Hang Seng, Shanghai, KOSPI, ASX, Sensex, Bovespa y TSX.', state: 'READY' },
+      { title: 'Money Rotation Ω', detail: 'Mercado → sectores → industrias → acciones → flujo/volumen → fuerza relativa → persistencia.', state: 'READY' },
+      { title: 'Movers / Breadth', detail: 'Ganadores, perdedores, gaps, volumen anómalo y amplitud con sesión regular separada de 24/5.', state: 'DATA GATE' },
+      { title: 'Macro Regime', detail: 'Oro, BTC, tipos, USD, crédito, petróleo y breadth para clasificar el régimen.', state: 'READY' },
+    ],
+    primary: { label: 'Abrir Security Hub', route: '/analyze' },
+  },
+  opportunities: {
+    title: 'Opportunities', code: 'OPP',
+    description: 'Mesa de oportunidades de ATLAS. Separa compañía excelente, receptor de dinero actual, dislocación y entrada ejecutable.',
+    panels: [
+      { title: 'Wave Detection Ω', detail: 'Fundamentales, revisiones, momentum, noticias materiales y riesgo → Wave Score con umbral explícito.', state: 'READY' },
+      { title: 'Money Rotation Ω', detail: 'Receptores de capital hoy, sin permitir que calidad fundamental sustituya evidencia de flujo.', state: 'READY' },
+      { title: 'Return / Valuation Ω', detail: 'CAGR implícito, normalización cíclica y brecha entre expectativas y precio.', state: 'READY' },
+      { title: 'Entry Discipline', detail: 'GREEN, no-chase, opening gate y ejecución por tramos antes de asignar capital.', state: 'READY' },
+    ],
+    primary: { label: 'Auditar candidato', route: '/audit' },
+  },
+  atlas: {
+    title: 'ATLAS Ω', code: 'Ω',
+    description: 'Centro de decisión. Evidence Director primero; después motores especialistas, contradicciones, Falsifiers Ω y decisión.',
+    panels: [
+      { title: 'Investment Committee Ω', detail: 'Economic Proof, valoración, CAPEX, moat, rotación, macro, falsificadores y evidencia.', state: 'READY' },
+      { title: 'Evidence Director', detail: 'FACT / HYPOTHESIS / INTERPRETATION / NOISE con trazabilidad y conflictos preservados.', state: 'READY' },
+      { title: 'Engine Grid', detail: 'GREEN, Retorno, Money Rotation, Defensive, Clinical Shock, CAPEX y motores aplicables.', state: 'READY' },
+      { title: 'Falsifiers Ω', detail: 'Veto independiente antes de cualquier salida de decisión.', state: 'READY' },
+    ],
+    primary: { label: 'Abrir AUDIT', route: '/audit' },
+  },
+  screener: {
+    title: 'Screener', code: 'SCR',
+    description: 'Universos, filtros, rankings y comparaciones. Un filtro identifica candidatos; nunca crea automáticamente una orden.',
+    panels: [
+      { title: 'Universe Builder', detail: 'Master Universe, sectores, regiones, market cap, disponibilidad T212 y listas congeladas.', state: 'READY' },
+      { title: 'GREEN Ω', detail: '1W / 1M / 3M / 1Y / TOTAL con corte temporal sincronizado.', state: 'DATA GATE' },
+      { title: 'Return Ω', detail: 'Expectativas inversas, CAGR normalizado y sensibilidad de múltiplos/ciclos.', state: 'READY' },
+      { title: 'Ranking Board', detail: 'Ranking por motor y consenso sin votación simple.', state: 'READY' },
+    ],
+    primary: { label: 'Auditar resultado', route: '/audit' },
+  },
+  research: {
+    title: 'Research', code: 'RSR',
+    description: 'Descubrimiento y adquisición de evidencia con Firecrawl Search Ω, fuentes primarias y documentación trazable.',
+    panels: [
+      { title: 'Evidence Search', detail: 'Web, news, research, GitHub, PDF y developer con provenance por resultado.', state: 'READY' },
+      { title: 'Clinical Evidence', detail: 'Ensayos, endpoints, magnitud clínica, probabilidad regulatoria, TAM y economics.', state: 'READY' },
+      { title: 'CAPEX Chain', detail: 'Comprador → bottleneck → proveedor → captura económica → fragilidad.', state: 'READY' },
+      { title: 'Thesis Notes', detail: 'ACTIVA / REVISIÓN EXTRAORDINARIA / MODIFICADA / RETIRADA.', state: 'READY' },
+    ],
+    primary: { label: 'Abrir Security Hub', route: '/analyze' },
+  },
+  catalysts: {
+    title: 'Catalysts', code: 'CAL',
+    description: 'Calendario operativo para resultados, FDA/clinical, guidance, macro, investor days y eventos que puedan cambiar una tesis.',
+    panels: [
+      { title: 'Earnings Calendar', detail: 'Próximos resultados, guidance y ventanas de overnight risk; requiere feed de calendario certificado.', state: 'DATA GATE' },
+      { title: 'Clinical / FDA', detail: 'Readouts, PDUFA, congresos y evidencia clínica conectados a Clinical Evidence Shock Ω.', state: 'READY' },
+      { title: 'Macro Events', detail: 'FOMC, CPI, empleo, subastas, yields y otros eventos de régimen; requiere calendario macro live.', state: 'DATA GATE' },
+      { title: 'Catalyst Alerts', detail: 'Eventos enlazados con watchlist, resultados guardados y falsificadores.', state: 'READY' },
+    ],
+    primary: { label: 'Abrir Watchlist', route: '/watchlist' },
+  },
+  news: {
+    title: 'News', code: 'NEWS',
+    description: 'Noticias filtradas por relevancia ATLAS. Firecrawl descubre y extrae; Evidence Director determina cómo puede utilizarse cada pieza.',
+    panels: [
+      { title: 'Live News Search', detail: 'Firecrawl Search Ω con web/news, ventanas temporales y contenido completo por resultado.', state: 'READY' },
+      { title: 'Source Hierarchy', detail: 'Primaria > regulatoria > IR > prensa fiable > análisis > ruido. AI nunca es evidencia.', state: 'READY' },
+      { title: 'Materiality Filter', detail: 'Separa evento que cambia economics/tesis de movimiento narrativo o repetición de titulares.', state: 'READY' },
+      { title: 'Ticker Linkage', detail: 'Noticias vinculadas a watchlist, auditorías y falsificadores.', state: 'READY' },
+    ],
+    primary: { label: 'Abrir Research', route: '/workspace/research' },
+  },
+  orders: {
+    title: 'Orders', code: 'ORD',
+    description: 'Ejecución separada del análisis. Demo/paper por defecto y live fail-closed.',
+    panels: [
+      { title: 'Open Orders', detail: 'Órdenes pendientes y estado upstream de Trading 212.', state: 'BROKER GATE' },
+      { title: 'Order Ticket', detail: 'Market, limit, stop y stop-limit con confirmación explícita y clientRequestId único.', state: 'BROKER GATE' },
+      { title: 'History', detail: 'Órdenes, dividendos y transacciones con paginación del broker.', state: 'BROKER GATE' },
+      { title: 'Execution Safety', detail: 'Demo por defecto, kill switch live y disciplina de sesión regular.', state: 'READY' },
+    ],
+    primary: { label: 'Abrir Broker Ω', route: '/broker' },
+  },
+  risk: {
+    title: 'Risk', code: 'RSK',
+    description: 'Riesgo de cartera, concentración y exposición sin confundir volatilidad de precio con deterioro fundamental.',
+    panels: [
+      { title: 'Exposure', detail: 'Sector, factor, moneda, región y cadenas económicas.', state: 'DATA GATE' },
+      { title: 'Concentration', detail: 'Pesos, contribución al riesgo y solapamiento de tesis.', state: 'DATA GATE' },
+      { title: 'Drawdown', detail: 'Pérdida máxima, recuperación y stress por régimen.', state: 'DATA GATE' },
+      { title: 'Correlation', detail: 'Matriz de correlación y clústeres cuando exista histórico validado.', state: 'DATA GATE' },
+    ],
+    primary: { label: 'Abrir cartera', route: '/portfolio' },
+  },
+};
+
+export default function WorkspaceScreen() {
+  const params = useLocalSearchParams<{ module?: string }>();
+  const key = typeof params.module === 'string' ? params.module.toLowerCase() : 'atlas';
+  const spec: ModuleSpec = MODULES[key] ?? MODULES.atlas!;
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.headerRow}><View style={styles.codeBox}><Text style={styles.code}>{spec.code}</Text></View><View style={styles.headerText}><Text style={styles.eyebrow}>ATLAS TERMINAL · WORKSPACE</Text><Text style={styles.title}>{spec.title}</Text></View></View>
+      <Text style={styles.description}>{spec.description}</Text>
+      <View style={styles.grid}>{spec.panels.map((panel) => <View key={panel.title} style={styles.panel}><View style={styles.panelTop}><Text style={styles.panelTitle}>{panel.title}</Text><StateBadge state={panel.state} /></View><Text style={styles.panelDetail}>{panel.detail}</Text></View>)}</View>
+      {spec.primary ? <Pressable accessibilityRole="button" accessibilityLabel={spec.primary.label} onPress={() => router.push(spec.primary!.route as never)} style={({ pressed }) => [styles.primary, pressed && styles.pressed]}><Text style={styles.primaryCode}>GO</Text><Text style={styles.primaryText}>{spec.primary.label}</Text><Text style={styles.primaryArrow}>→</Text></Pressable> : null}
+      <View style={styles.rule}><Text style={styles.ruleTitle}>TERMINAL RULE</Text><Text style={styles.ruleText}>Una superficie puede existir antes que su feed. Si falta evidencia certificada, ATLAS muestra DATA GATE en lugar de fabricar una cifra.</Text></View>
+    </ScrollView>
+  );
+}
+
+function StateBadge({ state }: { state: PanelState }) { const style = state === 'READY' ? styles.ready : state === 'BROKER GATE' ? styles.broker : styles.gate; return <View style={[styles.badge, style]}><Text style={styles.badgeText}>{state}</Text></View>; }
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#050708' }, content: { paddingHorizontal: 12, paddingTop: 14, paddingBottom: 24, gap: 12 }, headerRow: { flexDirection: 'row', alignItems: 'center', gap: 12, borderBottomWidth: 1, borderBottomColor: '#1b272c', paddingBottom: 12 }, codeBox: { width: 48, height: 48, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: '#2e6c58', backgroundColor: '#071510' }, code: { color: '#54efbd', fontFamily: 'monospace', fontSize: 14, fontWeight: '900' }, headerText: { flex: 1 }, eyebrow: { color: '#5e7379', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1.1 }, title: { color: '#eff5f3', fontFamily: 'monospace', fontSize: 24, fontWeight: '900', marginTop: 3 }, description: { color: '#8c9a9f', fontSize: 12, lineHeight: 18 }, grid: { gap: 8 }, panel: { minHeight: 102, borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#080d0f', padding: 12 }, panelTop: { flexDirection: 'row', alignItems: 'center', gap: 8 }, panelTitle: { flex: 1, color: '#dfe8e5', fontFamily: 'monospace', fontWeight: '900', fontSize: 11 }, panelDetail: { color: '#708086', marginTop: 9, lineHeight: 17, fontSize: 11 }, badge: { borderWidth: 1, paddingHorizontal: 6, paddingVertical: 3 }, ready: { borderColor: '#236a52', backgroundColor: '#081912' }, gate: { borderColor: '#5e4b2a', backgroundColor: '#171208' }, broker: { borderColor: '#425975', backgroundColor: '#0b121b' }, badgeText: { color: '#aebbb7', fontFamily: 'monospace', fontSize: 7, fontWeight: '900', letterSpacing: 0.5 }, primary: { minHeight: 48, flexDirection: 'row', alignItems: 'center', gap: 10, borderWidth: 1, borderColor: '#2f725b', backgroundColor: '#071510', paddingHorizontal: 12 }, primaryCode: { color: '#50e9b8', fontFamily: 'monospace', fontSize: 9, fontWeight: '900' }, primaryText: { flex: 1, color: '#e8f3ef', fontFamily: 'monospace', fontSize: 11, fontWeight: '900' }, primaryArrow: { color: '#50e9b8', fontFamily: 'monospace', fontSize: 14 }, pressed: { opacity: 0.7 }, rule: { borderTopWidth: 1, borderTopColor: '#1a2428', paddingTop: 12 }, ruleTitle: { color: '#4fe8b6', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 }, ruleText: { color: '#718087', fontSize: 10, lineHeight: 16, marginTop: 5 },
+});

--- a/mobile/core/api/marketApi.ts
+++ b/mobile/core/api/marketApi.ts
@@ -1,0 +1,48 @@
+import { apiBaseUrl } from './mobileApi';
+
+export type GlobalIndexQuote = {
+  symbol: string;
+  name: string;
+  region: string;
+  price: number | null;
+  change: number | null;
+  percentageChange: number | null;
+  time: string | null;
+  status: 'OK' | 'MISSING';
+};
+
+export type GlobalIndicesPayload = {
+  provider: string;
+  providerMode: string;
+  generatedAt: string;
+  refreshHintSeconds: number;
+  items: GlobalIndexQuote[];
+  guardrails: string[];
+};
+
+async function request<T>(path: string, timeoutMs = 12000): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${apiBaseUrl()}${path}`, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const payload: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const row = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+      const detail = typeof row.detail === 'string' ? row.detail : `Market data HTTP ${response.status}`;
+      throw new Error(detail);
+    }
+    return payload as T;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') throw new Error('Market feed no respondió a tiempo.');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export const MarketApi = {
+  indices: () => request<GlobalIndicesPayload>('/v1/mobile/indices'),
+};

--- a/mobile/core/security/brokerSession.ts
+++ b/mobile/core/security/brokerSession.ts
@@ -1,0 +1,24 @@
+import * as SecureStore from 'expo-secure-store';
+
+const BROKER_CONTROL_TOKEN_KEY = 'atlas.broker-control-token.v1';
+
+export const BrokerSession = {
+  async getControlToken(): Promise<string | null> {
+    try {
+      const value = await SecureStore.getItemAsync(BROKER_CONTROL_TOKEN_KEY);
+      return value?.trim() || null;
+    } catch {
+      return null;
+    }
+  },
+  async saveControlToken(token: string): Promise<void> {
+    const value = token.trim();
+    if (!value) throw new Error('El token de control está vacío.');
+    await SecureStore.setItemAsync(BROKER_CONTROL_TOKEN_KEY, value, {
+      keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+  },
+  async clearControlToken(): Promise<void> {
+    await SecureStore.deleteItemAsync(BROKER_CONTROL_TOKEN_KEY);
+  },
+};

--- a/mobile/core/storage/localStore.ts
+++ b/mobile/core/storage/localStore.ts
@@ -1,0 +1,79 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const WATCHLIST_KEY = 'atlas.watchlist.v1';
+const AUDIT_RESULTS_KEY = 'atlas.audit-results.v1';
+
+export type AuditResultRecord = {
+  id: string;
+  ticker: string;
+  createdAt: string;
+  provider: string;
+  companyName: string;
+  sector: string | null;
+  price: number | null;
+  marketCap: number | null;
+  pe: number | null;
+  capexPosition: string | null;
+  note: string;
+};
+
+function normalizeTicker(value: string): string {
+  return value.trim().toUpperCase().replace(/[^A-Z0-9.\-]/g, '').slice(0, 24);
+}
+
+async function readJson<T>(key: string, fallback: T): Promise<T> {
+  try {
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJson<T>(key: string, value: T): Promise<void> {
+  await AsyncStorage.setItem(key, JSON.stringify(value));
+}
+
+export const WatchlistStore = {
+  async list(): Promise<string[]> {
+    const rows = await readJson<string[]>(WATCHLIST_KEY, []);
+    return Array.from(new Set(rows.map(normalizeTicker).filter(Boolean)));
+  },
+  async add(ticker: string): Promise<string[]> {
+    const symbol = normalizeTicker(ticker);
+    if (!symbol) return this.list();
+    const next = Array.from(new Set([symbol, ...(await this.list())]));
+    await writeJson(WATCHLIST_KEY, next);
+    return next;
+  },
+  async remove(ticker: string): Promise<string[]> {
+    const symbol = normalizeTicker(ticker);
+    const next = (await this.list()).filter((item) => item !== symbol);
+    await writeJson(WATCHLIST_KEY, next);
+    return next;
+  },
+};
+
+export const AuditResultStore = {
+  async list(): Promise<AuditResultRecord[]> {
+    const rows = await readJson<AuditResultRecord[]>(AUDIT_RESULTS_KEY, []);
+    return rows
+      .filter((row) => row && typeof row.id === 'string' && typeof row.ticker === 'string')
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  },
+  async save(record: AuditResultRecord): Promise<AuditResultRecord[]> {
+    const current = await this.list();
+    const next = [record, ...current.filter((row) => row.id !== record.id)].slice(0, 250);
+    await writeJson(AUDIT_RESULTS_KEY, next);
+    return next;
+  },
+  async remove(id: string): Promise<AuditResultRecord[]> {
+    const next = (await this.list()).filter((row) => row.id !== id);
+    await writeJson(AUDIT_RESULTS_KEY, next);
+    return next;
+  },
+  async clear(): Promise<void> {
+    await AsyncStorage.removeItem(AUDIT_RESULTS_KEY);
+  },
+};

--- a/mobile/core/ui/TerminalShell.tsx
+++ b/mobile/core/ui/TerminalShell.tsx
@@ -1,0 +1,201 @@
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { router, usePathname } from 'expo-router';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, TextInput, useWindowDimensions, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { GlobalIndexQuote, MarketApi } from '../api/marketApi';
+
+export type TerminalRoute = {
+  key: string;
+  label: string;
+  short: string;
+  route: string;
+  hint: string;
+};
+
+export const TERMINAL_ROUTES: TerminalRoute[] = [
+  { key: 'home', label: 'Cockpit', short: 'HOME', route: '/', hint: 'Cartera live, índices y prioridades' },
+  { key: 'markets', label: 'Markets', short: 'MKT', route: '/workspace/markets', hint: 'Mercados, índices, movers y macro' },
+  { key: 'portfolio', label: 'Portfolio', short: 'PORT', route: '/portfolio', hint: 'Cartera, P&L, exposición y contribución' },
+  { key: 'audit', label: 'Auditar', short: 'AUD', route: '/audit', hint: 'Auditoría ticker-first y motores ATLAS' },
+  { key: 'watchlist', label: 'Watchlist', short: 'WL', route: '/watchlist', hint: 'Candidatos, no-chase y alertas' },
+  { key: 'results', label: 'Resultados', short: 'RES', route: '/results', hint: 'Historial guardado e inmutable de auditorías' },
+  { key: 'opportunities', label: 'Opportunities', short: 'OPP', route: '/workspace/opportunities', hint: 'Prioridades, Wave Score y receptores de capital' },
+  { key: 'atlas', label: 'ATLAS Ω', short: 'Ω', route: '/workspace/atlas', hint: 'Investment Committee, motores y Falsifiers' },
+  { key: 'screener', label: 'Screener', short: 'SCR', route: '/workspace/screener', hint: 'Universos, filtros y rankings' },
+  { key: 'research', label: 'Research', short: 'RSR', route: '/workspace/research', hint: 'Firecrawl Search Ω, evidencia y tesis' },
+  { key: 'catalysts', label: 'Catalysts', short: 'CAL', route: '/workspace/catalysts', hint: 'Resultados, FDA, macro y eventos' },
+  { key: 'news', label: 'News', short: 'NEWS', route: '/workspace/news', hint: 'Noticias con procedencia y relevancia ATLAS' },
+  { key: 'orders', label: 'Orders', short: 'ORD', route: '/workspace/orders', hint: 'Órdenes, execution gate e historial' },
+  { key: 'risk', label: 'Risk', short: 'RSK', route: '/workspace/risk', hint: 'Concentración, drawdown y correlación' },
+  { key: 'analyze', label: 'Security Hub', short: 'SEC', route: '/analyze', hint: 'Ficha profunda de un valor' },
+  { key: 'broker', label: 'Broker Ω', short: 'T212', route: '/broker', hint: 'Trading 212, sesión y control' },
+  { key: 'settings', label: 'System', short: 'SYS', route: '/settings', hint: 'Proveedores, backend y configuración' },
+];
+
+const TOP_KEYS = ['markets', 'portfolio', 'audit', 'watchlist', 'results', 'opportunities', 'atlas', 'screener', 'research', 'catalysts', 'news', 'orders', 'risk'];
+const TOP_MODULES = TERMINAL_ROUTES.filter((item) => TOP_KEYS.includes(item.key));
+const BOTTOM_KEYS = ['home', 'portfolio', 'audit', 'watchlist'];
+
+export function TerminalShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const { width } = useWindowDimensions();
+  const wide = width >= 900;
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const navigate = (route: string) => {
+    setPaletteOpen(false);
+    setQuery('');
+    router.push(route as never);
+  };
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <View style={styles.root}>
+        <TerminalHeader onOpenPalette={() => setPaletteOpen(true)} />
+        <WorldIndexTape />
+        {!wide ? (
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.moduleStrip} contentContainerStyle={styles.moduleStripContent}>
+            {TOP_MODULES.map((item) => <ModuleChip key={item.key} item={item} active={isActive(pathname, item.route)} onPress={() => navigate(item.route)} />)}
+          </ScrollView>
+        ) : null}
+        <View style={styles.body}>
+          {wide ? <DesktopRail pathname={pathname} onNavigate={navigate} /> : null}
+          <View style={styles.content}>{children}</View>
+        </View>
+        {!wide ? (
+          <View style={styles.bottomNav}>
+            {BOTTOM_KEYS.map((key) => {
+              const item = TERMINAL_ROUTES.find((row) => row.key === key)!;
+              return <BottomItem key={key} item={item} active={isActive(pathname, item.route)} onPress={() => navigate(item.route)} />;
+            })}
+            <Pressable onPress={() => setPaletteOpen(true)} style={({ pressed }) => [styles.bottomItem, pressed && styles.pressed]}>
+              <Text style={styles.bottomShort}>GO</Text><Text style={styles.bottomLabel}>Más</Text>
+            </Pressable>
+          </View>
+        ) : null}
+        <CommandPalette open={paletteOpen} query={query} onChangeQuery={setQuery} onClose={() => { setPaletteOpen(false); setQuery(''); }} onNavigate={navigate} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function TerminalHeader({ onOpenPalette }: { onOpenPalette: () => void }) {
+  return (
+    <View style={styles.header}>
+      <Pressable onPress={() => router.push('/' as never)} style={styles.brandWrap}>
+        <View style={styles.brandMark}><Text style={styles.brandOmega}>Ω</Text></View>
+        <View><Text style={styles.brand}>ATLAS</Text><Text style={styles.brandSub}>INVESTMENT TERMINAL</Text></View>
+      </Pressable>
+      <Pressable onPress={onOpenPalette} style={({ pressed }) => [styles.goBar, pressed && styles.pressed]}>
+        <Text style={styles.goPrompt}>GO</Text><Text numberOfLines={1} style={styles.goText}>ticker, AUD, WL, RES…</Text><View style={styles.keycap}><Text style={styles.keycapText}>⌘K</Text></View>
+      </Pressable>
+      <View style={styles.livePill}><View style={styles.liveDot} /><Text style={styles.liveText}>LIVE</Text></View>
+    </View>
+  );
+}
+
+function WorldIndexTape() {
+  const [items, setItems] = useState<GlobalIndexQuote[]>([]);
+  const [gate, setGate] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      try {
+        const payload = await MarketApi.indices();
+        if (mounted) { setItems(payload.items.filter((row) => row.status === 'OK')); setGate(null); }
+      } catch (cause) {
+        if (mounted) setGate(cause instanceof Error ? cause.message : 'INDEX DATA GATE');
+      }
+    };
+    void load();
+    const timer = setInterval(() => { void load(); }, 15000);
+    return () => { mounted = false; clearInterval(timer); };
+  }, []);
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.tape} contentContainerStyle={styles.tapeContent}>
+      {items.length ? items.map((item) => <IndexChip key={item.symbol} item={item} />) : (
+        <View style={styles.gateTape}><Text style={styles.gateLabel}>GLOBAL INDICES</Text><Text style={styles.gateText}>{gate || 'CONECTANDO FEED…'}</Text></View>
+      )}
+    </ScrollView>
+  );
+}
+
+function IndexChip({ item }: { item: GlobalIndexQuote }) {
+  const pct = item.percentageChange;
+  const positive = typeof pct === 'number' && pct > 0;
+  const negative = typeof pct === 'number' && pct < 0;
+  return (
+    <View style={styles.indexChip}>
+      <View><Text style={styles.indexName}>{item.name}</Text><Text style={styles.indexRegion}>{item.region}</Text></View>
+      <Text style={styles.indexPrice}>{formatMarket(item.price)}</Text>
+      <Text style={[styles.indexChange, positive && styles.positive, negative && styles.negative]}>{formatPct(pct)}</Text>
+    </View>
+  );
+}
+
+function DesktopRail({ pathname, onNavigate }: { pathname: string; onNavigate: (route: string) => void }) {
+  return (
+    <ScrollView style={styles.rail} contentContainerStyle={styles.railContent} showsVerticalScrollIndicator={false}>
+      <Text style={styles.railTitle}>FUNCTIONS</Text>
+      {TERMINAL_ROUTES.map((item) => (
+        <Pressable key={item.key} onPress={() => onNavigate(item.route)} style={({ pressed }) => [styles.railItem, isActive(pathname, item.route) && styles.railItemActive, pressed && styles.pressed]}>
+          <Text style={[styles.railCode, isActive(pathname, item.route) && styles.railCodeActive]}>{item.short}</Text>
+          <View style={styles.railTextWrap}><Text style={[styles.railLabel, isActive(pathname, item.route) && styles.railLabelActive]}>{item.label}</Text><Text numberOfLines={1} style={styles.railHint}>{item.hint}</Text></View>
+        </Pressable>
+      ))}
+    </ScrollView>
+  );
+}
+
+function ModuleChip({ item, active, onPress }: { item: TerminalRoute; active: boolean; onPress: () => void }) {
+  return <Pressable onPress={onPress} style={({ pressed }) => [styles.moduleChip, active && styles.moduleChipActive, pressed && styles.pressed]}><Text style={[styles.moduleCode, active && styles.moduleCodeActive]}>{item.short}</Text><Text style={[styles.moduleLabel, active && styles.moduleLabelActive]}>{item.label}</Text></Pressable>;
+}
+function BottomItem({ item, active, onPress }: { item: TerminalRoute; active: boolean; onPress: () => void }) {
+  return <Pressable onPress={onPress} style={({ pressed }) => [styles.bottomItem, active && styles.bottomItemActive, pressed && styles.pressed]}><Text style={[styles.bottomShort, active && styles.bottomShortActive]}>{item.short}</Text><Text style={[styles.bottomLabel, active && styles.bottomLabelActive]}>{item.label}</Text></Pressable>;
+}
+
+function CommandPalette({ open, query, onChangeQuery, onClose, onNavigate }: { open: boolean; query: string; onChangeQuery: (value: string) => void; onClose: () => void; onNavigate: (route: string) => void }) {
+  const normalized = query.trim().toLowerCase();
+  const rows = useMemo(() => !normalized ? TERMINAL_ROUTES : TERMINAL_ROUTES.filter((item) => `${item.label} ${item.short} ${item.hint}`.toLowerCase().includes(normalized)), [normalized]);
+  const ticker = query.trim().toUpperCase();
+  const tickerCandidate = /^[A-Z0-9.\-]{1,12}$/.test(ticker);
+  return (
+    <Modal visible={open} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.modalBackdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <View style={styles.palette}>
+          <View style={styles.paletteHeader}><Text style={styles.paletteLabel}>ATLAS GO BAR</Text><Pressable onPress={onClose} style={styles.closeButton}><Text style={styles.closeText}>ESC</Text></Pressable></View>
+          <TextInput autoFocus value={query} onChangeText={onChangeQuery} autoCapitalize="characters" autoCorrect={false} placeholder="Ticker, AUD, WATCHLIST, RESULTS…" placeholderTextColor="#5f6b70" style={styles.paletteInput} returnKeyType="search" onSubmitEditing={() => { if (tickerCandidate) onNavigate(`/analyze?ticker=${encodeURIComponent(ticker)}`); }} />
+          <ScrollView style={styles.paletteResults} keyboardShouldPersistTaps="handled">
+            {tickerCandidate ? <CommandRow code="SEC" title={`Analizar ${ticker}`} hint="Security Hub" onPress={() => onNavigate(`/analyze?ticker=${encodeURIComponent(ticker)}`)} /> : null}
+            {rows.map((item) => <CommandRow key={item.key} code={item.short} title={item.label} hint={item.hint} onPress={() => onNavigate(item.route)} />)}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+function CommandRow({ code, title, hint, onPress }: { code: string; title: string; hint: string; onPress: () => void }) {
+  return <Pressable onPress={onPress} style={({ pressed }) => [styles.commandRow, pressed && styles.pressed]}><View style={styles.commandCodeBox}><Text style={styles.commandCode}>{code}</Text></View><View style={styles.commandTextWrap}><Text style={styles.commandTitle}>{title}</Text><Text style={styles.commandHint}>{hint}</Text></View><Text style={styles.commandArrow}>→</Text></Pressable>;
+}
+
+function isActive(pathname: string, route: string): boolean { return route === '/' ? pathname === '/' : pathname === route || pathname.startsWith(`${route}/`); }
+function formatMarket(value: number | null): string { return value === null ? '—' : value.toLocaleString('es-ES', { maximumFractionDigits: 2 }); }
+function formatPct(value: number | null): string { return value === null ? '—' : `${value > 0 ? '+' : ''}${value.toFixed(2)}%`; }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#030506' }, root: { flex: 1, backgroundColor: '#030506' },
+  header: { minHeight: 54, flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 10, borderBottomWidth: 1, borderBottomColor: '#1a2428', backgroundColor: '#050809' },
+  brandWrap: { flexDirection: 'row', alignItems: 'center', gap: 8 }, brandMark: { width: 30, height: 30, borderWidth: 1, borderColor: '#23d9a7', alignItems: 'center', justifyContent: 'center', backgroundColor: '#07130f' }, brandOmega: { color: '#51f2c5', fontFamily: 'monospace', fontSize: 18, fontWeight: '900' }, brand: { color: '#f3f6f5', fontFamily: 'monospace', fontWeight: '900', fontSize: 14, letterSpacing: 1.5 }, brandSub: { color: '#66757b', fontFamily: 'monospace', fontWeight: '700', fontSize: 7, letterSpacing: 1.1 },
+  goBar: { flex: 1, minWidth: 0, height: 34, borderWidth: 1, borderColor: '#26343a', backgroundColor: '#0a0f11', flexDirection: 'row', alignItems: 'center', paddingHorizontal: 9, gap: 8 }, goPrompt: { color: '#42e8b4', fontFamily: 'monospace', fontWeight: '900', fontSize: 11 }, goText: { color: '#7d8c92', fontFamily: 'monospace', fontSize: 10, flex: 1 }, keycap: { borderWidth: 1, borderColor: '#2d3a3f', paddingHorizontal: 5, paddingVertical: 2, backgroundColor: '#0f1517' }, keycapText: { color: '#829197', fontFamily: 'monospace', fontSize: 8, fontWeight: '800' },
+  livePill: { flexDirection: 'row', alignItems: 'center', gap: 5, borderWidth: 1, borderColor: '#214b3d', backgroundColor: '#081510', paddingHorizontal: 7, height: 28 }, liveDot: { width: 6, height: 6, borderRadius: 99, backgroundColor: '#31e6a3' }, liveText: { color: '#7ff5ce', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
+  tape: { maxHeight: 42, borderBottomWidth: 1, borderBottomColor: '#172126', backgroundColor: '#060a0c' }, tapeContent: { alignItems: 'stretch' }, indexChip: { minWidth: 172, height: 41, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 10, borderRightWidth: 1, borderRightColor: '#172126' }, indexName: { color: '#b9c5c2', fontFamily: 'monospace', fontWeight: '800', fontSize: 8 }, indexRegion: { color: '#45545a', fontFamily: 'monospace', fontSize: 7, marginTop: 2 }, indexPrice: { color: '#e5ecea', fontFamily: 'monospace', fontWeight: '900', fontSize: 10 }, indexChange: { minWidth: 48, textAlign: 'right', color: '#849197', fontFamily: 'monospace', fontWeight: '900', fontSize: 9 }, positive: { color: '#4fe0ad' }, negative: { color: '#e37c83' }, gateTape: { minHeight: 41, flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 10 }, gateLabel: { color: '#d0c16f', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, gateText: { color: '#6e7b80', fontFamily: 'monospace', fontSize: 8 },
+  moduleStrip: { maxHeight: 39, borderBottomWidth: 1, borderBottomColor: '#182226', backgroundColor: '#050809' }, moduleStripContent: { alignItems: 'center', paddingHorizontal: 5 }, moduleChip: { height: 38, flexDirection: 'row', alignItems: 'center', gap: 5, paddingHorizontal: 9, borderRightWidth: 1, borderRightColor: '#111b1f' }, moduleChipActive: { backgroundColor: '#09130f' }, moduleCode: { color: '#54646a', fontFamily: 'monospace', fontWeight: '900', fontSize: 8 }, moduleCodeActive: { color: '#4fe8b6' }, moduleLabel: { color: '#88969b', fontSize: 9, fontWeight: '700' }, moduleLabelActive: { color: '#dbe7e3' },
+  body: { flex: 1, flexDirection: 'row' }, content: { flex: 1, minWidth: 0 }, rail: { width: 228, backgroundColor: '#050809', borderRightWidth: 1, borderRightColor: '#172126' }, railContent: { paddingBottom: 20 }, railTitle: { color: '#3e4d53', fontFamily: 'monospace', fontSize: 7, fontWeight: '900', letterSpacing: 1.1, paddingHorizontal: 10, paddingVertical: 9 }, railItem: { minHeight: 49, flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 9, borderTopWidth: 1, borderTopColor: '#0d1518' }, railItemActive: { backgroundColor: '#08130f', borderLeftWidth: 2, borderLeftColor: '#3de1ad' }, railCode: { width: 34, color: '#536269', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, railCodeActive: { color: '#4fe8b6' }, railTextWrap: { flex: 1 }, railLabel: { color: '#98a5a9', fontSize: 10, fontWeight: '800' }, railLabelActive: { color: '#e3ece9' }, railHint: { color: '#445258', fontSize: 8, marginTop: 2 },
+  bottomNav: { minHeight: 55, flexDirection: 'row', borderTopWidth: 1, borderTopColor: '#1a2529', backgroundColor: '#050809' }, bottomItem: { flex: 1, minWidth: 0, alignItems: 'center', justifyContent: 'center', gap: 3 }, bottomItemActive: { backgroundColor: '#08120f' }, bottomShort: { color: '#637178', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, bottomShortActive: { color: '#51e8b7' }, bottomLabel: { color: '#66757a', fontSize: 8, fontWeight: '700' }, bottomLabelActive: { color: '#d8e4e0' },
+  modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.72)', alignItems: 'center', paddingTop: 80, paddingHorizontal: 12 }, palette: { width: '100%', maxWidth: 680, maxHeight: '78%', borderWidth: 1, borderColor: '#2a3b40', backgroundColor: '#070b0d' }, paletteHeader: { minHeight: 40, flexDirection: 'row', alignItems: 'center', paddingHorizontal: 11, borderBottomWidth: 1, borderBottomColor: '#1c292e' }, paletteLabel: { flex: 1, color: '#4fe8b6', fontFamily: 'monospace', fontSize: 9, fontWeight: '900', letterSpacing: 1 }, closeButton: { borderWidth: 1, borderColor: '#2a383d', paddingHorizontal: 7, paddingVertical: 4 }, closeText: { color: '#718086', fontFamily: 'monospace', fontSize: 8 }, paletteInput: { minHeight: 50, color: '#edf4f2', fontFamily: 'monospace', fontSize: 14, paddingHorizontal: 12, borderBottomWidth: 1, borderBottomColor: '#1c292e' }, paletteResults: { maxHeight: 430 }, commandRow: { minHeight: 56, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 11, borderBottomWidth: 1, borderBottomColor: '#101a1d' }, commandCodeBox: { width: 42, height: 28, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: '#26383e', backgroundColor: '#091012' }, commandCode: { color: '#63d9b7', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, commandTextWrap: { flex: 1 }, commandTitle: { color: '#dfe8e5', fontSize: 11, fontWeight: '800' }, commandHint: { color: '#526168', fontSize: 9, marginTop: 2 }, commandArrow: { color: '#55d9b2', fontFamily: 'monospace' }, pressed: { opacity: 0.65 },
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,8 +12,10 @@
     "build:aab": "eas build -p android --profile production"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~57.0.8",
     "expo-router": "~57.0.8",
+    "expo-secure-store": "~57.0.1",
     "expo-status-bar": "~57.0.1",
     "react": "19.2.3",
     "react-native": "0.86.2",

--- a/mobile/scripts/android-functional-smoke.sh
+++ b/mobile/scripts/android-functional-smoke.sh
@@ -32,9 +32,6 @@ PY
 }
 
 dismiss_emulator_noise() {
-  # GitHub's cold Pixel emulator occasionally raises a Pixel Launcher ANR even
-  # while our explicitly launched activity is healthy. Dismiss that system-only
-  # dialog; never suppress a crash/ANR whose title names ATLAS.
   if grep -Fq "Pixel Launcher isn't responding" window.xml 2>/dev/null; then
     local coords
     coords="$(node_center_by_resource_id 'android:id/aerr_wait')"
@@ -112,24 +109,29 @@ PY
   exit 1
 }
 
-wait_text "ATLAS Ω TERMINAL"
-wait_text "Command Center"
+# Terminal home must render the new portfolio-first shell.
+wait_text "Portfolio First"
+wait_text "GLOBAL INDICES"
+wait_text "LIVE PORTFOLIO · TRADING 212"
+wait_text "PRIMARY WORKSPACES"
+
+# Core mobile navigation must be reachable from persistent terminal controls.
+tap_desc "AUD, Auditar"
+wait_text "ATLAS TERMINAL · AUDIT"
+wait_text "Auditar"
+adb shell input keyevent 4
 wait_text "Portfolio First"
 
-tap_desc "Audit Console"
-wait_text "Analizar empresa"
+tap_desc "WL, Watchlist"
+wait_text "ATLAS TERMINAL · WATCHLIST"
+wait_text "Watchlist"
 adb shell input keyevent 4
-wait_text "ATLAS Ω TERMINAL"
+wait_text "Portfolio First"
 
-tap_desc "Portfolio First"
-wait_text "Cartera 36"
+tap_desc "RES, Resultados"
+wait_text "RESULTADOS"
 adb shell input keyevent 4
-wait_text "ATLAS Ω TERMINAL"
-
-tap_desc "Broker Ω"
-wait_text "Trading 212"
-adb shell input keyevent 4
-wait_text "ATLAS Ω TERMINAL"
+wait_text "Portfolio First"
 
 capture_ui
-echo "ATLAS Ω OpenTerminalUI mobile gate: PASS"
+echo "ATLAS Ω terminal Android launch/navigation gate: PASS"


### PR DESCRIPTION
Re-applies the exact OpenTerminalUI mobile shell from PR #65 on top of the current main tree, preserving all newer ATLAS canon/engine commits. Includes TerminalShell, terminal cockpit, AUD, Watchlist, Result Journal, workspace routes, encrypted broker session, global index tape API, tests and updated Android smoke gate. This replaces the old screener UI that was accidentally rebuilt.