### PR TITLE
Add Media Discovery & Persistence Ω canon

### DIFF
--- a/CURRENT_CANON/MEDIA_DISCOVERY_AND_PERSISTENCE_OMEGA.md
+++ b/CURRENT_CANON/MEDIA_DISCOVERY_AND_PERSISTENCE_OMEGA.md
@@ -1,0 +1,217 @@
+# ATLAS Ω — Media Discovery & Persistence Ω
+
+**Status:** ACTIVE CANON  
+**Effective:** 2026-08-21  
+**Scope:** transversal discovery / moat-persistence / monetization evidence layer; no automatic BUY authority.
+
+## 1. Objective
+
+Detect structural changes in media, entertainment, creator formats, IP, streaming and AI-generated content without confusing attention, cultural momentum or format adoption with company-level Economic Proof.
+
+This module answers two different questions:
+
+1. **Discovery:** is a new consumption format, distribution behavior or monetization layer forming?
+2. **Persistence:** does an existing franchise, IP or platform continue to monetize durably enough to strengthen moat evidence?
+
+Neither answer can bypass valuation, Expected Return, Falsifiers Ω, Money Rotation Ω or portfolio construction.
+
+## 2. Constitutional laws
+
+- **ATTENTION ≠ REVENUE.**
+- **FORMAT GROWTH ≠ COMPANY ECONOMIC PROOF.**
+- **CULTURAL TREND ≠ DURABLE IP.**
+- **FRANCHISE LONGEVITY ≠ CURRENT MONETIZATION.**
+- **USER GROWTH ≠ FCF.**
+- **AI CAPABILITY ≠ AI ECONOMIC PROOF.**
+- **INDUSTRY RECOVERY ≠ ISSUER-SPECIFIC BUY.**
+- **STREAMING FRAGMENTATION ≠ AGGREGATOR MOAT.**
+- **PRIVATE / MEDIA ATTENTION ≠ PUBLIC EQUITY FLOW.**
+- **PRICE ACTION ≠ THESIS PROOF.**
+
+All evidence remains subject to FACT / HYPOTHESIS / INTERPRETATION / NOISE separation.
+
+## 3. Media Discovery Ladder Ω
+
+### Causal chain
+
+**Format emergence → audience adoption → repeat usage → paid conversion / advertising yield → retention → unit economics → margin / FCF → durable control point → valuation → observed repricing.**
+
+### States
+
+- `M0_NOISE` — anecdote, viral clip, isolated title, social buzz, press narrative.
+- `M1_FORMAT_ADOPTION` — measurable audience / usage growth across more than one title, cohort or platform.
+- `M2_MONETIZATION_SIGNAL` — observable paid conversion, ad yield, IAP, subscription, licensing or transaction revenue linkage.
+- `M3_RETENTION_AND_REPEATABILITY` — repeat usage, cohort retention, franchise recurrence, repeat advertiser / customer spend or durable catalogue demand.
+- `M4_MARGIN_CASH_PROOF` — monetization reconciles with gross margin, OCF/FCF and acceptable content / rights / inference economics.
+- `M5_DURABLE_CONTROL_POINT` — persistent IP, distribution, recommendation, billing, rights, marketplace or workflow control point with defensible economics.
+
+`M0-M1` may create DISCOVERY/WATCH evidence only.  
+No BUY authority exists below `M4`, and `M4-M5` still require valuation, expected return and falsifier clearance.
+
+## 4. Mandatory fields
+
+Every relevant media-format event should return:
+
+`FORMAT_OR_IP → SOURCE_QUALITY → ADOPTION_SIGNAL → REPEAT_USAGE → MONETIZATION_UNIT → PAYER → PAID_CONVERSION_OR_AD_YIELD → RETENTION → CONTENT/RIGHTS_COST → COMPUTE/INFERENCE_COST_IF_AI → GROSS_MARGIN → OCF/FCF → CONTROL_POINT → BYPASS_RISK → REPRICING_STATE → FALSIFIERS → ACTION_PERMITTED`
+
+## 5. IP Persistence Evidence Ω
+
+Long-lived franchises may contribute to Moat / Persistence Ω only when longevity is connected to current economic output.
+
+### Persistence chain
+
+**Historical longevity → current active audience → recurring monetization → low decay / reactivation ability → cross-platform distribution → margin / cash conversion → durable IP evidence.**
+
+### Evidence levels
+
+- `P0_NOSTALGIA_ONLY`
+- `P1_ACTIVE_AUDIENCE`
+- `P2_CURRENT_MONETIZATION`
+- `P3_REPEATABLE_REACTIVATION`
+- `P4_DURABLE_CASH_GENERATION`
+- `P5_MULTI-CYCLE_IP_MOAT`
+
+A franchise age or ranking statistic alone cannot exceed `P1`.
+
+## 6. Aggregation / Fragmentation Tollbooth Ω
+
+When distribution becomes fragmented and consumer coordination cost rises, ATLAS may create an **Aggregation Tollbooth hypothesis**.
+
+### Chain
+
+**Fragmented rights / services → consumer friction → aggregation demand → bundle / discovery / billing layer → subscriber retention / take rate → rights-cost coverage → margin / FCF → control-point durability.**
+
+Mandatory tests:
+
+1. Who pays the aggregator?
+2. Is there a measurable subscription fee, take rate, ad yield or bundling economics?
+3. Does aggregation reduce churn or customer-acquisition cost?
+4. Are sports / content rights costs growing faster than monetization?
+5. Can rights owners or hyperscalers bypass the aggregator?
+6. Is the distributor gaining bargaining power or merely absorbing cost inflation?
+
+Fragmentation itself is not proof of aggregator value.
+
+## 7. AI-Generated Media Bridge
+
+AI music, AI video and AI creator tools are routed into existing AI Economic Proof and AI Tollbooth gates.
+
+### Required chain
+
+**Generation capability → active creators → repeated production → paid conversion → workflow integration → inference cost → gross margin → retention → revenue quality → OCF/FCF → durable control point.**
+
+AI media cannot satisfy Economic Proof from demos, virality, user counts, funding or media coverage alone.
+
+Where a third-party routing / billing / distribution layer repeatedly monetizes AI-generated content, forward the candidate to **AI Tollbooth Ω** for independent T0–T4 scoring.
+
+## 8. Industry Recovery Rule
+
+Industry-wide recovery evidence — e.g. cinema attendance / box office normalization — is classified as:
+
+`INDUSTRY_DEMAND_SIGNAL`
+
+It may raise audit priority for exposed issuers, but cannot establish issuer-level Economic Proof until reconciled with:
+
+- revenue growth,
+- pricing / attendance / ARPU,
+- content slate economics,
+- operating leverage,
+- rights / production costs,
+- margin,
+- OCF/FCF,
+- balance-sheet burden,
+- valuation.
+
+## 9. Calibration — Bloomberg Screentime, 21-Aug-2026
+
+**Source status:** user-supplied Bloomberg Screentime newsletter; calibration evidence, not standalone issuer proof.
+
+### A. Global cinema recovery
+Reported global movie-ticket sales on pace for the strongest annual total since the pandemic.
+
+Classification: `INDUSTRY_DEMAND_SIGNAL / WATCH`.
+
+Allowed inference: audit exhibitors, studios, distributors and ad / ancillary beneficiaries for operating leverage and FCF recovery.  
+Forbidden inference: sector recovery = automatic BUY.
+
+### B. Candy Crush / King / Microsoft
+Reported persistence of Candy Crush approximately fifteen years after launch.
+
+Classification: `IP_PERSISTENCE_SIGNAL` for King / Microsoft.
+
+Allowed contribution: Moat / Persistence evidence after current users, bookings / revenue contribution, margin and cash economics are verified.  
+Forbidden inference: franchise age alone = material MSFT Economic Proof or valuation uplift.
+
+### C. Romantasy
+Reported roughly billion-dollar genre momentum and potential Hollywood franchise pipeline.
+
+Classification: `M0-M1 DISCOVERY`.
+
+Required next evidence: rights ownership, publisher / studio economics, adaptation pipeline, licensing, repeat readership / viewership and margin capture.
+
+### D. 90-second microdramas
+Reported transition from large-scale Chinese smartphone adoption toward U.S. / Hollywood participation.
+
+Classification: `M1 FORMAT_ADOPTION / DISCOVERY`.
+
+Mandatory economic map:
+
+**smartphone → short-form content → recommendation → production → advertising / IAP / subscription → payments → distribution.**
+
+ATLAS must identify the control point before ticker promotion: distribution, recommendation, billing, payments, creator workflow, IP or ad monetization.
+
+### E. Suno / AI music
+Reported AI-music consumer / creator adoption theme.
+
+Classification: `AI_APPLICATION_DISCOVERY`, initially `M0-M1` and AI Economic Proof `T0-T1` unless company-specific monetization evidence is verified.
+
+Required next evidence: paid users, retention, ARPU, enterprise / professional usage, inference cost, gross margin, copyright / licensing burden, revenue quality and FCF.
+
+### F. Sports-streaming fragmentation
+Reported increasing cost / complexity for U.S. sports consumers.
+
+Classification: `AGGREGATION_TOLLBOOTH_HYPOTHESIS`.
+
+Required next evidence: bundle adoption, churn reduction, ARPU, rights-cost inflation, distributor bargaining power, take rate / subscription economics and FCF.
+
+## 10. Integration with ATLAS Ω
+
+- **Moat / Persistence Ω:** receives verified `P2+` IP persistence evidence.
+- **AI Tollbooth Ω:** receives recurring AI-media routing, billing, distribution or workflow control-point candidates.
+- **AI Economic Proof Ω:** independently validates revenue, margin and cash conversion for AI-media issuers.
+- **Money Rotation Ω:** tests public-equity capital flow separately from media attention.
+- **Valuation / Implied Return Ω:** determines whether verified economics remain underpriced.
+- **Falsifiers Ω:** keeps independent veto authority.
+- **Investment Committee Ω:** integrates outputs; no majority vote overrides evidence gates.
+
+## 11. Red-team falsifiers
+
+Downgrade or reject when materially present:
+
+- virality without repeat usage;
+- one-hit dependence;
+- rising content / rights costs consuming monetization gains;
+- creator subsidies masking weak unit economics;
+- AI inference cost compressing gross margin;
+- copyright / licensing liability;
+- platform disintermediation;
+- weak paid conversion;
+- high churn;
+- ad CPM / fill-rate deterioration;
+- catalogue decay;
+- franchise reactivation failure;
+- rights owner bypass;
+- bundling that raises revenue but destroys margin;
+- price rerating unsupported by economic delta.
+
+## 12. Output contract
+
+Each run returns:
+
+`ticker_or_private_entity, timestamp, source, media_state, persistence_state, FACTS[], HYPOTHESES[], INTERPRETATIONS[], NOISE[], adoption_signal, monetization_unit, payer, retention_signal, cost_structure, margin_cash_proof, control_point, bypass_risk, economic_proof_state, repricing_state, falsifiers[], next_evidence_required[], action_permitted`
+
+## 13. Canonical principle
+
+**MEDIA ATTENTION → POSSIBLE ADOPTION → POSSIBLE MONETIZATION → VERIFIED CASH ECONOMICS → DURABLE CONTROL POINT → VALUATION.**
+
+Never reverse the chain by treating cultural relevance, virality, franchise age or media coverage as proof of revenue, margin, FCF or investable expected return.


### PR DESCRIPTION
Implements the Bloomberg Screentime-derived media signal framework without promoting trend/attention to Economic Proof. Adds Media Discovery Ladder, IP Persistence, Aggregation/Fragmentation Tollbooth, AI-generated media bridge, industry recovery rule, red-team falsifiers, output contract, and calibrations for cinema recovery, Candy Crush/King/MSFT, romantasy, microdramas, Suno and sports-streaming fragmentation.