### PR TITLE
Motor 13 Ω: enforce P0/P3 data-integrity reset

### DIFF
--- a/CURRENT_CANON/RETURN_OBJECTIVE_SEPARATION_OMEGA.md
+++ b/CURRENT_CANON/RETURN_OBJECTIVE_SEPARATION_OMEGA.md
@@ -9,49 +9,47 @@
 
 Prevent ATLAS Ω from answering a request for **return** with a ranking that is actually dominated by company quality, moat, Economic Proof, prestige or a multi-factor opportunity composite.
 
-The trigger for this amendment was a European-equity ranking in which ASML/ASMI rose to the top because quality and Economic Proof contaminated what the user had requested as a return ranking.
-
 ## Constitutional separation
 
-ATLAS now has four explicitly separate ranking objectives:
+ATLAS has four separate ranking objectives:
 
-1. **HISTORICAL RETURN** — what has already delivered the highest verified market return over a specified past window.
-2. **EXPECTED RETURN** — what offers the highest evidence-backed forward expected CAGR from the current price.
-3. **BUSINESS QUALITY** — what has the strongest business, moat, economics and durability.
-4. **COMPOSITE OPPORTUNITY** — a multi-engine opportunity view combining return, revisions, flows, momentum, specialist engines, risk and business evidence.
+1. **HISTORICAL RETURN** — verified past-window market return.
+2. **EXPECTED RETURN** — evidence-backed forward CAGR from the current entry price.
+3. **BUSINESS QUALITY** — business, moat, economics and durability.
+4. **COMPOSITE OPPORTUNITY** — multi-engine opportunity view.
 
-These outputs may be displayed side by side, but **must never be silently substituted for one another**.
+These outputs may be displayed side by side, but must never be silently substituted for one another.
 
 ## Pure-return law
 
-When the user asks for:
+Requests for `más retorno`, `máximo retorno`, `por retorno`, `retorno esperado`, `retorno futuro`, `Expected Return`, `CAGR`, `retorno` or `rentabilidad` route to **EXPECTED RETURN** unless explicitly anchored to a historical period.
 
-- `más retorno`;
-- `máximo retorno`;
-- `por retorno`;
-- `retorno esperado`;
-- `retorno futuro`;
-- `Expected Return`;
-- `CAGR`;
-
-ATLAS routes to **EXPECTED RETURN** unless the request explicitly anchors the metric to a historical period.
-
-When the user explicitly asks for YTD, a named past year, 1Y/3Y/5Y performance, `ha subido`, historical performance or another backward-looking window, ATLAS routes to **HISTORICAL RETURN**.
+Historical windows route to **HISTORICAL RETURN**.
 
 ## EXPECTED RETURN ranking rule
 
-The ordering variable is:
+The ordering variable is **probability-weighted forward CAGR from a verified current price**.
 
-**probability-weighted forward CAGR from current price.**
+Canonical terminal-value calculation:
 
-The calculation uses scenario total returns over a common horizon, converts them into an expected terminal value and annualizes that expected terminal value.
+`P̄_h = Σ(probability_i × P_terminal_i)`
+
+`Expected CAGR = (P̄_h / P0)^(1/h) - 1`
+
+For the standard three-scenario / three-year Motor 13 configuration:
+
+`P̄_3 = 0.20 × P_bear + 0.60 × P_base + 0.20 × P_bull`
+
+`Expected CAGR = (P̄_3 / P0)^(1/3) - 1`
+
+Scenario CAGRs must never be averaged directly. Expected terminal capital is computed first and only then geometrically annualized.
 
 ### What may affect ranking order
 
-- current price;
-- scenario terminal values / valuation outputs;
+- verified current price P0;
+- scenario terminal values;
 - scenario probabilities;
-- explicit dilution or per-share effects embedded in the valuation path;
+- explicit dilution/per-share effects;
 - horizon normalization.
 
 ### What may NOT add ranking points
@@ -68,78 +66,118 @@ The calculation uses scenario total returns over a common horizon, converts them
 - Money Rotation score;
 - momentum score.
 
