### PR TITLE
ATLAS Ω: separate pure return ranking from quality/composite

### DIFF
--- a/CURRENT_CANON/RETURN_OBJECTIVE_SEPARATION_OMEGA.md
+++ b/CURRENT_CANON/RETURN_OBJECTIVE_SEPARATION_OMEGA.md
@@ -1,0 +1,145 @@
+# RETURN OBJECTIVE SEPARATION Ω
+
+**Status:** ACTIVE CANON  
+**Effective date:** 2026-08-21  
+**Authority:** explicit user correction after Europe return-ranking audit  
+**Implementation:** `src/atlas/algorithm/return-objective-separation-omega.ts`
+
+## Purpose
+
+Prevent ATLAS Ω from answering a request for **return** with a ranking that is actually dominated by company quality, moat, Economic Proof, prestige or a multi-factor opportunity composite.
+
+The trigger for this amendment was a European-equity ranking in which ASML/ASMI rose to the top because quality and Economic Proof contaminated what the user had requested as a return ranking.
+
+## Constitutional separation
+
+ATLAS now has four explicitly separate ranking objectives:
+
+1. **HISTORICAL RETURN** — what has already delivered the highest verified market return over a specified past window.
+2. **EXPECTED RETURN** — what offers the highest evidence-backed forward expected CAGR from the current price.
+3. **BUSINESS QUALITY** — what has the strongest business, moat, economics and durability.
+4. **COMPOSITE OPPORTUNITY** — a multi-engine opportunity view combining return, revisions, flows, momentum, specialist engines, risk and business evidence.
+
+These outputs may be displayed side by side, but **must never be silently substituted for one another**.
+
+## Pure-return law
+
+When the user asks for:
+
+- `más retorno`;
+- `máximo retorno`;
+- `por retorno`;
+- `retorno esperado`;
+- `retorno futuro`;
+- `Expected Return`;
+- `CAGR`;
+
+ATLAS routes to **EXPECTED RETURN** unless the request explicitly anchors the metric to a historical period.
+
+When the user explicitly asks for YTD, a named past year, 1Y/3Y/5Y performance, `ha subido`, historical performance or another backward-looking window, ATLAS routes to **HISTORICAL RETURN**.
+
+## EXPECTED RETURN ranking rule
+
+The ordering variable is:
+
+**probability-weighted forward CAGR from current price.**
+
+The calculation uses scenario total returns over a common horizon, converts them into an expected terminal value and annualizes that expected terminal value.
+
+### What may affect ranking order
+
+- current price;
+- scenario terminal values / valuation outputs;
+- scenario probabilities;
+- explicit dilution or per-share effects embedded in the valuation path;
+- horizon normalization.
+
+### What may NOT add ranking points
+
+- generic company quality;
+- moat score;
+- fame;
+- market capitalization;
+- analyst coverage;
+- absolute FCF dollars;
+- index membership;
+- GREEN continuity;
+- Economic Proof score itself;
+- Money Rotation score;
+- momentum score.
+
+Those variables may be displayed as diagnostics or used by their own engines, but they do not mathematically lift a ticker above another ticker in a pure Expected Return ordering.
+
+## Economic Proof = survival gate, not return bonus
+
+For EXPECTED RETURN candidates:
+
+- **5/5 PASS** → eligible;
+- **4/5 PASS** → eligible only if the sole FAIL is non-material and does not invalidate the thesis;
+- **3/5 or lower** → excluded from the confirmed Expected Return ranking;
+- **material FAIL at 4/5** → excluded;
+- **Falsifiers Ω** → absolute veto.
+
+This preserves the user's canonical Economic Proof approval rule while preventing quality from overpowering the requested return objective.
+
+A 4/5 company with 35% evidence-backed expected CAGR ranks above a 5/5 company with 20% expected CAGR, provided neither has a material falsifier.
+
+## HISTORICAL RETURN ranking rule
+
+Historical Return is ordered by the verified total market return for the requested window.
+
+Business quality, Economic Proof, moat and expected future return do not alter that historical ordering.
+
+A separate warning may state that a historical winner is expensive, low quality or unlikely to repeat, but ATLAS may not rewrite the historical leaderboard because of that warning.
+
+## BUSINESS QUALITY ranking rule
+
+Business Quality remains a separate surface for:
+
+- Economic Proof;
+- FCF conversion;
+- incremental ROIC;
+- moat;
+- durability;
+- balance-sheet quality;
+- structural growth quality.
+
+**BEST COMPANY ≠ HIGHEST EXPECTED RETURN.**
+
+## COMPOSITE OPPORTUNITY rule
+
+`SIZE_NEUTRAL_RETURN_RANKING_OMEGA_V1` remains useful as a broad opportunity composite, but its 10-block 0–1000 result is now explicitly classified as **COMPOSITE OPPORTUNITY**, not a pure-return ranking.
+
+It may answer questions such as:
+
+- `mejores oportunidades`;
+- `ranking ATLAS completo`;
+- `mejor combinación de calidad, retorno, flujo y riesgo`.
+
+It may **not** be presented as the answer to a pure `por retorno` request.
+
+## Required output labeling
+
+Any ranked table must expose its objective in the heading or metadata:
+
+- `HISTORICAL RETURN — <window>`;
+- `EXPECTED RETURN — <horizon>`;
+- `BUSINESS QUALITY`;
+- `COMPOSITE OPPORTUNITY`.
+
+If more than one surface is shown, each column/rank must retain its own label.
+
+## Intent examples
+
+- `Tickers europeos con más retorno` → **EXPECTED RETURN**.
+- `Tickers europeos que más han subido en 2026` → **HISTORICAL RETURN**.
+- `Cuáles son las mejores empresas europeas` → **BUSINESS QUALITY** unless the rest of the request specifies another objective.
+- `Mejores oportunidades europeas ATLAS` → **COMPOSITE OPPORTUNITY**.
+
+## Anti-contamination invariant
+
+**RETURN REQUEST → RETURN METRIC.**  
+**QUALITY = FILTER / SEPARATE DIAGNOSTIC, NOT RETURN BONUS.**  
+**HISTORICAL ≠ FORWARD.**  
+**COMPOSITE ≠ PURE RETURN.**  
+**FALSIFIERS Ω REMAINS ABSOLUTE.**

