### PR TITLE
ATLAS Ω: add copper upstream watchlist

### DIFF
--- a/docs/research/watchlists/2026-08-21_COPPER_UPSTREAM_WATCHLIST_OMEGA.md
+++ b/docs/research/watchlists/2026-08-21_COPPER_UPSTREAM_WATCHLIST_OMEGA.md
@@ -1,0 +1,56 @@
+# ATLAS Ω — Copper Upstream Watchlist
+
+**Date:** 2026-08-21  
+**Status:** ACTIVE WATCHLIST  
+**Universe rule:** Economic Proof Ω minimum 4/5. 5/5 = strongest pass; 4/5 = valid pass unless the single failed gate is a material falsifier. Economic Proof Ω and Equity Monetization Ω remain orthogonal.
+
+## Current approved watchlist — 27 names
+
+### Tier 1 — strongest current winners / receivers
+1. **BHP — BHP Group Limited** — Economic Proof **5/5** — current confirmed receiver.
+2. **FCX — Freeport-McMoRan Inc.** — Economic Proof **4/5** — very strong relative strength / near highs.
+3. **SFR.AX — Sandfire Resources Limited** — Economic Proof **4/5** — strong relative strength / near highs.
+4. **TGB / TKO — Trekor Metals Corp.** — Economic Proof **5/5** — full economic pass; price relatively resilient.
+5. **SCCO — Southern Copper Corporation** — Economic Proof **4/5** — exceptional current economic capture.
+
+### Tier 2 — strong Economic Proof / equity not fully confirmed
+6. **CS.TO — Capstone Copper Corp.** — Economic Proof **5/5**.
+7. **LUN — Lundin Mining Corporation** — Economic Proof **5/5**.
+8. **RIO — Rio Tinto Group** — Economic Proof **4/5**.
+9. **HBM — Hudbay Minerals Inc.** — Economic Proof **4/5**.
+10. **ERO — Ero Copper Corp.** — Economic Proof **4/5**.
+11. **TECK.B — Teck Resources Limited** — Economic Proof **4/5**.
+12. **ANTO — Antofagasta plc** — Economic Proof **4/5**.
+13. **GLEN — Glencore plc** — Economic Proof **4/5**.
+14. **CMOC — CMOC Group Limited** — Economic Proof **4/5**.
+15. **ATYM — Atalaya Mining Copper, S.A.** — Economic Proof **4/5**.
+16. **ARG — Amerigo Resources Ltd.** — Economic Proof **4/5**.
+
+### Tier 3 — approved smaller / emerging producers and diversified names
+17. **VALE — Vale S.A.** — Economic Proof **4/5**.
+18. **1515.T — Nittetsu Mining Co., Ltd.** — Economic Proof **4/5**.
+19. **AIS.AX — Aeris Resources Limited** — Economic Proof **4/5**.
+20. **HGO.AX — Hillgrove Resources Limited / Kantra Copper** — Economic Proof **4/5**.
+21. **DVP.AX — Develop Global Limited** — Economic Proof **4/5**.
+22. **CBE.AX — Cobre Limited** — Economic Proof **4/5**.
+23. **AR1.AX — Austral Resources Australia Ltd.** — Economic Proof **4/5**.
+24. **FM.TO / FQVLF — First Quantum Minerals Ltd.** — Economic Proof **4/5**.
+25. **B / ABX.TO — Barrick Mining Corporation** — Economic Proof **4/5**.
+26. **A1M.AX — AIC Mines Limited** — Economic Proof **4/5**.
+27. **GCU.TO — Gunnison Copper Corp.** — Economic Proof **4/5**.
+
+## Canonical interpretation
+- A stock is not a winner merely because it is positive from an arbitrary starting date.
+- Current Equity Monetization requires continuity, strong relative strength and proximity to / confirmation of period highs.
+- A deep drawdown is not a BUY signal.
+- Priority opportunity pattern: **Economic Proof ↑ while Equity Monetization ↓**, provided valuation, capital efficiency and falsifiers remain acceptable.
+- Developers/explorers without commercial production cannot substitute resource estimates, PEA/PFS/DFS projections or drilling results for realized revenue, cash flow or ROIC.
+
+## Current research focus
+- **Current receiver:** BHP.
+- **Strong current price candidates:** FCX, SFR.AX, TGB/TKO, SCCO.
+- **Economic Proof / Equity divergence candidates:** CS.TO, LUN, RIO and other approved names where price confirmation is still absent.
+- Maintain explicit jurisdiction/event overlays for First Quantum Minerals and other politically exposed producers.
+
+## Governance
+This watchlist is research inventory, not an automatic portfolio instruction. Every promotion to BUY/HOLD/portfolio action must still pass applicable ATLAS Ω valuation, expected-return, falsifier, regime, execution and portfolio-construction gates under a common evidence cutoff.


### PR DESCRIPTION
Closed under ATLAS construction freeze. Copper watchlist is not required for ATLAS v1 completion. Preserve as historical research; no promotion before core validation and product closure.