-Those variables may be displayed as diagnostics or used by their own engines, but they do not mathematically lift a ticker above another ticker in a pure Expected Return ordering.
+## MOTOR 13 PRICE & TARGET INTEGRITY GATE Ω — 2026-08-21
+
+### Trigger
+
+A 21-Aug-2026 audit detected systemic temporal/scale contamination in Expected Return inputs. Multiple matrices mixed stale historical prices, current prices, pre/post corporate-action scales and terminal targets built on incompatible price regimes. The mathematical CAGR engine remained valid, but the ranking output was invalid because its denominators and targets were not contemporaneously reconciled.
+
+### Hard-reset rule
+
+If P0 fails integrity, the following are invalidated together for that observation set:
+
+- P0;
+- inherited terminal targets;
+- inherited Expected CAGR;
+- inherited ranking position.
+
+**Do not repair a contaminated ranking by replacing P0 while retaining inherited P3 targets.** Both sides of the valuation ratio must be independently reconstructed and reconciled.
+
+### P0 integrity requirements
+
+Before a ticker may enter a canonical Expected Return ranking, P0 must carry:
+
+1. exact ticker and primary listing;
+2. currency and quotation unit (USD, CAD, EUR, CHF, GBp, etc.);
+3. exact observation date;
+4. observation type: official close or intraday snapshot;
+5. timestamp when intraday;
+6. source/evidence identifier;
+7. corporate-action normalization status, including stock splits where relevant.
+
+An intraday observation may never be labelled as an official close. If the requested session has not closed, either use a timestamped intraday P0 or the latest completed official close and label it explicitly.
+
+### Terminal-target integrity requirements
+
+Bear/Base/Bull terminal values must be rebuilt from contemporaneous fundamentals and must use the same per-share scale and currency as P0. At minimum the valuation trace must expose the material drivers used: EPS/FCF or operating cash-flow bridge, diluted share count/dilution assumptions, net debt/cash, sanctioned production/capacity and the terminal multiple or valuation method.
+
+Unsanctioned growth projects do not enter the base case merely because they exist in the pipeline. They require explicit probability treatment or a bull/upside scenario until sanctioned.
+
+### Corporate-action gate
+
+Any split, reverse split, spin-off, merger, ticker migration or other material corporate action between the source period and P0 requires explicit normalization before ranking. A target on a pre-action share scale cannot be compared with a post-action P0.
+
+### Fail-closed behavior
+
+If any required P0 or terminal-target integrity field is missing, stale, contradictory or unreconciled:
+
+`EXPECTED RETURN → EVIDENCE_PENDING / INVALIDATED`
+
+The ticker must not receive a canonical rank. No placeholder target, inherited target or guessed scale is permitted to fill the gap.
+
+### Reset propagation invariant
+
+`P0 FAIL → P0 DELETE + P3 DELETE + CAGR DELETE + RANK DELETE`
+
+A ranking may be regenerated only after:
+
+`VERIFIED P0 → CONTEMPORARY FUNDAMENTALS → BEAR/BASE/BULL P3 → EXPECTED TERMINAL VALUE → CAGR → FALSIFIER GATE → RANK`
+
+### Epistemic labels
+
+Outputs derived only from supplied but unverified inputs must be labelled:
+
+`INPUTS PROVIDED / NOT INDEPENDENTLY VERIFIED`
+
+Only evidence-reconciled inputs may be labelled:
+
+`CANONICAL VERIFIED`
+
+Mathematical correctness alone never upgrades source integrity.
 
 ## Economic Proof = survival gate, not return bonus
 
 For EXPECTED RETURN candidates:
 
 - **5/5 PASS** → eligible;
-- **4/5 PASS** → eligible only if the sole FAIL is non-material and does not invalidate the thesis;
-- **3/5 or lower** → excluded from the confirmed Expected Return ranking;
+- **4/5 PASS** → eligible only if the sole FAIL is non-material;
+- **3/5 or lower** → excluded;
 - **material FAIL at 4/5** → excluded;
 - **Falsifiers Ω** → absolute veto.
 
-This preserves the user's canonical Economic Proof approval rule while preventing quality from overpowering the requested return objective.
-
-A 4/5 company with 35% evidence-backed expected CAGR ranks above a 5/5 company with 20% expected CAGR, provided neither has a material falsifier.
+A 4/5 company with a higher verified Expected CAGR ranks above a 5/5 company with a lower Expected CAGR if both survive the applicable gates.
 
 ## HISTORICAL RETURN ranking rule
 
-Historical Return is ordered by the verified total market return for the requested window.
-
-Business quality, Economic Proof, moat and expected future return do not alter that historical ordering.
-
-A separate warning may state that a historical winner is expensive, low quality or unlikely to repeat, but ATLAS may not rewrite the historical leaderboard because of that warning.
+Historical Return is ordered by verified total market return for the requested window. Business quality, Economic Proof, moat and forward return do not alter that ordering.
 
 ## BUSINESS QUALITY ranking rule
 
-Business Quality remains a separate surface for:
-
-- Economic Proof;
-- FCF conversion;
-- incremental ROIC;
-- moat;
-- durability;
-- balance-sheet quality;
-- structural growth quality.
+Business Quality remains a separate surface for Economic Proof, FCF conversion, incremental ROIC, moat, durability, balance-sheet quality and structural growth quality.
 
 **BEST COMPANY ≠ HIGHEST EXPECTED RETURN.**
 
 ## COMPOSITE OPPORTUNITY rule
 