--- a/src/atlas/algorithm/return-objective-separation-omega.test.ts
+++ b/src/atlas/algorithm/return-objective-separation-omega.test.ts
@@ -1,0 +1,165 @@
+import {
+  evaluateReturnObjective,
+  rankByReturnObjective,
+  resolveReturnRankingObjective,
+  type ReturnObjectiveInput,
+} from './return-objective-separation-omega';
+
+const base: Omit<ReturnObjectiveInput, 'ticker' | 'objective'> = {
+  evidenceTraceable: true,
+  evidenceIds: ['filing-q2', 'valuation-model'],
+};
+
+describe('Return Objective Separation Omega', () => {
+  it('routes generic max-return language to forward EXPECTED_RETURN', () => {
+    expect(resolveReturnRankingObjective('Tickers europeos con más retorno')).toBe('EXPECTED_RETURN');
+    expect(resolveReturnRankingObjective('ordena por retorno')).toBe('EXPECTED_RETURN');
+    expect(resolveReturnRankingObjective('máximo retorno futuro')).toBe('EXPECTED_RETURN');
+  });
+
+  it('routes explicitly backward-looking requests to HISTORICAL_RETURN', () => {
+    expect(resolveReturnRankingObjective('mejores por rentabilidad 2026 YTD')).toBe('HISTORICAL_RETURN');
+    expect(resolveReturnRankingObjective('qué acciones han subido más este último año')).toBe('HISTORICAL_RETURN');
+  });
+
+  it('keeps business quality on a separate ranking surface', () => {
+    expect(resolveReturnRankingObjective('cuál es la mejor empresa por calidad del negocio')).toBe('BUSINESS_QUALITY');
+  });
+
+  it('ranks EXPECTED_RETURN by expected CAGR, not by company quality', () => {
+    const highReturnLowerQuality = evaluateReturnObjective({
+      ...base,
+      ticker: 'HIGH_RETURN',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [
+        { probability: 0.25, totalReturnPct: -20 },
+        { probability: 0.5, totalReturnPct: 120 },
+        { probability: 0.25, totalReturnPct: 260 },
+      ],
+      businessQualityScore: 70,
+      economicProofPassCount: 4,
+      economicProofMaterialFail: false,
+    });
+
+    const lowerReturnBestQuality = evaluateReturnObjective({
+      ...base,
+      ticker: 'LOWER_RETURN',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [
+        { probability: 0.25, totalReturnPct: -5 },
+        { probability: 0.5, totalReturnPct: 55 },
+        { probability: 0.25, totalReturnPct: 100 },
+      ],
+      businessQualityScore: 100,
+      economicProofPassCount: 5,
+      economicProofMaterialFail: false,
+    });
+
+    const ranked = rankByReturnObjective([lowerReturnBestQuality, highReturnLowerQuality]);
+    expect(ranked.map((item) => item.ticker)).toEqual(['HIGH_RETURN', 'LOWER_RETURN']);
+    expect(highReturnLowerQuality.qualityWasUsedAsReturnBonus).toBe(false);
+    expect(lowerReturnBestQuality.qualityWasUsedAsReturnBonus).toBe(false);
+  });
+
+  it('uses Economic Proof as a survival gate: 5/5 passes and non-material 4/5 passes', () => {
+    const pass5 = evaluateReturnObjective({
+      ...base,
+      ticker: 'PASS5',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 100 }],
+      economicProofPassCount: 5,
+    });
+
+    const pass4 = evaluateReturnObjective({
+      ...base,
+      ticker: 'PASS4',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 120 }],
+      economicProofPassCount: 4,
+      economicProofMaterialFail: false,
+    });
+
+    expect(pass5.verdict).toBe('RANK_ELIGIBLE');
+    expect(pass5.economicProofGate).toBe('PASS_5_OF_5');
+    expect(pass4.verdict).toBe('RANK_ELIGIBLE');
+    expect(pass4.economicProofGate).toBe('PASS_4_OF_5');
+  });
+
+  it('rejects <=3/5 or a material 4/5 fail from the expected-return ranking', () => {
+    const fail3 = evaluateReturnObjective({
+      ...base,
+      ticker: 'FAIL3',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 200 }],
+      economicProofPassCount: 3,
+    });
+
+    const fail4Material = evaluateReturnObjective({
+      ...base,
+      ticker: 'FAIL4',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 220 }],
+      economicProofPassCount: 4,
+      economicProofMaterialFail: true,
+    });
+
+    expect(fail3.verdict).toBe('ECONOMIC_PROOF_REJECT');
+    expect(fail4Material.verdict).toBe('ECONOMIC_PROOF_REJECT');
+    expect(rankByReturnObjective([fail3, fail4Material])).toEqual([]);
+  });
+
+  it('ranks HISTORICAL_RETURN only by the verified past-window return', () => {
+    const a = evaluateReturnObjective({
+      ...base,
+      ticker: 'A',
+      objective: 'HISTORICAL_RETURN',
+      historicalTotalReturnPct: 80,
+      businessQualityScore: 20,
+    });
+    const b = evaluateReturnObjective({
+      ...base,
+      ticker: 'B',
+      objective: 'HISTORICAL_RETURN',
+      historicalTotalReturnPct: 30,
+      businessQualityScore: 100,
+    });
+
+    expect(rankByReturnObjective([b, a]).map((item) => item.ticker)).toEqual(['A', 'B']);
+  });
+
+  it('marks composite opportunity as non-pure-return output', () => {
+    const result = evaluateReturnObjective({
+      ...base,
+      ticker: 'COMPOSITE',
+      objective: 'COMPOSITE_OPPORTUNITY',
+      compositeOpportunityScore: 950,
+    });
+
+    expect(result.rankingMetric).toBe(95);
+    expect(result.compositeMayAnswerPureReturnQuery).toBe(false);
+    expect(result.reasons.join(' ')).toContain('not a pure-return ranking');
+  });
+
+  it('keeps Falsifiers Omega as an absolute veto', () => {
+    const result = evaluateReturnObjective({
+      ...base,
+      ticker: 'VETO',
+      objective: 'EXPECTED_RETURN',
+      expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 300 }],
+      economicProofPassCount: 5,
+      falsifierVeto: true,
+      falsifierReasons: ['structural accounting falsifier'],
+    });
+
+    expect(result.rankingMetric).not.toBeNull();
+    expect(result.verdict).toBe('FALSIFIER_VETO');
+    expect(result.eligibleForRanking).toBe(false);
+  });
+});