-`SIZE_NEUTRAL_RETURN_RANKING_OMEGA_V1` remains useful as a broad opportunity composite, but its 10-block 0–1000 result is now explicitly classified as **COMPOSITE OPPORTUNITY**, not a pure-return ranking.
-
-It may answer questions such as:
-
-- `mejores oportunidades`;
-- `ranking ATLAS completo`;
-- `mejor combinación de calidad, retorno, flujo y riesgo`.
-
-It may **not** be presented as the answer to a pure `por retorno` request.
+Composite Opportunity may combine return, revisions, flows, momentum, specialist engines, risk and business evidence. It may never be presented as a pure-return ranking.
 
 ## Required output labeling
 
-Any ranked table must expose its objective in the heading or metadata:
+Any ranked table must expose its objective:
 
 - `HISTORICAL RETURN — <window>`;
 - `EXPECTED RETURN — <horizon>`;
 - `BUSINESS QUALITY`;
 - `COMPOSITE OPPORTUNITY`.
 
-If more than one surface is shown, each column/rank must retain its own label.
+For Expected Return, also expose the P0 observation date/type and verification state.
 
-## Intent examples
-
-- `Tickers europeos con más retorno` → **EXPECTED RETURN**.
-- `Tickers europeos que más han subido en 2026` → **HISTORICAL RETURN**.
-- `Cuáles son las mejores empresas europeas` → **BUSINESS QUALITY** unless the rest of the request specifies another objective.
-- `Mejores oportunidades europeas ATLAS` → **COMPOSITE OPPORTUNITY**.
-
-## Anti-contamination invariant
+## Anti-contamination invariants
 
 **RETURN REQUEST → RETURN METRIC.**  
 **QUALITY = FILTER / SEPARATE DIAGNOSTIC, NOT RETURN BONUS.**  
 **HISTORICAL ≠ FORWARD.**  
 **COMPOSITE ≠ PURE RETURN.**  
-**FALSIFIERS Ω REMAINS ABSOLUTE.**
+**FALSIFIERS Ω REMAINS ABSOLUTE.**  
+**MATH PASS ≠ DATA PASS.**  
+**STALE P0 OR P3 → NO CANONICAL RANK.**

--- a/src/atlas/algorithm/return-objective-separation-omega.test.ts
+++ b/src/atlas/algorithm/return-objective-separation-omega.test.ts
@@ -1,164 +1,86 @@
-import {
-  evaluateReturnObjective,
-  rankByReturnObjective,
-  resolveReturnRankingObjective,
-  type ReturnObjectiveInput,
-} from './return-objective-separation-omega';
+import { evaluateReturnObjective, rankByReturnObjective, resolveReturnRankingObjective, type ReturnObjectiveInput } from './return-objective-separation-omega';
+
+const integrity = {
+  currentPrice: 100,
+  currency: 'USD',
+  primaryListing: 'NASDAQ',
+  observationDate: '2026-08-21',
+  observationType: 'OFFICIAL_CLOSE' as const,
+  priceEvidenceId: 'official-price',
+  corporateActionsReconciled: true,
+  terminalTargetsRebuiltFromCurrentFundamentals: true,
+  terminalTargetsSameCurrencyAndShareScale: true,
+};
 
 const base: Omit<ReturnObjectiveInput, 'ticker' | 'objective'> = {
   evidenceTraceable: true,
   evidenceIds: ['filing-q2', 'valuation-model'],
+  expectedReturnIntegrity: integrity,
 };
 
 describe('Return Objective Separation Omega', () => {
   it('routes generic max-return language to forward EXPECTED_RETURN', () => {
     expect(resolveReturnRankingObjective('Tickers europeos con más retorno')).toBe('EXPECTED_RETURN');
     expect(resolveReturnRankingObjective('ordena por retorno')).toBe('EXPECTED_RETURN');
-    expect(resolveReturnRankingObjective('máximo retorno futuro')).toBe('EXPECTED_RETURN');
   });
 
   it('routes explicitly backward-looking requests to HISTORICAL_RETURN', () => {
     expect(resolveReturnRankingObjective('mejores por rentabilidad 2026 YTD')).toBe('HISTORICAL_RETURN');
-    expect(resolveReturnRankingObjective('qué acciones han subido más este último año')).toBe('HISTORICAL_RETURN');
   });
 
-  it('keeps business quality on a separate ranking surface', () => {
-    expect(resolveReturnRankingObjective('cuál es la mejor empresa por calidad del negocio')).toBe('BUSINESS_QUALITY');
+  it('ranks EXPECTED_RETURN by expected terminal capital CAGR, not company quality', () => {
+    const high = evaluateReturnObjective({ ...base, ticker: 'HIGH', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: .2, totalReturnPct: -20 }, { probability: .6, totalReturnPct: 120 }, { probability: .2, totalReturnPct: 260 }],
+      businessQualityScore: 70, economicProofPassCount: 4, economicProofMaterialFail: false });
+    const low = evaluateReturnObjective({ ...base, ticker: 'LOW', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: .2, totalReturnPct: -5 }, { probability: .6, totalReturnPct: 55 }, { probability: .2, totalReturnPct: 100 }],
+      businessQualityScore: 100, economicProofPassCount: 5 });
+    expect(rankByReturnObjective([low, high]).map(x => x.ticker)).toEqual(['HIGH', 'LOW']);
   });
 