--- a/src/atlas/algorithm/return-objective-separation-omega.test.ts
+++ b/src/atlas/algorithm/return-objective-separation-omega.test.ts
@@ -138,7 +138,7 @@ describe('Return Objective Separation Omega', () => {
       ...base,
       ticker: 'COMPOSITE',
       objective: 'COMPOSITE_OPPORTUNITY',
-      compositeOpportunityScore: 950,
+      compositeOpportunityScore: 95,
     });
 
     expect(result.rankingMetric).toBe(95);

--- a/src/atlas/algorithm/return-objective-separation-omega.ts
+++ b/src/atlas/algorithm/return-objective-separation-omega.ts
@@ -1,0 +1,266 @@
+export type ReturnRankingObjective =
+  | 'HISTORICAL_RETURN'
+  | 'EXPECTED_RETURN'
+  | 'BUSINESS_QUALITY'
+  | 'COMPOSITE_OPPORTUNITY';
+
+export type ReturnObjectiveVerdict =
+  | 'RANK_ELIGIBLE'
+  | 'EVIDENCE_PENDING'
+  | 'ECONOMIC_PROOF_REJECT'
+  | 'FALSIFIER_VETO';
+
+export interface ExpectedReturnScenario {
+  /** Probability weight. Any positive scale is accepted and normalized. */
+  probability: number;
+  /** Total equity return over the full horizon, in percentage points. */
+  totalReturnPct: number;
+  label?: string;
+}
+
+export interface ReturnObjectiveInput {
+  ticker: string;
+  objective: ReturnRankingObjective;
+  evidenceTraceable: boolean;
+  evidenceIds: string[];
+
+  /** Historical total return for the requested past window. */
+  historicalTotalReturnPct?: number;
+
+  /** Expected-return scenarios over one common horizon. */
+  expectedHorizonYears?: number;
+  expectedScenarios?: ExpectedReturnScenario[];
+
+  /** Diagnostics only unless objective === BUSINESS_QUALITY. */
+  businessQualityScore?: number;
+
+  /** Existing composite opportunity score. Never allowed to answer a pure-return request. */
+  compositeOpportunityScore?: number;
+
+  /**
+   * Economic Proof is a survival gate for EXPECTED_RETURN, not an additive ranking bonus.
+   * Canon: 5/5 passes; 4/5 passes only when the sole fail is non-material; <=3/5 fails.
+   */
+  economicProofPassCount?: number;
+  economicProofMaterialFail?: boolean;
+
+  falsifierVeto?: boolean;
+  falsifierReasons?: string[];
+}
+
+export interface ReturnObjectiveResult {
+  ticker: string;
+  objective: ReturnRankingObjective;
+  verdict: ReturnObjectiveVerdict;
+  eligibleForRanking: boolean;
+  rankingMetric: number | null;
+  rankingMetricLabel: string;
+  historicalTotalReturnPct?: number;
+  probabilityWeightedTotalReturnPct?: number;
+  expectedReturnCagrPct?: number;
+  businessQualityScore?: number;
+  compositeOpportunityScore?: number;
+  economicProofGate: 'NOT_APPLICABLE' | 'PASS_5_OF_5' | 'PASS_4_OF_5' | 'FAIL';
+  qualityWasUsedAsReturnBonus: false;
+  compositeMayAnswerPureReturnQuery: false;
+  reasons: string[];
+}
+
+function finiteOrNull(value: number | undefined): number | null {
+  return value != null && Number.isFinite(value) ? value : null;
+}
+
+function clamp100(value: number | undefined): number | undefined {
+  if (value == null || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.min(100, value));
+}
+
+function annualizeTotalReturn(totalReturnPct: number, years: number): number | null {
+  if (!Number.isFinite(totalReturnPct) || !Number.isFinite(years) || years <= 0) return null;
+  const terminalMultiple = 1 + totalReturnPct / 100;
+  if (terminalMultiple <= 0) return -100;
+  return (Math.pow(terminalMultiple, 1 / years) - 1) * 100;
+}
+
+function expectedReturnFromScenarios(
+  scenarios: ExpectedReturnScenario[] | undefined,
+  years: number | undefined,
+): { weightedTotalReturnPct: number; cagrPct: number } | null {
+  if (!scenarios?.length || years == null || !Number.isFinite(years) || years <= 0) return null;
+
+  const valid = scenarios.filter(
+    (scenario) =>
+      Number.isFinite(scenario.probability) &&
+      scenario.probability > 0 &&
+      Number.isFinite(scenario.totalReturnPct),
+  );
+  if (!valid.length) return null;
+
+  const probabilitySum = valid.reduce((sum, scenario) => sum + scenario.probability, 0);
+  if (!(probabilitySum > 0)) return null;
+
+  const expectedTerminalMultiple = valid.reduce(
+    (sum, scenario) =>
+      sum + (scenario.probability / probabilitySum) * (1 + scenario.totalReturnPct / 100),
+    0,
+  );
+
+  const weightedTotalReturnPct = (expectedTerminalMultiple - 1) * 100;
+  const cagrPct = annualizeTotalReturn(weightedTotalReturnPct, years);
+  if (cagrPct == null) return null;
+
+  return { weightedTotalReturnPct, cagrPct };
+}
+
+function evaluateEconomicProofGate(input: ReturnObjectiveInput): ReturnObjectiveResult['economicProofGate'] {
+  if (input.objective !== 'EXPECTED_RETURN') return 'NOT_APPLICABLE';
+
+  const passes = input.economicProofPassCount;
+  if (passes === 5) return 'PASS_5_OF_5';
+  if (passes === 4 && input.economicProofMaterialFail !== true) return 'PASS_4_OF_5';
+  return 'FAIL';
+}
+
+/**
+ * Intent resolver used before any ranking engine runs.
+ * Generic "more/max return" means forward expected return unless the request explicitly
+ * anchors the metric to a past period (YTD, 2026 performance, 1Y return, etc.).
+ */
+export function resolveReturnRankingObjective(intent: string): ReturnRankingObjective {
+  const normalized = intent.trim().toLowerCase();
+
+  const historicalMarkers = [
+    'ytd',
+    'rentabilidad 2026',
+    'retorno 2026',
+    'performance 2026',
+    'ha subido',
+    'han subido',
+    'último año',
+    'ultimo año',
+    '1 año',
+    '1a',
+    'pasado',
+    'histórico',
+    'historico',
+  ];
+  if (historicalMarkers.some((marker) => normalized.includes(marker))) return 'HISTORICAL_RETURN';
+
+  const qualityMarkers = [
+    'mejor empresa',
+    'más calidad',
+    'mas calidad',
+    'business quality',
+    'calidad del negocio',
+  ];
+  if (qualityMarkers.some((marker) => normalized.includes(marker))) return 'BUSINESS_QUALITY';
+
+  const returnMarkers = [
+    'más retorno',
+    'mas retorno',
+    'máximo retorno',
+    'maximo retorno',
+    'por retorno',
+    'expected return',
+    'retorno esperado',
+    'retorno futuro',
+    'cagr',
+    'upside futuro',
+  ];
+  if (returnMarkers.some((marker) => normalized.includes(marker))) return 'EXPECTED_RETURN';
+
+  return 'COMPOSITE_OPPORTUNITY';
+}
+
+/**
+ * Return Objective Separation Ω
+ *
+ * Invariants:
+ * - HISTORICAL_RETURN ranks only by verified historical total return for the requested window.
+ * - EXPECTED_RETURN ranks only by evidence-backed forward expected CAGR.
+ * - Business Quality / Economic Proof may gate survival for EXPECTED_RETURN but add zero ranking points.
+ * - BUSINESS_QUALITY is its own ranking surface.
+ * - COMPOSITE_OPPORTUNITY is explicitly not a pure-return ranking and may never be presented as one.
+ * - Falsifiers Ω remains an absolute veto without rewriting the diagnostic ranking metric.
+ */
+export function evaluateReturnObjective(input: ReturnObjectiveInput): ReturnObjectiveResult {
+  const reasons: string[] = [];
+  const economicProofGate = evaluateEconomicProofGate(input);
+  const evidenceOk = input.evidenceTraceable && input.evidenceIds.length >= 2;
+  const falsifierVeto = input.falsifierVeto === true;
+
+  let rankingMetric: number | null = null;
+  let rankingMetricLabel = '';
+  let probabilityWeightedTotalReturnPct: number | undefined;
+  let expectedReturnCagrPct: number | undefined;
+
+  const historicalTotalReturnPct = finiteOrNull(input.historicalTotalReturnPct);
+  const businessQualityScore = clamp100(input.businessQualityScore);
+  const compositeOpportunityScore = clamp100(input.compositeOpportunityScore);
+
+  if (input.objective === 'HISTORICAL_RETURN') {
+    rankingMetric = historicalTotalReturnPct;
+    rankingMetricLabel = 'verified historical total return %';
+    reasons.push('Historical-return ranking is ordered by the requested past-window return only.');
+  } else if (input.objective === 'EXPECTED_RETURN') {
+    const expected = expectedReturnFromScenarios(input.expectedScenarios, input.expectedHorizonYears);
+    if (expected) {
+      probabilityWeightedTotalReturnPct = expected.weightedTotalReturnPct;
+      expectedReturnCagrPct = expected.cagrPct;
+      rankingMetric = expected.cagrPct;
+    }
+    rankingMetricLabel = 'probability-weighted expected CAGR %';
+    reasons.push('Expected-return ranking is ordered by forward probability-weighted CAGR only.');
+    reasons.push('Business Quality and Economic Proof contribute zero ranking bonus; Economic Proof is a survival gate only.');
+  } else if (input.objective === 'BUSINESS_QUALITY') {
+    rankingMetric = businessQualityScore ?? null;
+    rankingMetricLabel = 'business quality score';
+    reasons.push('Business-quality ranking is independent from historical and expected return.');
+  } else {
+    rankingMetric = compositeOpportunityScore ?? null;
+    rankingMetricLabel = 'composite opportunity score';
+    reasons.push('Composite Opportunity combines multiple engines and is not a pure-return ranking.');
+  }
+
+  let verdict: ReturnObjectiveVerdict = 'RANK_ELIGIBLE';
+  if (falsifierVeto) {
+    verdict = 'FALSIFIER_VETO';
+  } else if (!evidenceOk || rankingMetric == null) {
+    verdict = 'EVIDENCE_PENDING';
+  } else if (input.objective === 'EXPECTED_RETURN' && economicProofGate === 'FAIL') {
+    verdict = 'ECONOMIC_PROOF_REJECT';
+  }
+
+  if (!evidenceOk) reasons.push('Traceable evidence gate is incomplete.');
+  if (input.objective === 'EXPECTED_RETURN' && economicProofGate === 'FAIL') {
+    reasons.push('Expected-return candidate fails the Economic Proof survival gate: requires 5/5 or non-material 4/5.');
+  }
+  if (falsifierVeto) {
+    reasons.push('Falsifiers Ω veto is absolute.');
+    for (const reason of input.falsifierReasons ?? []) reasons.push(`FALSIFIER: ${reason}`);
+  }
+
+  return {
+    ticker: input.ticker,
+    objective: input.objective,
+    verdict,
+    eligibleForRanking: verdict === 'RANK_ELIGIBLE',
+    rankingMetric,
+    rankingMetricLabel,
+    historicalTotalReturnPct: historicalTotalReturnPct ?? undefined,
+    probabilityWeightedTotalReturnPct,
+    expectedReturnCagrPct,
+    businessQualityScore,
+    compositeOpportunityScore,
+    economicProofGate,
+    qualityWasUsedAsReturnBonus: false,
+    compositeMayAnswerPureReturnQuery: false,
+    reasons,
+  };
+}
+
+export function rankByReturnObjective(results: ReturnObjectiveResult[]): ReturnObjectiveResult[] {
+  return [...results]
+    .filter((result) => result.eligibleForRanking && result.rankingMetric != null)
+    .sort((a, b) => (b.rankingMetric ?? -Infinity) - (a.rankingMetric ?? -Infinity));
+}