-  it('ranks EXPECTED_RETURN by expected CAGR, not by company quality', () => {
-    const highReturnLowerQuality = evaluateReturnObjective({
-      ...base,
-      ticker: 'HIGH_RETURN',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [
-        { probability: 0.25, totalReturnPct: -20 },
-        { probability: 0.5, totalReturnPct: 120 },
-        { probability: 0.25, totalReturnPct: 260 },
-      ],
-      businessQualityScore: 70,
-      economicProofPassCount: 4,
-      economicProofMaterialFail: false,
+  it('fails closed when P0/P3 integrity metadata is missing', () => {
+    const result = evaluateReturnObjective({
+      ticker: 'STALE', objective: 'EXPECTED_RETURN', evidenceTraceable: true, evidenceIds: ['price', 'model'],
+      expectedHorizonYears: 3, expectedScenarios: [{ probability: 1, totalReturnPct: 100 }], economicProofPassCount: 5,
     });
-
-    const lowerReturnBestQuality = evaluateReturnObjective({
-      ...base,
-      ticker: 'LOWER_RETURN',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [
-        { probability: 0.25, totalReturnPct: -5 },
-        { probability: 0.5, totalReturnPct: 55 },
-        { probability: 0.25, totalReturnPct: 100 },
-      ],
-      businessQualityScore: 100,
-      economicProofPassCount: 5,
-      economicProofMaterialFail: false,
-    });
-
-    const ranked = rankByReturnObjective([lowerReturnBestQuality, highReturnLowerQuality]);
-    expect(ranked.map((item) => item.ticker)).toEqual(['HIGH_RETURN', 'LOWER_RETURN']);
-    expect(highReturnLowerQuality.qualityWasUsedAsReturnBonus).toBe(false);
-    expect(lowerReturnBestQuality.qualityWasUsedAsReturnBonus).toBe(false);
+    expect(result.verdict).toBe('DATA_INTEGRITY_REJECT');
+    expect(result.rankingMetric).toBeNull();
+    expect(result.eligibleForRanking).toBe(false);
   });
 
-  it('uses Economic Proof as a survival gate: 5/5 passes and non-material 4/5 passes', () => {
-    const pass5 = evaluateReturnObjective({
-      ...base,
-      ticker: 'PASS5',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [{ probability: 1, totalReturnPct: 100 }],
-      economicProofPassCount: 5,
-    });
+  it('rejects inherited terminal targets after a P0 reset', () => {
+    const result = evaluateReturnObjective({ ...base, ticker: 'OLD_TARGET', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 50 }], economicProofPassCount: 5,
+      expectedReturnIntegrity: { ...integrity, terminalTargetsRebuiltFromCurrentFundamentals: false } });
+    expect(result.verdict).toBe('DATA_INTEGRITY_REJECT');
+  });
 
-    const pass4 = evaluateReturnObjective({
-      ...base,
-      ticker: 'PASS4',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [{ probability: 1, totalReturnPct: 120 }],
-      economicProofPassCount: 4,
-      economicProofMaterialFail: false,
-    });
+  it('requires a timestamp for intraday P0 and never silently treats it as a close', () => {
+    const result = evaluateReturnObjective({ ...base, ticker: 'INTRADAY', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 50 }], economicProofPassCount: 5,
+      expectedReturnIntegrity: { ...integrity, observationType: 'INTRADAY_SNAPSHOT', observationTimestamp: undefined } });
+    expect(result.verdict).toBe('DATA_INTEGRITY_REJECT');
+  });
 
-    expect(pass5.verdict).toBe('RANK_ELIGIBLE');
-    expect(pass5.economicProofGate).toBe('PASS_5_OF_5');
+  it('requires corporate-action reconciliation', () => {
+    const result = evaluateReturnObjective({ ...base, ticker: 'SPLIT', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 50 }], economicProofPassCount: 5,
+      expectedReturnIntegrity: { ...integrity, corporateActionsReconciled: false } });
+    expect(result.verdict).toBe('DATA_INTEGRITY_REJECT');
+  });
+
+  it('uses Economic Proof only as survival gate', () => {
+    const pass4 = evaluateReturnObjective({ ...base, ticker: 'PASS4', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 120 }], economicProofPassCount: 4, economicProofMaterialFail: false });
+    const fail3 = evaluateReturnObjective({ ...base, ticker: 'FAIL3', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 220 }], economicProofPassCount: 3 });
     expect(pass4.verdict).toBe('RANK_ELIGIBLE');
-    expect(pass4.economicProofGate).toBe('PASS_4_OF_5');
-  });
-
-  it('rejects <=3/5 or a material 4/5 fail from the expected-return ranking', () => {
-    const fail3 = evaluateReturnObjective({
-      ...base,
-      ticker: 'FAIL3',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [{ probability: 1, totalReturnPct: 200 }],
-      economicProofPassCount: 3,
-    });
-
-    const fail4Material = evaluateReturnObjective({
-      ...base,
-      ticker: 'FAIL4',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [{ probability: 1, totalReturnPct: 220 }],
-      economicProofPassCount: 4,
-      economicProofMaterialFail: true,
-    });
-
     expect(fail3.verdict).toBe('ECONOMIC_PROOF_REJECT');
-    expect(fail4Material.verdict).toBe('ECONOMIC_PROOF_REJECT');
-    expect(rankByReturnObjective([fail3, fail4Material])).toEqual([]);
   });
 
-  it('ranks HISTORICAL_RETURN only by the verified past-window return', () => {
-    const a = evaluateReturnObjective({
-      ...base,
-      ticker: 'A',
-      objective: 'HISTORICAL_RETURN',
-      historicalTotalReturnPct: 80,
-      businessQualityScore: 20,
-    });
-    const b = evaluateReturnObjective({
-      ...base,
-      ticker: 'B',
-      objective: 'HISTORICAL_RETURN',
-      historicalTotalReturnPct: 30,
-      businessQualityScore: 100,
-    });
-
-    expect(rankByReturnObjective([b, a]).map((item) => item.ticker)).toEqual(['A', 'B']);
-  });
-
-  it('marks composite opportunity as non-pure-return output', () => {
-    const result = evaluateReturnObjective({
-      ...base,
-      ticker: 'COMPOSITE',
-      objective: 'COMPOSITE_OPPORTUNITY',
-      compositeOpportunityScore: 95,
-    });
-
-    expect(result.rankingMetric).toBe(95);
-    expect(result.compositeMayAnswerPureReturnQuery).toBe(false);
-    expect(result.reasons.join(' ')).toContain('not a pure-return ranking');
-  });
-
-  it('keeps Falsifiers Omega as an absolute veto', () => {
-    const result = evaluateReturnObjective({
-      ...base,
-      ticker: 'VETO',
-      objective: 'EXPECTED_RETURN',
-      expectedHorizonYears: 3,
-      expectedScenarios: [{ probability: 1, totalReturnPct: 300 }],
-      economicProofPassCount: 5,
-      falsifierVeto: true,
-      falsifierReasons: ['structural accounting falsifier'],
-    });
-
-    expect(result.rankingMetric).not.toBeNull();
+  it('keeps Falsifiers Omega as absolute veto', () => {
+    const result = evaluateReturnObjective({ ...base, ticker: 'VETO', objective: 'EXPECTED_RETURN', expectedHorizonYears: 3,
+      expectedScenarios: [{ probability: 1, totalReturnPct: 300 }], economicProofPassCount: 5, falsifierVeto: true });
     expect(result.verdict).toBe('FALSIFIER_VETO');
     expect(result.eligibleForRanking).toBe(false);
   });

--- a/src/atlas/algorithm/return-objective-separation-omega.ts
+++ b/src/atlas/algorithm/return-objective-separation-omega.ts
@@ -7,15 +7,29 @@ export type ReturnRankingObjective =
 export type ReturnObjectiveVerdict =
   | 'RANK_ELIGIBLE'
   | 'EVIDENCE_PENDING'
+  | 'DATA_INTEGRITY_REJECT'
   | 'ECONOMIC_PROOF_REJECT'
   | 'FALSIFIER_VETO';
 
 export interface ExpectedReturnScenario {
-  /** Probability weight. Any positive scale is accepted and normalized. */
   probability: number;
-  /** Total equity return over the full horizon, in percentage points. Minimum valid value is -100%. */
   totalReturnPct: number;
   label?: string;
+}
+
+export type PriceObservationType = 'OFFICIAL_CLOSE' | 'INTRADAY_SNAPSHOT';
+
+export interface ExpectedReturnIntegrity {
+  currentPrice: number;
+  currency: string;
+  primaryListing: string;
+  observationDate: string;
+  observationType: PriceObservationType;
+  observationTimestamp?: string;
+  priceEvidenceId: string;
+  corporateActionsReconciled: boolean;
+  terminalTargetsRebuiltFromCurrentFundamentals: boolean;
+  terminalTargetsSameCurrencyAndShareScale: boolean;
 }
 
 export interface ReturnObjectiveInput {
@@ -23,27 +37,14 @@ export interface ReturnObjectiveInput {
   objective: ReturnRankingObjective;
   evidenceTraceable: boolean;
   evidenceIds: string[];
-
-  /** Historical total return for the requested past window. */
   historicalTotalReturnPct?: number;
-
-  /** Expected-return scenarios over one common horizon. */
   expectedHorizonYears?: number;
   expectedScenarios?: ExpectedReturnScenario[];
-
-  /** Diagnostics only unless objective === BUSINESS_QUALITY. */
+  expectedReturnIntegrity?: ExpectedReturnIntegrity;
   businessQualityScore?: number;
-
-  /** Existing composite opportunity score. Never allowed to answer a pure-return request. */
   compositeOpportunityScore?: number;
-
-  /**
-   * Economic Proof is a survival gate for EXPECTED_RETURN, not an additive ranking bonus.
-   * Canon: 5/5 passes; 4/5 passes only when the sole fail is non-material; <=3/5 fails.
-   */
   economicProofPassCount?: number;
   economicProofMaterialFail?: boolean;
-
   falsifierVeto?: boolean;
   falsifierReasons?: string[];
 }
@@ -61,6 +62,7 @@ export interface ReturnObjectiveResult {
   businessQualityScore?: number;
   compositeOpportunityScore?: number;
   economicProofGate: 'NOT_APPLICABLE' | 'PASS_5_OF_5' | 'PASS_4_OF_5' | 'FAIL';
+  dataIntegrityGate: 'NOT_APPLICABLE' | 'PASS' | 'FAIL';
   qualityWasUsedAsReturnBonus: false;
   compositeMayAnswerPureReturnQuery: false;
   reasons: string[];
@@ -82,121 +84,58 @@ function annualizeTotalReturn(totalReturnPct: number, years: number): number | n
   return (Math.pow(terminalMultiple, 1 / years) - 1) * 100;
 }
 
-function expectedReturnFromScenarios(
-  scenarios: ExpectedReturnScenario[] | undefined,
-  years: number | undefined,
-): { weightedTotalReturnPct: number; cagrPct: number } | null {
+function expectedReturnFromScenarios(scenarios: ExpectedReturnScenario[] | undefined, years: number | undefined) {
   if (!scenarios?.length || years == null || !Number.isFinite(years) || years <= 0) return null;
-
-  const valid = scenarios.filter(
-    (scenario) =>
-      Number.isFinite(scenario.probability) &&
-      scenario.probability > 0 &&
-      Number.isFinite(scenario.totalReturnPct) &&
-      scenario.totalReturnPct >= -100,
-  );
+  const valid = scenarios.filter((s) => Number.isFinite(s.probability) && s.probability > 0 && Number.isFinite(s.totalReturnPct) && s.totalReturnPct >= -100);
   if (!valid.length || valid.length !== scenarios.length) return null;
-
-  const probabilitySum = valid.reduce((sum, scenario) => sum + scenario.probability, 0);
-  if (!(probabilitySum > 0)) return null;
-
-  const expectedTerminalMultiple = valid.reduce(
-    (sum, scenario) =>
-      sum + (scenario.probability / probabilitySum) * (1 + scenario.totalReturnPct / 100),
-    0,
-  );
-
+  const probabilitySum = valid.reduce((sum, s) => sum + s.probability, 0);
+  const expectedTerminalMultiple = valid.reduce((sum, s) => sum + (s.probability / probabilitySum) * (1 + s.totalReturnPct / 100), 0);
   const weightedTotalReturnPct = (expectedTerminalMultiple - 1) * 100;
   const cagrPct = annualizeTotalReturn(weightedTotalReturnPct, years);
-  if (cagrPct == null) return null;
-
-  return { weightedTotalReturnPct, cagrPct };
+  return cagrPct == null ? null : { weightedTotalReturnPct, cagrPct };
 }
 
 function evaluateEconomicProofGate(input: ReturnObjectiveInput): ReturnObjectiveResult['economicProofGate'] {
   if (input.objective !== 'EXPECTED_RETURN') return 'NOT_APPLICABLE';
-
-  const passes = input.economicProofPassCount;
-  if (passes === 5) return 'PASS_5_OF_5';
-  if (passes === 4 && input.economicProofMaterialFail !== true) return 'PASS_4_OF_5';
+  if (input.economicProofPassCount === 5) return 'PASS_5_OF_5';
+  if (input.economicProofPassCount === 4 && input.economicProofMaterialFail !== true) return 'PASS_4_OF_5';
   return 'FAIL';
 }
 
-/**
- * Intent resolver used before any ranking engine runs.
- * Generic return/rentability language means forward expected return unless the request explicitly
- * anchors the metric to a past period (YTD, 2026 performance, 1Y return, etc.).
- */
+function evaluateDataIntegrityGate(input: ReturnObjectiveInput): ReturnObjectiveResult['dataIntegrityGate'] {
+  if (input.objective !== 'EXPECTED_RETURN') return 'NOT_APPLICABLE';
+  const i = input.expectedReturnIntegrity;
+  if (!i) return 'FAIL';
+  if (!(Number.isFinite(i.currentPrice) && i.currentPrice > 0)) return 'FAIL';
+  if (!i.currency.trim() || !i.primaryListing.trim() || !i.observationDate.trim() || !i.priceEvidenceId.trim()) return 'FAIL';
+  if (i.observationType === 'INTRADAY_SNAPSHOT' && !i.observationTimestamp?.trim()) return 'FAIL';
+  if (!i.corporateActionsReconciled) return 'FAIL';
+  if (!i.terminalTargetsRebuiltFromCurrentFundamentals) return 'FAIL';
+  if (!i.terminalTargetsSameCurrencyAndShareScale) return 'FAIL';
+  return 'PASS';
+}
+
 export function resolveReturnRankingObjective(intent: string): ReturnRankingObjective {
   const normalized = intent.trim().toLowerCase();
-
-  const historicalMarkers = [
-    'ytd',
-    'rentabilidad 2026',
-    'retorno 2026',
-    'performance 2026',
-    'ha subido',
-    'han subido',
-    'último año',
-    'ultimo año',
-    '1 año',
-    '1a',
-    'pasado',
-    'histórico',
-    'historico',
-  ];
+  const historicalMarkers = ['ytd','rentabilidad 2026','retorno 2026','performance 2026','ha subido','han subido','último año','ultimo año','1 año','1a','pasado','histórico','historico'];
   if (historicalMarkers.some((marker) => normalized.includes(marker))) return 'HISTORICAL_RETURN';
-
-  const qualityMarkers = [
-    'mejor empresa',
-    'más calidad',
-    'mas calidad',
-    'business quality',
-    'calidad del negocio',
-  ];
+  const qualityMarkers = ['mejor empresa','más calidad','mas calidad','business quality','calidad del negocio'];
   if (qualityMarkers.some((marker) => normalized.includes(marker))) return 'BUSINESS_QUALITY';
-
-  const returnMarkers = [
-    'más retorno',
-    'mas retorno',
-    'máximo retorno',
-    'maximo retorno',
-    'por retorno',
-    'expected return',
-    'retorno esperado',
-    'retorno futuro',
-    'cagr',
-    'upside futuro',
-    'retorno',
-    'rentabilidad',
-  ];
+  const returnMarkers = ['más retorno','mas retorno','máximo retorno','maximo retorno','por retorno','expected return','retorno esperado','retorno futuro','cagr','upside futuro','retorno','rentabilidad'];
   if (returnMarkers.some((marker) => normalized.includes(marker))) return 'EXPECTED_RETURN';
-
   return 'COMPOSITE_OPPORTUNITY';
 }
 
-/**
- * Return Objective Separation Ω
- *
- * Invariants:
- * - HISTORICAL_RETURN ranks only by verified historical total return for the requested window.
- * - EXPECTED_RETURN ranks only by evidence-backed forward expected CAGR.
- * - Business Quality / Economic Proof may gate survival for EXPECTED_RETURN but add zero ranking points.
- * - BUSINESS_QUALITY is its own ranking surface.
- * - COMPOSITE_OPPORTUNITY is explicitly not a pure-return ranking and may never be presented as one.
- * - Falsifiers Ω remains an absolute veto without rewriting the diagnostic ranking metric.
- */
 export function evaluateReturnObjective(input: ReturnObjectiveInput): ReturnObjectiveResult {
   const reasons: string[] = [];
   const economicProofGate = evaluateEconomicProofGate(input);
+  const dataIntegrityGate = evaluateDataIntegrityGate(input);
   const evidenceOk = input.evidenceTraceable && input.evidenceIds.length >= 2;
   const falsifierVeto = input.falsifierVeto === true;
-
   let rankingMetric: number | null = null;
   let rankingMetricLabel = '';
   let probabilityWeightedTotalReturnPct: number | undefined;
   let expectedReturnCagrPct: number | undefined;
-
   const historicalTotalReturnPct = finiteOrNull(input.historicalTotalReturnPct);
   const businessQualityScore = clamp100(input.businessQualityScore);
   const compositeOpportunityScore = clamp100(input.compositeOpportunityScore);
@@ -204,66 +143,48 @@ export function evaluateReturnObjective(input: ReturnObjectiveInput): ReturnObje
   if (input.objective === 'HISTORICAL_RETURN') {
     rankingMetric = historicalTotalReturnPct;
     rankingMetricLabel = 'verified historical total return %';
-    reasons.push('Historical-return ranking is ordered by the requested past-window return only.');
   } else if (input.objective === 'EXPECTED_RETURN') {
     const expected = expectedReturnFromScenarios(input.expectedScenarios, input.expectedHorizonYears);
-    if (expected) {
+    if (expected && dataIntegrityGate === 'PASS') {
       probabilityWeightedTotalReturnPct = expected.weightedTotalReturnPct;
       expectedReturnCagrPct = expected.cagrPct;
       rankingMetric = expected.cagrPct;
     }
     rankingMetricLabel = 'probability-weighted expected CAGR %';
-    reasons.push('Expected-return ranking is ordered by forward probability-weighted CAGR only.');
+    reasons.push('Expected-return ranking requires verified P0 plus contemporaneously rebuilt terminal targets.');
     reasons.push('Business Quality and Economic Proof contribute zero ranking bonus; Economic Proof is a survival gate only.');
   } else if (input.objective === 'BUSINESS_QUALITY') {
     rankingMetric = businessQualityScore ?? null;
     rankingMetricLabel = 'business quality score';
-    reasons.push('Business-quality ranking is independent from historical and expected return.');
   } else {
     rankingMetric = compositeOpportunityScore ?? null;
     rankingMetricLabel = 'composite opportunity score';
-    reasons.push('Composite Opportunity combines multiple engines and is not a pure-return ranking.');
   }
 
   let verdict: ReturnObjectiveVerdict = 'RANK_ELIGIBLE';
-  if (falsifierVeto) {
-    verdict = 'FALSIFIER_VETO';
-  } else if (!evidenceOk || rankingMetric == null) {
-    verdict = 'EVIDENCE_PENDING';
-  } else if (input.objective === 'EXPECTED_RETURN' && economicProofGate === 'FAIL') {
-    verdict = 'ECONOMIC_PROOF_REJECT';
-  }
+  if (falsifierVeto) verdict = 'FALSIFIER_VETO';
+  else if (input.objective === 'EXPECTED_RETURN' && dataIntegrityGate === 'FAIL') verdict = 'DATA_INTEGRITY_REJECT';
+  else if (!evidenceOk || rankingMetric == null) verdict = 'EVIDENCE_PENDING';
+  else if (input.objective === 'EXPECTED_RETURN' && economicProofGate === 'FAIL') verdict = 'ECONOMIC_PROOF_REJECT';
 
   if (!evidenceOk) reasons.push('Traceable evidence gate is incomplete.');
-  if (input.objective === 'EXPECTED_RETURN' && economicProofGate === 'FAIL') {
-    reasons.push('Expected-return candidate fails the Economic Proof survival gate: requires 5/5 or non-material 4/5.');
-  }
+  if (input.objective === 'EXPECTED_RETURN' && dataIntegrityGate === 'FAIL') reasons.push('P0/P3 integrity gate failed: stale, missing, scale-incompatible or unreconciled inputs cannot receive a canonical rank.');
+  if (input.objective === 'EXPECTED_RETURN' && economicProofGate === 'FAIL') reasons.push('Expected-return candidate fails the Economic Proof survival gate.');
   if (falsifierVeto) {
     reasons.push('Falsifiers Ω veto is absolute.');
     for (const reason of input.falsifierReasons ?? []) reasons.push(`FALSIFIER: ${reason}`);
   }
 
   return {
-    ticker: input.ticker,
-    objective: input.objective,
-    verdict,
-    eligibleForRanking: verdict === 'RANK_ELIGIBLE',
-    rankingMetric,
-    rankingMetricLabel,
+    ticker: input.ticker, objective: input.objective, verdict,
+    eligibleForRanking: verdict === 'RANK_ELIGIBLE', rankingMetric, rankingMetricLabel,
     historicalTotalReturnPct: historicalTotalReturnPct ?? undefined,
-    probabilityWeightedTotalReturnPct,
-    expectedReturnCagrPct,
-    businessQualityScore,
-    compositeOpportunityScore,
-    economicProofGate,
-    qualityWasUsedAsReturnBonus: false,
-    compositeMayAnswerPureReturnQuery: false,
-    reasons,
+    probabilityWeightedTotalReturnPct, expectedReturnCagrPct, businessQualityScore, compositeOpportunityScore,
+    economicProofGate, dataIntegrityGate, qualityWasUsedAsReturnBonus: false,
+    compositeMayAnswerPureReturnQuery: false, reasons,
   };
 }
 
 export function rankByReturnObjective(results: ReturnObjectiveResult[]): ReturnObjectiveResult[] {
-  return [...results]
-    .filter((result) => result.eligibleForRanking && result.rankingMetric != null)
-    .sort((a, b) => (b.rankingMetric ?? -Infinity) - (a.rankingMetric ?? -Infinity));
+  return [...results].filter((r) => r.eligibleForRanking && r.rankingMetric != null).sort((a, b) => (b.rankingMetric ?? -Infinity) - (a.rankingMetric ?? -Infinity));
 }


### PR DESCRIPTION
Implements the 21-Aug-2026 Motor 13 hard-reset rule after detecting stale/scale-contaminated Expected Return inputs.

- Adds fail-closed P0/P3 integrity gate.
- Requires listing, currency, date, observation type, intraday timestamp, evidence ID and corporate-action reconciliation.
- Rejects inherited terminal targets after a P0 reset.
- Makes P0 FAIL propagate to P3/CAGR/rank invalidation.
- Documents canonical expected-terminal-value-before-CAGR calculation.
- Adds tests for stale inputs, intraday timestamps, corporate actions and target rebuilds.

Business Quality/Economic Proof remain separate; Economic Proof is survival gate only and Falsifiers remains absolute.