--- a/src/atlas/algorithm/return-objective-separation-omega.ts
+++ b/src/atlas/algorithm/return-objective-separation-omega.ts
@@ -13,7 +13,7 @@ export type ReturnObjectiveVerdict =
 export interface ExpectedReturnScenario {
   /** Probability weight. Any positive scale is accepted and normalized. */
   probability: number;
-  /** Total equity return over the full horizon, in percentage points. */
+  /** Total equity return over the full horizon, in percentage points. Minimum valid value is -100%. */
   totalReturnPct: number;
   label?: string;
 }
@@ -92,9 +92,10 @@ function expectedReturnFromScenarios(
     (scenario) =>
       Number.isFinite(scenario.probability) &&
       scenario.probability > 0 &&
-      Number.isFinite(scenario.totalReturnPct),
+      Number.isFinite(scenario.totalReturnPct) &&
+      scenario.totalReturnPct >= -100,
   );
-  if (!valid.length) return null;
+  if (!valid.length || valid.length !== scenarios.length) return null;
 
   const probabilitySum = valid.reduce((sum, scenario) => sum + scenario.probability, 0);
   if (!(probabilitySum > 0)) return null;
@@ -123,7 +124,7 @@ function evaluateEconomicProofGate(input: ReturnObjectiveInput): ReturnObjective
 
 /**
  * Intent resolver used before any ranking engine runs.
- * Generic "more/max return" means forward expected return unless the request explicitly
+ * Generic return/rentability language means forward expected return unless the request explicitly
  * anchors the metric to a past period (YTD, 2026 performance, 1Y return, etc.).
  */
 export function resolveReturnRankingObjective(intent: string): ReturnRankingObjective {
@@ -166,6 +167,8 @@ export function resolveReturnRankingObjective(intent: string): ReturnRankingObje
     'retorno futuro',
     'cagr',
     'upside futuro',
+    'retorno',
+    'rentabilidad',
   ];
   if (returnMarkers.some((marker) => normalized.includes(marker))) return 'EXPECTED_RETURN';
 


### PR DESCRIPTION
## What changes
- Adds `Return Objective Separation Ω` with four explicit ranking surfaces: Historical Return, Expected Return, Business Quality, Composite Opportunity.
- Routes generic `más retorno / por retorno / máximo retorno` intent to forward Expected Return unless a historical window is explicit.
- Orders pure Expected Return by probability-weighted forward CAGR only.
- Keeps Economic Proof as a survival gate (5/5 or non-material 4/5), never an additive return bonus.
- Adds tests proving a higher-return 4/5 candidate outranks a lower-return 5/5 candidate when both pass the gate.
- Canonizes the anti-contamination rule in `CURRENT_CANON/RETURN_OBJECTIVE_SEPARATION_OMEGA.md`.

## Why
The prior 0–1000 composite could let business quality, moat and Economic Proof dominate a request that was explicitly asking for return. This PR makes the requested objective binding.

## Invariants
- RETURN REQUEST → RETURN METRIC.
- QUALITY = FILTER / SEPARATE DIAGNOSTIC, NOT RETURN BONUS.
- HISTORICAL ≠ FORWARD.
- COMPOSITE ≠ PURE RETURN.
- FALSIFIERS Ω remains absolute.