### PR TITLE
Implement Screener Ω + terminal UI across all mobile workspaces

### DIFF
--- a/.github/workflows/mobile-ci-eas-apk.yml
+++ b/.github/workflows/mobile-ci-eas-apk.yml
@@ -1,4 +1,4 @@
-# Rebuild marker: 2026-08-22 certified APK rebuild trigger
+# Rebuild marker: 2026-08-22 screener + terminal v3 certified rebuild
 name: ATLAS Ω Mobile v1 Clean Rebuild
 
 on:
@@ -17,6 +17,8 @@ on:
       - 'api/test_trading212_v2.py'
       - 'api/global_capex_chain_mobile.py'
       - 'api/test_global_capex_chain_mobile.py'
+      - 'api/screener.py'
+      - 'tests/test_screener.py'
       - 'api/app.py'
       - 'render.yaml'
       - '.github/workflows/mobile-ci-eas-apk.yml'
@@ -34,6 +36,8 @@ on:
       - 'api/test_trading212_v2.py'
       - 'api/global_capex_chain_mobile.py'
       - 'api/test_global_capex_chain_mobile.py'
+      - 'api/screener.py'
+      - 'tests/test_screener.py'
       - 'api/app.py'
       - 'render.yaml'
       - '.github/workflows/mobile-ci-eas-apk.yml'
@@ -51,7 +55,7 @@ env:
 
 jobs:
   api-unit:
-    name: Mobile backend + audit + Trading 212 + CAPEX + entrypoint tests
+    name: Mobile backend + audit + Trading 212 + CAPEX + screener + entrypoint tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -60,7 +64,7 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install -r api/requirements.txt
-      - run: PYTHONPATH=. pytest -q api/test_mobile_v2.py api/test_mobile_audit_omega.py api/test_trading212_v2.py api/test_global_capex_chain_mobile.py api/test_mobile_entrypoints.py
+      - run: PYTHONPATH=. pytest -q api/test_mobile_v2.py api/test_mobile_audit_omega.py api/test_trading212_v2.py api/test_global_capex_chain_mobile.py api/test_mobile_entrypoints.py tests/test_screener.py
 
   typecheck:
     name: Mobile TypeScript gate
@@ -74,22 +78,29 @@ jobs:
         with:
           node-version: '22.13.0'
       - run: npm install --include=dev --no-audit --no-fund
-      - name: Verify pinned Expo native ABI set
+      - name: Verify deterministic Expo native ABI set
         shell: bash
         run: |
           set -euo pipefail
           node <<'NODE'
           const expected = {
             expo: '57.0.11',
-            'expo-modules-core': '57.0.10',
+            'expo-modules-core': '57.0.12',
             'react-native': '0.86.2',
-            'react-native-reanimated': '4.5.1',
-            'react-native-worklets': '0.10.1',
           };
           for (const [pkg, want] of Object.entries(expected)) {
             const got = require(`./node_modules/${pkg}/package.json`).version;
             if (got !== want) throw new Error(`${pkg}: expected ${want}, got ${got}`);
             console.log(`${pkg}=${got}`);
+          }
+          for (const pkg of ['react-native-reanimated', 'react-native-worklets']) {
+            try {
+              require.resolve(`${pkg}/package.json`);
+              throw new Error(`${pkg}: must not be installed; ATLAS does not use it and it re-enables the incompatible WorkletJSCallInvoker native path`);
+            } catch (error) {
+              if (error && error.code === 'MODULE_NOT_FOUND') console.log(`${pkg}=ABSENT`);
+              else throw error;
+            }
           }
           NODE
       - run: npx tsc --noEmit
@@ -114,22 +125,29 @@ jobs:
           distribution: temurin
           java-version: '17'
       - run: npm install --include=dev --no-audit --no-fund
-      - name: Verify pinned Expo native ABI set
+      - name: Verify deterministic Expo native ABI set
         shell: bash
         run: |
           set -euo pipefail
           node <<'NODE'
           const expected = {
             expo: '57.0.11',
-            'expo-modules-core': '57.0.10',
+            'expo-modules-core': '57.0.12',
             'react-native': '0.86.2',
-            'react-native-reanimated': '4.5.1',
-            'react-native-worklets': '0.10.1',
           };
           for (const [pkg, want] of Object.entries(expected)) {
             const got = require(`./node_modules/${pkg}/package.json`).version;
             if (got !== want) throw new Error(`${pkg}: expected ${want}, got ${got}`);
             console.log(`${pkg}=${got}`);
+          }
+          for (const pkg of ['react-native-reanimated', 'react-native-worklets']) {
+            try {
+              require.resolve(`${pkg}/package.json`);
+              throw new Error(`${pkg}: must not be installed`);
+            } catch (error) {
+              if (error && error.code === 'MODULE_NOT_FOUND') console.log(`${pkg}=ABSENT`);
+              else throw error;
+            }
           }
           NODE
       - name: Generate Android project

--- a/CURRENT_CANON/SCREENER_TERMINAL_OMEGA.md
+++ b/CURRENT_CANON/SCREENER_TERMINAL_OMEGA.md
@@ -1,0 +1,97 @@
+# ATLAS Ω Screener Terminal
+
+Status: ACTIVE CANON CANDIDATE
+Version: v1.0
+Date: 2026-08-22
+
+## Objective
+
+Implement an Investing-style discovery workflow inside the ATLAS terminal without importing Investing.com as decision authority and without allowing a screener result to become an investment recommendation.
+
+The screener has two independent layers:
+
+1. **Screener Engine Ω** — universe, filters, sorting, missing-data behavior and provider provenance.
+2. **Screener Terminal UI Ω** — dense filter controls, presets, sortable results, expandable rows and direct routes to AUD / Security Hub.
+
+## Discovery chain
+
+Universe → provider observations → normalized fields → active filters → sortable survivors → AUD / Security Hub → Evidence Director → GREEN first → all applicable engines → contradictions → Falsifiers Ω → Investment Committee Ω.
+
+Hard law:
+
+`SCREENER PASS != BUY`
+
+`FILTER MATCH != ECONOMIC PROOF`
+
+`MISSING DATA != PASS`
+
+## Initial provider contract
+
+Technical history:
+- Stooq daily observations through the ATLAS backend.
+- Price, daily return, 200DMA, 1Y and 2Y are computed from observed history.
+
+Fundamentals:
+- Finnhub `stock/metric` through the ATLAS backend.
+- Market capitalization is normalized to USD billions.
+- P/E and beta are displayed only when supplied.
+- ROIC is accepted only from an explicit ROIC field. ROI must never be silently substituted for ROIC.
+
+If an active filter requires a field that is unavailable, that security cannot pass that filter and the UI exposes a DATA GATE.
+
+## Built-in filter family
+
+General / fundamentals:
+- Market Cap ≥ $10B / $50B.
+- P/E ≤ 25 / 40.
+- Beta ≤ 1.2.
+- ROIC ≥ 20% when exact ROIC exists.
+
+Technical / performance:
+- latest regular daily observation > 0.
+- price > 200DMA.
+- 1Y > 0.
+- 2Y > 0.
+
+Presets are convenience views only. They are not canonical investment models.
+
+## Interface contract
+
+The screener uses the same terminal language as every ATLAS route:
+- persistent ATLAS header;
+- GO command palette;
+- live index tape;
+- route context bar;
+- grouped functions menu;
+- mobile module strip;
+- bottom navigation;
+- square evidence panels;
+- monospace status codes;
+- explicit DATA GATE rather than placeholders.
+
+A result row exposes only discovery actions:
+- `AUD` → full audit;
+- `SEC` → Security Hub.
+
+No direct BUY/SELL/order button is allowed on the screener surface.
+
+## Full-app UI rule
+
+The Ainvest/OpenTerminalUI competitive lesson applies to the entire application, not just Cockpit.
+
+Every route — HOME, MKT, PORT, AUD, WL, RES, OPP, Ω, SCR, RSR, CAL, NEWS, ORD, RSK, SEC, T212 and SYS — inherits the same terminal chrome, grouped menus, command search, live tape, current-workspace context and cross-workspace quick navigation.
+
+A route may specialize its content, but it must not regress to an isolated consumer-app visual language.
+
+## External repository rule
+
+Public projects such as `Sagleft/goinvest` may be studied for API/filter mechanics under their licenses, but ATLAS does not depend on an unofficial Investing.com endpoint as a production source of truth. Provider adapters must remain replaceable and independently gated.
+
+## Release rule
+
+Screener Terminal Ω is not production-certified until:
+1. Python/API tests pass.
+2. TypeScript passes.
+3. Android release build passes.
+4. compiled APK passes backend/security contract checks.
+5. feature changes are merged to `main` and the mobile CI passes again on `main`.

--- a/api/app.py
+++ b/api/app.py
@@ -20,9 +20,11 @@ from api.main import app
 from api.market import router as market_router
 from api.mobile_audit_omega import router as mobile_audit_router
 from api.realizable_alpha import router as realizable_alpha_router
+from api.screener import router as screener_router
 
 app.include_router(execution_safety_router)
 app.include_router(market_router)
+app.include_router(screener_router)
 app.include_router(atlas_router)
 app.include_router(bottom_score_router)
 app.include_router(realizable_alpha_router)

--- a/api/screener.py
+++ b/api/screener.py
@@ -95,9 +95,7 @@ async def _finnhub_metrics(symbol: str) -> dict[str, Any]:
                 response = await client.get(f"{FINNHUB_BASE_URL}/stock/metric", params=params, headers=headers)
         except httpx.RequestError:
             return {}
-    if response.status_code == 429:
-        return {}
-    if response.status_code >= 400:
+    if response.status_code == 429 or response.status_code >= 400:
         return {}
     try:
         payload = response.json()
@@ -121,6 +119,7 @@ async def _build_row(symbol: str) -> dict[str, Any] | None:
     closes = [value for value in closes if value is not None]
     if not closes:
         return None
+
     current = closes[-1]
     previous = closes[-2] if len(closes) >= 2 else None
     day = None if previous in (None, 0) else (current / previous - 1.0) * 100.0
@@ -128,15 +127,16 @@ async def _build_row(symbol: str) -> dict[str, Any] | None:
     ret1y = _ret(closes, 252)
     ret2y = _ret(closes, 504)
 
-    market_cap = _first_number(metrics, "marketCapitalization", "marketCap", "marketCapitalizationTTM")
+    market_cap_m = _first_number(metrics, "marketCapitalization", "marketCap", "marketCapitalizationTTM")
+    market_cap_b = None if market_cap_m is None else market_cap_m / 1000.0
     pe = _first_number(metrics, "peTTM", "peNormalizedAnnual", "peBasicExclExtraTTM", "peExclExtraTTM")
     beta = _first_number(metrics, "beta")
-    roic = _first_number(metrics, "roicTTM", "roic", "roiTTM", "returnOnInvestmentTTM")
+    roic = _first_number(metrics, "roicTTM", "roic")
     if roic is not None and abs(roic) <= 1.5:
         roic *= 100.0
 
     meta = next((item for item in CATALOGUE if str(item.get("symbol", "")).upper() == symbol), None) or {}
-    fundamental_values = [market_cap, pe, beta, roic]
+    fundamental_values = [market_cap_b, pe, beta, roic]
     fundamental_coverage = sum(value is not None for value in fundamental_values) / len(fundamental_values)
     technical_values = [current, day, sma200, ret1y, ret2y]
     technical_coverage = sum(value is not None for value in technical_values) / len(technical_values)
@@ -151,7 +151,7 @@ async def _build_row(symbol: str) -> dict[str, Any] | None:
         "above200dma": None if sma200 is None else current > sma200,
         "ret1y": ret1y,
         "ret2y": ret2y,
-        "marketCap": market_cap,
+        "marketCap": market_cap_b,
         "pe": pe,
         "beta": beta,
         "roic": roic,
@@ -197,10 +197,10 @@ def _sort_value(row: dict[str, Any], key: SortKey) -> Any:
 @router.get("")
 async def screen(
     symbols: str | None = Query(default=None, max_length=800),
-    min_market_cap: float | None = Query(default=None, ge=0),
+    min_market_cap: float | None = Query(default=None, ge=0, description="USD billions"),
     max_pe: float | None = Query(default=None, ge=0),
     max_beta: float | None = Query(default=None, ge=-10, le=20),
-    min_roic: float | None = Query(default=None, ge=-1000, le=1000),
+    min_roic: float | None = Query(default=None, ge=-1000, le=1000, description="Percent; exact ROIC only"),
     positive_day: bool = Query(default=False),
     above_200dma: bool = Query(default=False),
     positive_1y: bool = Query(default=False),
@@ -232,11 +232,12 @@ async def screen(
     fundamental_gate_count = sum(1 for row in rows if row.get("fundamentalCoverage", 0) < 1)
     return {
         "engine": "ATLAS Screener Ω",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "universe": "CUSTOM" if symbols else "ATLAS_CORE_US",
         "scanned": len(universe),
         "returned": min(len(passed), limit),
         "fundamentalDataGates": fundamental_gate_count,
+        "units": {"marketCap": "USD billions", "roic": "percent", "returns": "percent"},
         "filters": {
             "minMarketCap": min_market_cap,
             "maxPE": max_pe,
@@ -251,6 +252,7 @@ async def screen(
         "items": passed[:limit],
         "guardrail": (
             "Screener results are discovery candidates only. Missing data never passes an active filter. "
+            "ROIC is never silently substituted with ROI. Market cap is normalized to USD billions. "
             "A screener result cannot emit BUY/SELL; every candidate must continue through Evidence Director, GREEN first, "
             "all applicable ATLAS engines, Falsifiers Ω and Investment Committee Ω."
         ),

--- a/api/screener.py
+++ b/api/screener.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any, Literal
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+from api.market import CATALOGUE, get_market_history
+
+router = APIRouter(prefix="/v1/screener", tags=["screener"])
+
+FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+FINNHUB_TOKEN = os.getenv("FINNHUB_TOKEN", "").strip()
+METRIC_CACHE_TTL_SECONDS = 900
+_METRIC_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_METRIC_SEMAPHORE = asyncio.Semaphore(5)
+
+SortKey = Literal["symbol", "day", "ret1y", "ret2y", "marketCap", "roic", "beta", "pe"]
+SortDirection = Literal["asc", "desc"]
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        return number if number == number else None
+    if isinstance(value, str):
+        try:
+            number = float(value.replace(",", ""))
+        except ValueError:
+            return None
+        return number if number == number else None
+    return None
+
+
+def _first_number(source: dict[str, Any], *keys: str) -> float | None:
+    normalized = {str(key).lower().replace("_", ""): value for key, value in source.items()}
+    for key in keys:
+        value = normalized.get(key.lower().replace("_", ""))
+        number = _number(value)
+        if number is not None:
+            return number
+    return None
+
+
+def _ret(closes: list[float], sessions: int) -> float | None:
+    if len(closes) <= sessions:
+        return None
+    start = closes[-1 - sessions]
+    end = closes[-1]
+    if start == 0:
+        return None
+    return (end / start - 1.0) * 100.0
+
+
+def _sma(closes: list[float], sessions: int) -> float | None:
+    if len(closes) < sessions:
+        return None
+    window = closes[-sessions:]
+    return sum(window) / len(window)
+
+
+def _normalize_symbols(value: str | None) -> list[str]:
+    if not value:
+        return [str(item["symbol"]).upper() for item in CATALOGUE]
+    result: list[str] = []
+    for raw in value.split(","):
+        symbol = raw.strip().upper()
+        if not symbol or len(symbol) > 20 or not all(ch.isalnum() or ch in ".-" for ch in symbol):
+            continue
+        if symbol not in result:
+            result.append(symbol)
+    if not result:
+        raise HTTPException(status_code=400, detail="No valid symbols were supplied")
+    return result[:60]
+
+
+async def _finnhub_metrics(symbol: str) -> dict[str, Any]:
+    if not FINNHUB_TOKEN:
+        return {}
+    cached = _METRIC_CACHE.get(symbol)
+    now = time.time()
+    if cached and now - cached[0] < METRIC_CACHE_TTL_SECONDS:
+        return cached[1]
+    params = {"symbol": symbol, "metric": "all"}
+    headers = {"X-Finnhub-Token": FINNHUB_TOKEN}
+    timeout = httpx.Timeout(14.0, connect=7.0)
+    async with _METRIC_SEMAPHORE:
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.get(f"{FINNHUB_BASE_URL}/stock/metric", params=params, headers=headers)
+        except httpx.RequestError:
+            return {}
+    if response.status_code == 429:
+        return {}
+    if response.status_code >= 400:
+        return {}
+    try:
+        payload = response.json()
+    except ValueError:
+        return {}
+    metric = payload.get("metric") if isinstance(payload, dict) else None
+    result = metric if isinstance(metric, dict) else {}
+    _METRIC_CACHE[symbol] = (now, result)
+    return result
+
+
+async def _build_row(symbol: str) -> dict[str, Any] | None:
+    history_task = asyncio.create_task(get_market_history(symbol, days=900))
+    metrics_task = asyncio.create_task(_finnhub_metrics(symbol))
+    try:
+        history = await history_task
+    except HTTPException:
+        history = []
+    metrics = await metrics_task
+    closes = [_number(row.get("close")) for row in history]
+    closes = [value for value in closes if value is not None]
+    if not closes:
+        return None
+    current = closes[-1]
+    previous = closes[-2] if len(closes) >= 2 else None
+    day = None if previous in (None, 0) else (current / previous - 1.0) * 100.0
+    sma200 = _sma(closes, 200)
+    ret1y = _ret(closes, 252)
+    ret2y = _ret(closes, 504)
+
+    market_cap = _first_number(metrics, "marketCapitalization", "marketCap", "marketCapitalizationTTM")
+    pe = _first_number(metrics, "peTTM", "peNormalizedAnnual", "peBasicExclExtraTTM", "peExclExtraTTM")
+    beta = _first_number(metrics, "beta")
+    roic = _first_number(metrics, "roicTTM", "roic", "roiTTM", "returnOnInvestmentTTM")
+    if roic is not None and abs(roic) <= 1.5:
+        roic *= 100.0
+
+    meta = next((item for item in CATALOGUE if str(item.get("symbol", "")).upper() == symbol), None) or {}
+    fundamental_values = [market_cap, pe, beta, roic]
+    fundamental_coverage = sum(value is not None for value in fundamental_values) / len(fundamental_values)
+    technical_values = [current, day, sma200, ret1y, ret2y]
+    technical_coverage = sum(value is not None for value in technical_values) / len(technical_values)
+
+    return {
+        "symbol": symbol,
+        "name": meta.get("name", symbol),
+        "sector": meta.get("sector", "Market"),
+        "price": current,
+        "day": day,
+        "sma200": sma200,
+        "above200dma": None if sma200 is None else current > sma200,
+        "ret1y": ret1y,
+        "ret2y": ret2y,
+        "marketCap": market_cap,
+        "pe": pe,
+        "beta": beta,
+        "roic": roic,
+        "fundamentalCoverage": round(fundamental_coverage, 4),
+        "technicalCoverage": round(technical_coverage, 4),
+        "source": {
+            "technical": "Stooq daily history",
+            "fundamental": "Finnhub stock/metric" if FINNHUB_TOKEN else "DATA GATE",
+        },
+    }
+
+
+def _passes(
+    row: dict[str, Any],
+    min_market_cap: float | None,
+    max_pe: float | None,
+    max_beta: float | None,
+    min_roic: float | None,
+    positive_day: bool,
+    above_200dma: bool,
+    positive_1y: bool,
+    positive_2y: bool,
+) -> bool:
+    gates = [
+        (min_market_cap is None, row.get("marketCap") is not None and row["marketCap"] >= min_market_cap),
+        (max_pe is None, row.get("pe") is not None and row["pe"] <= max_pe),
+        (max_beta is None, row.get("beta") is not None and row["beta"] <= max_beta),
+        (min_roic is None, row.get("roic") is not None and row["roic"] >= min_roic),
+        (not positive_day, row.get("day") is not None and row["day"] > 0),
+        (not above_200dma, row.get("above200dma") is True),
+        (not positive_1y, row.get("ret1y") is not None and row["ret1y"] > 0),
+        (not positive_2y, row.get("ret2y") is not None and row["ret2y"] > 0),
+    ]
+    return all(optional or passed for optional, passed in gates)
+
+
+def _sort_value(row: dict[str, Any], key: SortKey) -> Any:
+    if key == "symbol":
+        return str(row.get("symbol", ""))
+    return row.get(key)
+
+
+@router.get("")
+async def screen(
+    symbols: str | None = Query(default=None, max_length=800),
+    min_market_cap: float | None = Query(default=None, ge=0),
+    max_pe: float | None = Query(default=None, ge=0),
+    max_beta: float | None = Query(default=None, ge=-10, le=20),
+    min_roic: float | None = Query(default=None, ge=-1000, le=1000),
+    positive_day: bool = Query(default=False),
+    above_200dma: bool = Query(default=False),
+    positive_1y: bool = Query(default=False),
+    positive_2y: bool = Query(default=False),
+    sort: SortKey = Query(default="ret1y"),
+    direction: SortDirection = Query(default="desc"),
+    limit: int = Query(default=50, ge=1, le=60),
+) -> dict[str, Any]:
+    universe = _normalize_symbols(symbols)
+    results = await asyncio.gather(*(_build_row(symbol) for symbol in universe))
+    rows = [row for row in results if row is not None]
+    passed = [
+        row for row in rows
+        if _passes(row, min_market_cap, max_pe, max_beta, min_roic, positive_day, above_200dma, positive_1y, positive_2y)
+    ]
+
+    reverse = direction == "desc"
+    if sort == "symbol":
+        passed.sort(key=lambda row: _sort_value(row, sort), reverse=reverse)
+    else:
+        passed.sort(
+            key=lambda row: (
+                _sort_value(row, sort) is not None,
+                _sort_value(row, sort) if _sort_value(row, sort) is not None else float("-inf"),
+            ),
+            reverse=reverse,
+        )
+
+    fundamental_gate_count = sum(1 for row in rows if row.get("fundamentalCoverage", 0) < 1)
+    return {
+        "engine": "ATLAS Screener Ω",
+        "version": "1.0.0",
+        "universe": "CUSTOM" if symbols else "ATLAS_CORE_US",
+        "scanned": len(universe),
+        "returned": min(len(passed), limit),
+        "fundamentalDataGates": fundamental_gate_count,
+        "filters": {
+            "minMarketCap": min_market_cap,
+            "maxPE": max_pe,
+            "maxBeta": max_beta,
+            "minROIC": min_roic,
+            "positiveDay": positive_day,
+            "above200dma": above_200dma,
+            "positive1Y": positive_1y,
+            "positive2Y": positive_2y,
+        },
+        "sort": {"key": sort, "direction": direction},
+        "items": passed[:limit],
+        "guardrail": (
+            "Screener results are discovery candidates only. Missing data never passes an active filter. "
+            "A screener result cannot emit BUY/SELL; every candidate must continue through Evidence Director, GREEN first, "
+            "all applicable ATLAS engines, Falsifiers Ω and Investment Committee Ω."
+        ),
+    }

--- a/mobile/app/screener.tsx
+++ b/mobile/app/screener.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from 'react';
+import { router } from 'expo-router';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { ScreenerApi, ScreenerFilters, ScreenerPayload, ScreenerRow, ScreenerSortKey } from '../core/api/screenerApi';
+
+type PresetKey = 'NONE' | 'ATLAS_BASE' | 'MOMENTUM' | 'QUALITY' | 'VALUE';
+
+const EMPTY_FILTERS: ScreenerFilters = { sort: 'ret1y', direction: 'desc', limit: 50 };
+const PRESETS: Record<PresetKey, ScreenerFilters> = {
+  NONE: EMPTY_FILTERS,
+  ATLAS_BASE: { minMarketCap: 10, minROIC: 20, maxBeta: 1.2, positiveDay: true, above200dma: true, positive1Y: true, positive2Y: true, sort: 'ret1y', direction: 'desc', limit: 50 },
+  MOMENTUM: { positiveDay: true, above200dma: true, positive1Y: true, positive2Y: true, sort: 'ret1y', direction: 'desc', limit: 50 },
+  QUALITY: { minMarketCap: 10, maxBeta: 1.2, maxPE: 40, sort: 'marketCap', direction: 'desc', limit: 50 },
+  VALUE: { minMarketCap: 10, maxPE: 25, above200dma: true, sort: 'pe', direction: 'asc', limit: 50 },
+};
+
+export default function ScreenerScreen() {
+  const [filters, setFilters] = useState<ScreenerFilters>(EMPTY_FILTERS);
+  const [preset, setPreset] = useState<PresetKey>('NONE');
+  const [customUniverse, setCustomUniverse] = useState('');
+  const [payload, setPayload] = useState<ScreenerPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const activeFilterCount = useMemo(() => [
+    filters.minMarketCap, filters.maxPE, filters.maxBeta, filters.minROIC,
+    filters.positiveDay, filters.above200dma, filters.positive1Y, filters.positive2Y,
+  ].filter((value) => value !== null && value !== undefined && value !== false).length, [filters]);
+
+  const run = async () => {
+    setLoading(true);
+    setError(null);
+    const symbols = customUniverse.split(/[\s,;]+/).map((value) => value.trim().toUpperCase()).filter(Boolean);
+    try {
+      const next = await ScreenerApi.screen({ ...filters, symbols: symbols.length ? symbols : undefined });
+      setPayload(next);
+    } catch (cause) {
+      setPayload(null);
+      setError(cause instanceof Error ? cause.message : 'SCREENER DATA GATE');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const applyPreset = (key: PresetKey) => {
+    setPreset(key);
+    setFilters({ ...PRESETS[key] });
+    setPayload(null);
+    setError(null);
+  };
+
+  const toggle = (key: keyof ScreenerFilters) => {
+    setPreset('NONE');
+    setFilters((current) => ({ ...current, [key]: !current[key] }));
+  };
+
+  const setNumeric = (key: 'minMarketCap' | 'maxPE' | 'maxBeta' | 'minROIC', value: number | null) => {
+    setPreset('NONE');
+    setFilters((current) => ({ ...current, [key]: current[key] === value ? null : value }));
+  };
+
+  const setSort = (key: ScreenerSortKey) => {
+    setFilters((current) => ({ ...current, sort: key, direction: current.sort === key && current.direction === 'desc' ? 'asc' : 'desc' }));
+  };
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+      <View style={styles.header}>
+        <View style={styles.codeBox}><Text style={styles.code}>SCR</Text></View>
+        <View style={styles.flex}>
+          <Text style={styles.eyebrow}>ATLAS Ω · DISCOVERY TERMINAL</Text>
+          <Text style={styles.title}>Screener</Text>
+          <Text style={styles.subtitle}>Investing-style workflow · ATLAS evidence gates · candidate ≠ decision.</Text>
+        </View>
+        <View style={styles.countBadge}><Text style={styles.countValue}>{activeFilterCount}</Text><Text style={styles.countLabel}>FILTERS</Text></View>
+      </View>
+
+      <View style={styles.universePanel}>
+        <View style={styles.sectionHead}><Text style={styles.sectionCode}>UNIVERSE</Text><Text style={styles.sectionMeta}>ATLAS CORE US · CUSTOM ≤60</Text></View>
+        <TextInput
+          value={customUniverse}
+          onChangeText={setCustomUniverse}
+          autoCapitalize="characters"
+          autoCorrect={false}
+          placeholder="Custom tickers: HBM, FCX, NVDA, WMT…  (blank = ATLAS Core US)"
+          placeholderTextColor="#526269"
+          style={styles.input}
+        />
+      </View>
+
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.presetRow}>
+        <PresetChip label="RESET" active={preset === 'NONE'} onPress={() => applyPreset('NONE')} />
+        <PresetChip label="ATLAS BASE" active={preset === 'ATLAS_BASE'} onPress={() => applyPreset('ATLAS_BASE')} />
+        <PresetChip label="MOMENTUM" active={preset === 'MOMENTUM'} onPress={() => applyPreset('MOMENTUM')} />
+        <PresetChip label="QUALITY" active={preset === 'QUALITY'} onPress={() => applyPreset('QUALITY')} />
+        <PresetChip label="VALUE" active={preset === 'VALUE'} onPress={() => applyPreset('VALUE')} />
+      </ScrollView>
+
+      <View style={styles.filterPanel}>
+        <FilterGroup title="FUNDAMENTALS" hint="Missing values cannot pass an active gate.">
+          <Choice label="MCAP ≥ $10B" active={filters.minMarketCap === 10} onPress={() => setNumeric('minMarketCap', 10)} />
+          <Choice label="MCAP ≥ $50B" active={filters.minMarketCap === 50} onPress={() => setNumeric('minMarketCap', 50)} />
+          <Choice label="P/E ≤ 25" active={filters.maxPE === 25} onPress={() => setNumeric('maxPE', 25)} />
+          <Choice label="P/E ≤ 40" active={filters.maxPE === 40} onPress={() => setNumeric('maxPE', 40)} />
+          <Choice label="BETA ≤ 1.2" active={filters.maxBeta === 1.2} onPress={() => setNumeric('maxBeta', 1.2)} />
+          <Choice label="ROIC ≥ 20%" active={filters.minROIC === 20} onPress={() => setNumeric('minROIC', 20)} />
+        </FilterGroup>
+        <FilterGroup title="TECHNICAL / PERFORMANCE" hint="Daily history: Stooq. No synthetic prices.">
+          <Choice label="DAY > 0" active={Boolean(filters.positiveDay)} onPress={() => toggle('positiveDay')} />
+          <Choice label="PRICE > 200DMA" active={Boolean(filters.above200dma)} onPress={() => toggle('above200dma')} />
+          <Choice label="1Y > 0" active={Boolean(filters.positive1Y)} onPress={() => toggle('positive1Y')} />
+          <Choice label="2Y > 0" active={Boolean(filters.positive2Y)} onPress={() => toggle('positive2Y')} />
+        </FilterGroup>
+      </View>
+
+      <View style={styles.sortPanel}>
+        <Text style={styles.sectionCode}>SORT</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.sortRow}>
+          {(['ret1y','ret2y','day','marketCap','roic','beta','pe','symbol'] as ScreenerSortKey[]).map((key) => (
+            <Pressable key={key} onPress={() => setSort(key)} style={[styles.sortChip, filters.sort === key && styles.sortChipActive]}>
+              <Text style={[styles.sortText, filters.sort === key && styles.sortTextActive]}>{sortLabel(key)}{filters.sort === key ? ` ${filters.direction === 'desc' ? '↓' : '↑'}` : ''}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </View>
+
+      <Pressable onPress={() => void run()} disabled={loading} style={({ pressed }) => [styles.runButton, pressed && styles.pressed, loading && styles.disabled]}>
+        {loading ? <ActivityIndicator color="#08120f" /> : <Text style={styles.runCode}>RUN</Text>}
+        <Text style={styles.runText}>{loading ? 'SCREENING…' : 'RUN SCREENER Ω'}</Text>
+        <Text style={styles.runArrow}>→</Text>
+      </Pressable>
+
+      {error ? <View style={styles.errorPanel}><Text style={styles.errorCode}>DATA GATE</Text><Text style={styles.errorText}>{error}</Text></View> : null}
+
+      {payload ? (
+        <View style={styles.resultsPanel}>
+          <View style={styles.sectionHead}>
+            <Text style={styles.sectionCode}>RESULTS</Text>
+            <Text style={styles.sectionMeta}>{payload.returned}/{payload.scanned} · {payload.universe} · {payload.fundamentalDataGates} FUND GATES</Text>
+          </View>
+          <View style={styles.tableHeader}>
+            <Text style={[styles.th, styles.symbolCol]}>TICKER</Text><Text style={styles.th}>DAY</Text><Text style={styles.th}>1Y</Text><Text style={styles.th}>MCAP</Text>
+          </View>
+          {payload.items.map((row) => (
+            <ScreenerResult key={row.symbol} row={row} expanded={expanded === row.symbol} onToggle={() => setExpanded((current) => current === row.symbol ? null : row.symbol)} />
+          ))}
+          {!payload.items.length ? <Text style={styles.empty}>NO CANDIDATES PASS THE ACTIVE FILTERS</Text> : null}
+          <View style={styles.guardrail}><Text style={styles.guardrailCode}>GUARDRAIL</Text><Text style={styles.guardrailText}>{payload.guardrail}</Text></View>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function PresetChip({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+  return <Pressable onPress={onPress} style={[styles.presetChip, active && styles.presetChipActive]}><Text style={[styles.presetText, active && styles.presetTextActive]}>{label}</Text></Pressable>;
+}
+function FilterGroup({ title, hint, children }: { title: string; hint: string; children: React.ReactNode }) {
+  return <View style={styles.filterGroup}><View style={styles.filterGroupTop}><Text style={styles.filterTitle}>{title}</Text><Text style={styles.filterHint}>{hint}</Text></View><View style={styles.choices}>{children}</View></View>;
+}
+function Choice({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+  return <Pressable onPress={onPress} style={[styles.choice, active && styles.choiceActive]}><View style={[styles.check, active && styles.checkActive]}><Text style={styles.checkText}>{active ? '✓' : ''}</Text></View><Text style={[styles.choiceText, active && styles.choiceTextActive]}>{label}</Text></Pressable>;
+}
+function ScreenerResult({ row, expanded, onToggle }: { row: ScreenerRow; expanded: boolean; onToggle: () => void }) {
+  return (
+    <View style={styles.resultWrap}>
+      <Pressable onPress={onToggle} style={({ pressed }) => [styles.row, pressed && styles.pressed]}>
+        <View style={styles.symbolCol}><Text style={styles.symbol}>{row.symbol}</Text><Text numberOfLines={1} style={styles.company}>{row.name} · {row.sector}</Text></View>
+        <MetricCell value={fmtPct(row.day)} tone={tone(row.day)} />
+        <MetricCell value={fmtPct(row.ret1y)} tone={tone(row.ret1y)} />
+        <MetricCell value={row.marketCap === null ? 'GATE' : `$${row.marketCap.toFixed(1)}B`} />
+      </Pressable>
+      {expanded ? (
+        <View style={styles.detail}>
+          <View style={styles.detailGrid}>
+            <DetailMetric label="PRICE" value={fmt(row.price)} />
+            <DetailMetric label="2Y" value={fmtPct(row.ret2y)} tone={tone(row.ret2y)} />
+            <DetailMetric label="200DMA" value={row.above200dma === null ? 'GATE' : row.above200dma ? 'ABOVE' : 'BELOW'} tone={row.above200dma ? 'good' : row.above200dma === false ? 'bad' : 'neutral'} />
+            <DetailMetric label="P/E" value={fmt(row.pe)} />
+            <DetailMetric label="BETA" value={fmt(row.beta)} />
+            <DetailMetric label="ROIC" value={fmtPct(row.roic)} />
+            <DetailMetric label="FUND COVER" value={`${Math.round(row.fundamentalCoverage * 100)}%`} />
+            <DetailMetric label="TECH COVER" value={`${Math.round(row.technicalCoverage * 100)}%`} />
+          </View>
+          <View style={styles.actions}>
+            <Pressable onPress={() => router.push(`/audit?ticker=${encodeURIComponent(row.symbol)}` as never)} style={styles.action}><Text style={styles.actionCode}>AUD</Text><Text style={styles.actionText}>Auditar</Text></Pressable>
+            <Pressable onPress={() => router.push(`/analyze?ticker=${encodeURIComponent(row.symbol)}` as never)} style={styles.action}><Text style={styles.actionCode}>SEC</Text><Text style={styles.actionText}>Security Hub</Text></Pressable>
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+function MetricCell({ value, tone: metricTone = 'neutral' }: { value: string; tone?: 'good' | 'bad' | 'neutral' }) { return <Text style={[styles.td, metricTone === 'good' && styles.good, metricTone === 'bad' && styles.bad]}>{value}</Text>; }
+function DetailMetric({ label, value, tone: metricTone = 'neutral' }: { label: string; value: string; tone?: 'good' | 'bad' | 'neutral' }) { return <View style={styles.detailMetric}><Text style={styles.detailLabel}>{label}</Text><Text style={[styles.detailValue, metricTone === 'good' && styles.good, metricTone === 'bad' && styles.bad]}>{value}</Text></View>; }
+function tone(value: number | null): 'good' | 'bad' | 'neutral' { return value === null || value === 0 ? 'neutral' : value > 0 ? 'good' : 'bad'; }
+function fmt(value: number | null): string { return value === null ? 'GATE' : value.toLocaleString('es-ES', { maximumFractionDigits: 2 }); }
+function fmtPct(value: number | null): string { return value === null ? 'GATE' : `${value > 0 ? '+' : ''}${value.toFixed(1)}%`; }
+function sortLabel(key: ScreenerSortKey): string { return ({ ret1y: '1Y', ret2y: '2Y', day: 'DAY', marketCap: 'MCAP', roic: 'ROIC', beta: 'BETA', pe: 'P/E', symbol: 'ABC' })[key]; }
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#050708' }, content: { paddingHorizontal: 10, paddingTop: 10, paddingBottom: 30, gap: 9 }, flex: { flex: 1 }, pressed: { opacity: 0.68 }, disabled: { opacity: 0.55 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 10, borderBottomWidth: 1, borderBottomColor: '#1a262b', paddingBottom: 10 }, codeBox: { width: 46, height: 42, borderWidth: 1, borderColor: '#2f725b', backgroundColor: '#071510', alignItems: 'center', justifyContent: 'center' }, code: { color: '#54efbd', fontFamily: 'monospace', fontSize: 10, fontWeight: '900' }, eyebrow: { color: '#607278', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 }, title: { color: '#eef5f2', fontFamily: 'monospace', fontSize: 22, fontWeight: '900', marginTop: 2 }, subtitle: { color: '#596b70', fontSize: 9, marginTop: 3 }, countBadge: { minWidth: 48, borderWidth: 1, borderColor: '#233238', backgroundColor: '#080d0f', padding: 6, alignItems: 'center' }, countValue: { color: '#54efbd', fontFamily: 'monospace', fontSize: 14, fontWeight: '900' }, countLabel: { color: '#5d6d72', fontFamily: 'monospace', fontSize: 6, fontWeight: '900' },
+  universePanel: { borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#070c0e' }, sectionHead: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: 9, borderBottomWidth: 1, borderBottomColor: '#1b292e' }, sectionCode: { color: '#54efbd', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 }, sectionMeta: { color: '#53656a', fontFamily: 'monospace', fontSize: 7, fontWeight: '800' }, input: { height: 42, color: '#dce6e2', fontFamily: 'monospace', fontSize: 9, paddingHorizontal: 10, backgroundColor: '#050809' },
+  presetRow: { gap: 6, paddingVertical: 1 }, presetChip: { borderWidth: 1, borderColor: '#243239', backgroundColor: '#080d0f', paddingHorizontal: 10, height: 30, justifyContent: 'center' }, presetChipActive: { borderColor: '#35745f', backgroundColor: '#081610' }, presetText: { color: '#718087', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, presetTextActive: { color: '#64efc0' },
+  filterPanel: { borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#060a0b' }, filterGroup: { padding: 9, borderBottomWidth: 1, borderBottomColor: '#162126' }, filterGroupTop: { flexDirection: 'row', justifyContent: 'space-between', gap: 8, marginBottom: 8 }, filterTitle: { color: '#b9c7c3', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, filterHint: { flex: 1, color: '#4c5c61', fontSize: 7, textAlign: 'right' }, choices: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 }, choice: { minHeight: 30, flexDirection: 'row', alignItems: 'center', gap: 6, borderWidth: 1, borderColor: '#243239', paddingHorizontal: 8, backgroundColor: '#080d0f' }, choiceActive: { borderColor: '#35745f', backgroundColor: '#081610' }, check: { width: 13, height: 13, borderWidth: 1, borderColor: '#3b494e', alignItems: 'center', justifyContent: 'center' }, checkActive: { borderColor: '#52dcae', backgroundColor: '#0e271d' }, checkText: { color: '#6df0c2', fontSize: 8, fontWeight: '900' }, choiceText: { color: '#74848a', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, choiceTextActive: { color: '#cce9df' },
+  sortPanel: { flexDirection: 'row', alignItems: 'center', gap: 8, borderWidth: 1, borderColor: '#18242a', backgroundColor: '#070b0d', paddingLeft: 9 }, sortRow: { gap: 5, paddingVertical: 6, paddingRight: 8 }, sortChip: { borderWidth: 1, borderColor: '#253238', paddingHorizontal: 8, height: 26, justifyContent: 'center' }, sortChipActive: { borderColor: '#35745f', backgroundColor: '#081610' }, sortText: { color: '#627277', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, sortTextActive: { color: '#5aeaba' },
+  runButton: { minHeight: 46, flexDirection: 'row', alignItems: 'center', gap: 9, borderWidth: 1, borderColor: '#43a27e', backgroundColor: '#49e3ad', paddingHorizontal: 12 }, runCode: { color: '#05100c', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, runText: { flex: 1, color: '#05100c', fontFamily: 'monospace', fontSize: 10, fontWeight: '900' }, runArrow: { color: '#05100c', fontFamily: 'monospace', fontSize: 16, fontWeight: '900' },
+  errorPanel: { borderWidth: 1, borderColor: '#673b3b', backgroundColor: '#160909', padding: 10, gap: 4 }, errorCode: { color: '#e47c7c', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, errorText: { color: '#c89595', fontSize: 9, lineHeight: 14 },
+  resultsPanel: { borderWidth: 1, borderColor: '#1b292e', backgroundColor: '#060a0b' }, tableHeader: { flexDirection: 'row', paddingHorizontal: 9, paddingVertical: 6, borderBottomWidth: 1, borderBottomColor: '#1b292e' }, th: { width: 62, color: '#46565b', fontFamily: 'monospace', fontSize: 6, fontWeight: '900', textAlign: 'right' }, symbolCol: { flex: 1, textAlign: 'left' }, resultWrap: { borderBottomWidth: 1, borderBottomColor: '#10181b' }, row: { minHeight: 50, flexDirection: 'row', alignItems: 'center', paddingHorizontal: 9 }, symbol: { color: '#e9f1ef', fontFamily: 'monospace', fontSize: 10, fontWeight: '900' }, company: { color: '#53646a', fontSize: 7, marginTop: 2, maxWidth: 190 }, td: { width: 62, color: '#aab8b4', fontFamily: 'monospace', fontSize: 8, textAlign: 'right' }, good: { color: '#4de7b4' }, bad: { color: '#e47c7c' }, empty: { color: '#5d6b70', fontFamily: 'monospace', fontSize: 8, padding: 15 },
+  detail: { borderTopWidth: 1, borderTopColor: '#142025', backgroundColor: '#050809', padding: 9, gap: 8 }, detailGrid: { flexDirection: 'row', flexWrap: 'wrap' }, detailMetric: { width: '25%', minWidth: 78, paddingVertical: 6, paddingRight: 7 }, detailLabel: { color: '#46565b', fontFamily: 'monospace', fontSize: 6, fontWeight: '900' }, detailValue: { color: '#cbd7d3', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', marginTop: 3 }, actions: { flexDirection: 'row', gap: 6 }, action: { flex: 1, minHeight: 34, flexDirection: 'row', alignItems: 'center', gap: 7, borderWidth: 1, borderColor: '#285544', paddingHorizontal: 8, backgroundColor: '#07110d' }, actionCode: { color: '#53e7b7', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, actionText: { color: '#b9ccc5', fontFamily: 'monospace', fontSize: 8, fontWeight: '800' },
+  guardrail: { borderTopWidth: 1, borderTopColor: '#1b292e', padding: 9, flexDirection: 'row', gap: 8 }, guardrailCode: { color: '#d2b45c', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, guardrailText: { flex: 1, color: '#746d57', fontSize: 8, lineHeight: 13 },
+});

--- a/mobile/core/api/screenerApi.ts
+++ b/mobile/core/api/screenerApi.ts
@@ -1,0 +1,93 @@
+import { atlasApiBaseUrl } from './atlasOnlineApi';
+
+export type ScreenerSortKey = 'symbol' | 'day' | 'ret1y' | 'ret2y' | 'marketCap' | 'roic' | 'beta' | 'pe';
+export type ScreenerSortDirection = 'asc' | 'desc';
+
+export type ScreenerFilters = {
+  symbols?: string[];
+  minMarketCap?: number | null;
+  maxPE?: number | null;
+  maxBeta?: number | null;
+  minROIC?: number | null;
+  positiveDay?: boolean;
+  above200dma?: boolean;
+  positive1Y?: boolean;
+  positive2Y?: boolean;
+  sort?: ScreenerSortKey;
+  direction?: ScreenerSortDirection;
+  limit?: number;
+};
+
+export type ScreenerRow = {
+  symbol: string;
+  name: string;
+  sector: string;
+  price: number | null;
+  day: number | null;
+  sma200: number | null;
+  above200dma: boolean | null;
+  ret1y: number | null;
+  ret2y: number | null;
+  marketCap: number | null;
+  pe: number | null;
+  beta: number | null;
+  roic: number | null;
+  fundamentalCoverage: number;
+  technicalCoverage: number;
+  source: { technical: string; fundamental: string };
+};
+
+export type ScreenerPayload = {
+  engine: string;
+  version: string;
+  universe: string;
+  scanned: number;
+  returned: number;
+  fundamentalDataGates: number;
+  filters: Record<string, number | boolean | null>;
+  sort: { key: ScreenerSortKey; direction: ScreenerSortDirection };
+  items: ScreenerRow[];
+  guardrail: string;
+};
+
+function pushNumber(params: URLSearchParams, key: string, value: number | null | undefined) {
+  if (typeof value === 'number' && Number.isFinite(value)) params.set(key, String(value));
+}
+
+export const ScreenerApi = {
+  async screen(filters: ScreenerFilters = {}): Promise<ScreenerPayload> {
+    const params = new URLSearchParams();
+    if (filters.symbols?.length) params.set('symbols', filters.symbols.map((value) => value.trim().toUpperCase()).filter(Boolean).join(','));
+    pushNumber(params, 'min_market_cap', filters.minMarketCap);
+    pushNumber(params, 'max_pe', filters.maxPE);
+    pushNumber(params, 'max_beta', filters.maxBeta);
+    pushNumber(params, 'min_roic', filters.minROIC);
+    if (filters.positiveDay) params.set('positive_day', 'true');
+    if (filters.above200dma) params.set('above_200dma', 'true');
+    if (filters.positive1Y) params.set('positive_1y', 'true');
+    if (filters.positive2Y) params.set('positive_2y', 'true');
+    params.set('sort', filters.sort || 'ret1y');
+    params.set('direction', filters.direction || 'desc');
+    params.set('limit', String(filters.limit || 50));
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 65000);
+    try {
+      const response = await fetch(`${atlasApiBaseUrl()}/v1/screener?${params.toString()}`, {
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const detail = typeof payload?.detail === 'string' ? payload.detail : `SCREENER HTTP ${response.status}`;
+        throw new Error(detail);
+      }
+      return payload as ScreenerPayload;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') throw new Error('SCREENER DATA GATE · el backend no respondió a tiempo');
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+};

--- a/mobile/core/ui/TerminalShell.tsx
+++ b/mobile/core/ui/TerminalShell.tsx
@@ -5,37 +5,42 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { GlobalIndexQuote, MarketApi } from '../api/marketApi';
 
+type RouteGroup = 'MARKETS' | 'PORTFOLIO' | 'ANALYSIS' | 'RESEARCH' | 'EXECUTION' | 'SYSTEM';
+
 export type TerminalRoute = {
   key: string;
   label: string;
   short: string;
   route: string;
   hint: string;
+  group: RouteGroup;
 };
 
 export const TERMINAL_ROUTES: TerminalRoute[] = [
-  { key: 'home', label: 'Cockpit', short: 'HOME', route: '/', hint: 'Cartera live, índices y prioridades' },
-  { key: 'markets', label: 'Markets', short: 'MKT', route: '/workspace/markets', hint: 'Mercados, índices, movers y macro' },
-  { key: 'portfolio', label: 'Portfolio', short: 'PORT', route: '/portfolio', hint: 'Cartera, P&L, exposición y contribución' },
-  { key: 'audit', label: 'Auditar', short: 'AUD', route: '/audit', hint: 'Auditoría ticker-first y motores ATLAS' },
-  { key: 'watchlist', label: 'Watchlist', short: 'WL', route: '/watchlist', hint: 'Candidatos, no-chase y alertas' },
-  { key: 'results', label: 'Resultados', short: 'RES', route: '/results', hint: 'Historial guardado e inmutable de auditorías' },
-  { key: 'opportunities', label: 'Opportunities', short: 'OPP', route: '/workspace/opportunities', hint: 'Prioridades, Wave Score y receptores de capital' },
-  { key: 'atlas', label: 'ATLAS Ω', short: 'Ω', route: '/workspace/atlas', hint: 'Investment Committee, motores y Falsifiers' },
-  { key: 'screener', label: 'Screener', short: 'SCR', route: '/workspace/screener', hint: 'Universos, filtros y rankings' },
-  { key: 'research', label: 'Research', short: 'RSR', route: '/workspace/research', hint: 'Firecrawl Search Ω, evidencia y tesis' },
-  { key: 'catalysts', label: 'Catalysts', short: 'CAL', route: '/workspace/catalysts', hint: 'Resultados, FDA, macro y eventos' },
-  { key: 'news', label: 'News', short: 'NEWS', route: '/workspace/news', hint: 'Noticias con procedencia y relevancia ATLAS' },
-  { key: 'orders', label: 'Orders', short: 'ORD', route: '/workspace/orders', hint: 'Órdenes, execution gate e historial' },
-  { key: 'risk', label: 'Risk', short: 'RSK', route: '/workspace/risk', hint: 'Concentración, drawdown y correlación' },
-  { key: 'analyze', label: 'Security Hub', short: 'SEC', route: '/analyze', hint: 'Ficha profunda de un valor' },
-  { key: 'broker', label: 'Broker Ω', short: 'T212', route: '/broker', hint: 'Trading 212, sesión y control' },
-  { key: 'settings', label: 'System', short: 'SYS', route: '/settings', hint: 'Proveedores, backend y configuración' },
+  { key: 'home', label: 'Cockpit', short: 'HOME', route: '/', hint: 'Cartera live, índices y prioridades', group: 'MARKETS' },
+  { key: 'markets', label: 'Markets', short: 'MKT', route: '/workspace/markets', hint: 'Índices, breadth, macro y rotación', group: 'MARKETS' },
+  { key: 'opportunities', label: 'Opportunities', short: 'OPP', route: '/workspace/opportunities', hint: 'Wave Score, receptores y dislocaciones', group: 'MARKETS' },
+  { key: 'screener', label: 'Screener', short: 'SCR', route: '/screener', hint: 'Filtros, universos, rankings y discovery', group: 'MARKETS' },
+  { key: 'portfolio', label: 'Portfolio', short: 'PORT', route: '/portfolio', hint: 'Cartera, P&L, exposición y contribución', group: 'PORTFOLIO' },
+  { key: 'watchlist', label: 'Watchlist', short: 'WL', route: '/watchlist', hint: 'Candidatos, no-chase y alertas', group: 'PORTFOLIO' },
+  { key: 'results', label: 'Resultados', short: 'RES', route: '/results', hint: 'Journal inmutable de auditorías', group: 'PORTFOLIO' },
+  { key: 'risk', label: 'Risk', short: 'RSK', route: '/workspace/risk', hint: 'Concentración, drawdown y correlación', group: 'PORTFOLIO' },
+  { key: 'audit', label: 'Auditar', short: 'AUD', route: '/audit', hint: 'Auditoría ticker-first y motores ATLAS', group: 'ANALYSIS' },
+  { key: 'analyze', label: 'Security Hub', short: 'SEC', route: '/analyze', hint: 'Ficha profunda de un valor', group: 'ANALYSIS' },
+  { key: 'atlas', label: 'ATLAS Ω', short: 'Ω', route: '/workspace/atlas', hint: 'Investment Committee, motores y Falsifiers', group: 'ANALYSIS' },
+  { key: 'research', label: 'Research', short: 'RSR', route: '/workspace/research', hint: 'Evidencia, provenance y tesis', group: 'RESEARCH' },
+  { key: 'catalysts', label: 'Catalysts', short: 'CAL', route: '/workspace/catalysts', hint: 'Resultados, FDA, macro y eventos', group: 'RESEARCH' },
+  { key: 'news', label: 'News', short: 'NEWS', route: '/workspace/news', hint: 'Noticias con procedencia y materialidad', group: 'RESEARCH' },
+  { key: 'orders', label: 'Orders', short: 'ORD', route: '/workspace/orders', hint: 'Execution gate e historial', group: 'EXECUTION' },
+  { key: 'broker', label: 'Broker Ω', short: 'T212', route: '/broker', hint: 'Trading 212, sesión y control', group: 'EXECUTION' },
+  { key: 'settings', label: 'System', short: 'SYS', route: '/settings', hint: 'Proveedores, backend y configuración', group: 'SYSTEM' },
 ];
 
-const TOP_KEYS = ['markets', 'portfolio', 'audit', 'watchlist', 'results', 'opportunities', 'atlas', 'screener', 'research', 'catalysts', 'news', 'orders', 'risk'];
+const TOP_KEYS = ['markets', 'portfolio', 'screener', 'opportunities', 'audit', 'watchlist', 'results', 'research', 'catalysts', 'news', 'atlas', 'risk', 'orders'];
 const TOP_MODULES = TERMINAL_ROUTES.filter((item) => TOP_KEYS.includes(item.key));
-const BOTTOM_KEYS = ['home', 'portfolio', 'audit', 'watchlist'];
+const BOTTOM_KEYS = ['home', 'portfolio', 'audit', 'screener'];
+const GROUPS: RouteGroup[] = ['MARKETS', 'PORTFOLIO', 'ANALYSIS', 'RESEARCH', 'EXECUTION', 'SYSTEM'];
+const QUICK_KEYS = ['audit', 'screener', 'watchlist', 'results'];
 
 export function TerminalShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
@@ -43,6 +48,7 @@ export function TerminalShell({ children }: { children: ReactNode }) {
   const wide = width >= 900;
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const current = routeForPath(pathname);
 
   const navigate = (route: string) => {
     setPaletteOpen(false);
@@ -53,8 +59,9 @@ export function TerminalShell({ children }: { children: ReactNode }) {
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <View style={styles.root}>
-        <TerminalHeader onOpenPalette={() => setPaletteOpen(true)} />
+        <TerminalHeader current={current} onOpenPalette={() => setPaletteOpen(true)} />
         <WorldIndexTape />
+        <RouteContextBar current={current} onNavigate={navigate} />
         {!wide ? (
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.moduleStrip} contentContainerStyle={styles.moduleStripContent}>
             {TOP_MODULES.map((item) => <ModuleChip key={item.key} item={item} active={isActive(pathname, item.route)} onPress={() => navigate(item.route)} />)}
@@ -81,7 +88,7 @@ export function TerminalShell({ children }: { children: ReactNode }) {
   );
 }
 
-function TerminalHeader({ onOpenPalette }: { onOpenPalette: () => void }) {
+function TerminalHeader({ current, onOpenPalette }: { current: TerminalRoute; onOpenPalette: () => void }) {
   return (
     <View style={styles.header}>
       <Pressable onPress={() => router.push('/' as never)} style={styles.brandWrap}>
@@ -89,9 +96,26 @@ function TerminalHeader({ onOpenPalette }: { onOpenPalette: () => void }) {
         <View><Text style={styles.brand}>ATLAS</Text><Text style={styles.brandSub}>INVESTMENT TERMINAL</Text></View>
       </Pressable>
       <Pressable onPress={onOpenPalette} style={({ pressed }) => [styles.goBar, pressed && styles.pressed]}>
-        <Text style={styles.goPrompt}>GO</Text><Text numberOfLines={1} style={styles.goText}>ticker, AUD, WL, RES…</Text><View style={styles.keycap}><Text style={styles.keycapText}>⌘K</Text></View>
+        <Text style={styles.goPrompt}>GO</Text>
+        <Text numberOfLines={1} style={styles.goText}>{current.short} · ticker, función, workspace…</Text>
+        <View style={styles.keycap}><Text style={styles.keycapText}>⌘K</Text></View>
       </Pressable>
       <View style={styles.livePill}><View style={styles.liveDot} /><Text style={styles.liveText}>LIVE</Text></View>
+    </View>
+  );
+}
+
+function RouteContextBar({ current, onNavigate }: { current: TerminalRoute; onNavigate: (route: string) => void }) {
+  return (
+    <View style={styles.contextBar}>
+      <View style={styles.contextCode}><Text style={styles.contextCodeText}>{current.short}</Text></View>
+      <View style={styles.contextText}><Text style={styles.contextTitle}>{current.label}</Text><Text numberOfLines={1} style={styles.contextHint}>{current.group} · {current.hint}</Text></View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.quickRow}>
+        {QUICK_KEYS.filter((key) => key !== current.key).map((key) => {
+          const item = TERMINAL_ROUTES.find((row) => row.key === key)!;
+          return <Pressable key={key} onPress={() => onNavigate(item.route)} style={styles.quickChip}><Text style={styles.quickCode}>{item.short}</Text></Pressable>;
+        })}
+      </ScrollView>
     </View>
   );
 }
@@ -140,12 +164,16 @@ function IndexChip({ item }: { item: GlobalIndexQuote }) {
 function DesktopRail({ pathname, onNavigate }: { pathname: string; onNavigate: (route: string) => void }) {
   return (
     <ScrollView style={styles.rail} contentContainerStyle={styles.railContent} showsVerticalScrollIndicator={false}>
-      <Text style={styles.railTitle}>FUNCTIONS</Text>
-      {TERMINAL_ROUTES.map((item) => (
-        <Pressable key={item.key} onPress={() => onNavigate(item.route)} style={({ pressed }) => [styles.railItem, isActive(pathname, item.route) && styles.railItemActive, pressed && styles.pressed]}>
-          <Text style={[styles.railCode, isActive(pathname, item.route) && styles.railCodeActive]}>{item.short}</Text>
-          <View style={styles.railTextWrap}><Text style={[styles.railLabel, isActive(pathname, item.route) && styles.railLabelActive]}>{item.label}</Text><Text numberOfLines={1} style={styles.railHint}>{item.hint}</Text></View>
-        </Pressable>
+      {GROUPS.map((group) => (
+        <View key={group} style={styles.railGroup}>
+          <Text style={styles.railTitle}>{group}</Text>
+          {TERMINAL_ROUTES.filter((item) => item.group === group).map((item) => (
+            <Pressable key={item.key} onPress={() => onNavigate(item.route)} style={({ pressed }) => [styles.railItem, isActive(pathname, item.route) && styles.railItemActive, pressed && styles.pressed]}>
+              <Text style={[styles.railCode, isActive(pathname, item.route) && styles.railCodeActive]}>{item.short}</Text>
+              <View style={styles.railTextWrap}><Text style={[styles.railLabel, isActive(pathname, item.route) && styles.railLabelActive]}>{item.label}</Text><Text numberOfLines={1} style={styles.railHint}>{item.hint}</Text></View>
+            </Pressable>
+          ))}
+        </View>
       ))}
     </ScrollView>
   );
@@ -160,7 +188,7 @@ function BottomItem({ item, active, onPress }: { item: TerminalRoute; active: bo
 
 function CommandPalette({ open, query, onChangeQuery, onClose, onNavigate }: { open: boolean; query: string; onChangeQuery: (value: string) => void; onClose: () => void; onNavigate: (route: string) => void }) {
   const normalized = query.trim().toLowerCase();
-  const rows = useMemo(() => !normalized ? TERMINAL_ROUTES : TERMINAL_ROUTES.filter((item) => `${item.label} ${item.short} ${item.hint}`.toLowerCase().includes(normalized)), [normalized]);
+  const rows = useMemo(() => !normalized ? TERMINAL_ROUTES : TERMINAL_ROUTES.filter((item) => `${item.label} ${item.short} ${item.hint} ${item.group}`.toLowerCase().includes(normalized)), [normalized]);
   const ticker = query.trim().toUpperCase();
   const tickerCandidate = /^[A-Z0-9.\-]{1,12}$/.test(ticker);
   return (
@@ -168,11 +196,15 @@ function CommandPalette({ open, query, onChangeQuery, onClose, onNavigate }: { o
       <View style={styles.modalBackdrop}>
         <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         <View style={styles.palette}>
-          <View style={styles.paletteHeader}><Text style={styles.paletteLabel}>ATLAS GO BAR</Text><Pressable onPress={onClose} style={styles.closeButton}><Text style={styles.closeText}>ESC</Text></Pressable></View>
-          <TextInput autoFocus value={query} onChangeText={onChangeQuery} autoCapitalize="characters" autoCorrect={false} placeholder="Ticker, AUD, WATCHLIST, RESULTS…" placeholderTextColor="#5f6b70" style={styles.paletteInput} returnKeyType="search" onSubmitEditing={() => { if (tickerCandidate) onNavigate(`/analyze?ticker=${encodeURIComponent(ticker)}`); }} />
+          <View style={styles.paletteHeader}><Text style={styles.paletteLabel}>ATLAS GO · WORKSPACES + TICKERS</Text><Pressable onPress={onClose} style={styles.closeButton}><Text style={styles.closeText}>ESC</Text></Pressable></View>
+          <TextInput autoFocus value={query} onChangeText={onChangeQuery} autoCapitalize="characters" autoCorrect={false} placeholder="Ticker, SCR, AUD, WATCHLIST, RESEARCH…" placeholderTextColor="#5f6b70" style={styles.paletteInput} returnKeyType="search" onSubmitEditing={() => { if (tickerCandidate) onNavigate(`/analyze?ticker=${encodeURIComponent(ticker)}`); }} />
           <ScrollView style={styles.paletteResults} keyboardShouldPersistTaps="handled">
             {tickerCandidate ? <CommandRow code="SEC" title={`Analizar ${ticker}`} hint="Security Hub" onPress={() => onNavigate(`/analyze?ticker=${encodeURIComponent(ticker)}`)} /> : null}
-            {rows.map((item) => <CommandRow key={item.key} code={item.short} title={item.label} hint={item.hint} onPress={() => onNavigate(item.route)} />)}
+            {GROUPS.map((group) => {
+              const groupRows = rows.filter((item) => item.group === group);
+              if (!groupRows.length) return null;
+              return <View key={group}><Text style={styles.commandGroup}>{group}</Text>{groupRows.map((item) => <CommandRow key={item.key} code={item.short} title={item.label} hint={item.hint} onPress={() => onNavigate(item.route)} />)}</View>;
+            })}
           </ScrollView>
         </View>
       </View>
@@ -183,19 +215,21 @@ function CommandRow({ code, title, hint, onPress }: { code: string; title: strin
   return <Pressable onPress={onPress} style={({ pressed }) => [styles.commandRow, pressed && styles.pressed]}><View style={styles.commandCodeBox}><Text style={styles.commandCode}>{code}</Text></View><View style={styles.commandTextWrap}><Text style={styles.commandTitle}>{title}</Text><Text style={styles.commandHint}>{hint}</Text></View><Text style={styles.commandArrow}>→</Text></Pressable>;
 }
 
+function routeForPath(pathname: string): TerminalRoute {
+  return TERMINAL_ROUTES.find((item) => isActive(pathname, item.route)) || TERMINAL_ROUTES[0]!;
+}
 function isActive(pathname: string, route: string): boolean { return route === '/' ? pathname === '/' : pathname === route || pathname.startsWith(`${route}/`); }
 function formatMarket(value: number | null): string { return value === null ? '—' : value.toLocaleString('es-ES', { maximumFractionDigits: 2 }); }
 function formatPct(value: number | null): string { return value === null ? '—' : `${value > 0 ? '+' : ''}${value.toFixed(2)}%`; }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: '#030506' }, root: { flex: 1, backgroundColor: '#030506' },
-  header: { minHeight: 54, flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 10, borderBottomWidth: 1, borderBottomColor: '#1a2428', backgroundColor: '#050809' },
-  brandWrap: { flexDirection: 'row', alignItems: 'center', gap: 8 }, brandMark: { width: 30, height: 30, borderWidth: 1, borderColor: '#23d9a7', alignItems: 'center', justifyContent: 'center', backgroundColor: '#07130f' }, brandOmega: { color: '#51f2c5', fontFamily: 'monospace', fontSize: 18, fontWeight: '900' }, brand: { color: '#f3f6f5', fontFamily: 'monospace', fontWeight: '900', fontSize: 14, letterSpacing: 1.5 }, brandSub: { color: '#66757b', fontFamily: 'monospace', fontWeight: '700', fontSize: 7, letterSpacing: 1.1 },
-  goBar: { flex: 1, minWidth: 0, height: 34, borderWidth: 1, borderColor: '#26343a', backgroundColor: '#0a0f11', flexDirection: 'row', alignItems: 'center', paddingHorizontal: 9, gap: 8 }, goPrompt: { color: '#42e8b4', fontFamily: 'monospace', fontWeight: '900', fontSize: 11 }, goText: { color: '#7d8c92', fontFamily: 'monospace', fontSize: 10, flex: 1 }, keycap: { borderWidth: 1, borderColor: '#2d3a3f', paddingHorizontal: 5, paddingVertical: 2, backgroundColor: '#0f1517' }, keycapText: { color: '#829197', fontFamily: 'monospace', fontSize: 8, fontWeight: '800' },
-  livePill: { flexDirection: 'row', alignItems: 'center', gap: 5, borderWidth: 1, borderColor: '#214b3d', backgroundColor: '#081510', paddingHorizontal: 7, height: 28 }, liveDot: { width: 6, height: 6, borderRadius: 99, backgroundColor: '#31e6a3' }, liveText: { color: '#7ff5ce', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' },
-  tape: { maxHeight: 42, borderBottomWidth: 1, borderBottomColor: '#172126', backgroundColor: '#060a0c' }, tapeContent: { alignItems: 'stretch' }, indexChip: { minWidth: 172, height: 41, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 10, borderRightWidth: 1, borderRightColor: '#172126' }, indexName: { color: '#b9c5c2', fontFamily: 'monospace', fontWeight: '800', fontSize: 8 }, indexRegion: { color: '#45545a', fontFamily: 'monospace', fontSize: 7, marginTop: 2 }, indexPrice: { color: '#e5ecea', fontFamily: 'monospace', fontWeight: '900', fontSize: 10 }, indexChange: { minWidth: 48, textAlign: 'right', color: '#849197', fontFamily: 'monospace', fontWeight: '900', fontSize: 9 }, positive: { color: '#4fe0ad' }, negative: { color: '#e37c83' }, gateTape: { minHeight: 41, flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 10 }, gateLabel: { color: '#d0c16f', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, gateText: { color: '#6e7b80', fontFamily: 'monospace', fontSize: 8 },
-  moduleStrip: { maxHeight: 39, borderBottomWidth: 1, borderBottomColor: '#182226', backgroundColor: '#050809' }, moduleStripContent: { alignItems: 'center', paddingHorizontal: 5 }, moduleChip: { height: 38, flexDirection: 'row', alignItems: 'center', gap: 5, paddingHorizontal: 9, borderRightWidth: 1, borderRightColor: '#111b1f' }, moduleChipActive: { backgroundColor: '#09130f' }, moduleCode: { color: '#54646a', fontFamily: 'monospace', fontWeight: '900', fontSize: 8 }, moduleCodeActive: { color: '#4fe8b6' }, moduleLabel: { color: '#88969b', fontSize: 9, fontWeight: '700' }, moduleLabelActive: { color: '#dbe7e3' },
-  body: { flex: 1, flexDirection: 'row' }, content: { flex: 1, minWidth: 0 }, rail: { width: 228, backgroundColor: '#050809', borderRightWidth: 1, borderRightColor: '#172126' }, railContent: { paddingBottom: 20 }, railTitle: { color: '#3e4d53', fontFamily: 'monospace', fontSize: 7, fontWeight: '900', letterSpacing: 1.1, paddingHorizontal: 10, paddingVertical: 9 }, railItem: { minHeight: 49, flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 9, borderTopWidth: 1, borderTopColor: '#0d1518' }, railItemActive: { backgroundColor: '#08130f', borderLeftWidth: 2, borderLeftColor: '#3de1ad' }, railCode: { width: 34, color: '#536269', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, railCodeActive: { color: '#4fe8b6' }, railTextWrap: { flex: 1 }, railLabel: { color: '#98a5a9', fontSize: 10, fontWeight: '800' }, railLabelActive: { color: '#e3ece9' }, railHint: { color: '#445258', fontSize: 8, marginTop: 2 },
-  bottomNav: { minHeight: 55, flexDirection: 'row', borderTopWidth: 1, borderTopColor: '#1a2529', backgroundColor: '#050809' }, bottomItem: { flex: 1, minWidth: 0, alignItems: 'center', justifyContent: 'center', gap: 3 }, bottomItemActive: { backgroundColor: '#08120f' }, bottomShort: { color: '#637178', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, bottomShortActive: { color: '#51e8b7' }, bottomLabel: { color: '#66757a', fontSize: 8, fontWeight: '700' }, bottomLabelActive: { color: '#d8e4e0' },
-  modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.72)', alignItems: 'center', paddingTop: 80, paddingHorizontal: 12 }, palette: { width: '100%', maxWidth: 680, maxHeight: '78%', borderWidth: 1, borderColor: '#2a3b40', backgroundColor: '#070b0d' }, paletteHeader: { minHeight: 40, flexDirection: 'row', alignItems: 'center', paddingHorizontal: 11, borderBottomWidth: 1, borderBottomColor: '#1c292e' }, paletteLabel: { flex: 1, color: '#4fe8b6', fontFamily: 'monospace', fontSize: 9, fontWeight: '900', letterSpacing: 1 }, closeButton: { borderWidth: 1, borderColor: '#2a383d', paddingHorizontal: 7, paddingVertical: 4 }, closeText: { color: '#718086', fontFamily: 'monospace', fontSize: 8 }, paletteInput: { minHeight: 50, color: '#edf4f2', fontFamily: 'monospace', fontSize: 14, paddingHorizontal: 12, borderBottomWidth: 1, borderBottomColor: '#1c292e' }, paletteResults: { maxHeight: 430 }, commandRow: { minHeight: 56, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 11, borderBottomWidth: 1, borderBottomColor: '#101a1d' }, commandCodeBox: { width: 42, height: 28, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: '#26383e', backgroundColor: '#091012' }, commandCode: { color: '#63d9b7', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, commandTextWrap: { flex: 1 }, commandTitle: { color: '#dfe8e5', fontSize: 11, fontWeight: '800' }, commandHint: { color: '#526168', fontSize: 9, marginTop: 2 }, commandArrow: { color: '#55d9b2', fontFamily: 'monospace' }, pressed: { opacity: 0.65 },
+  safe: { flex: 1, backgroundColor: '#030506' }, root: { flex: 1, backgroundColor: '#030506' }, body: { flex: 1, flexDirection: 'row' }, content: { flex: 1, minWidth: 0 }, pressed: { opacity: 0.66 },
+  header: { minHeight: 52, flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 9, borderBottomWidth: 1, borderBottomColor: '#1a2428', backgroundColor: '#050809' }, brandWrap: { flexDirection: 'row', alignItems: 'center', gap: 7 }, brandMark: { width: 29, height: 29, borderWidth: 1, borderColor: '#23d9a7', alignItems: 'center', justifyContent: 'center', backgroundColor: '#07130f' }, brandOmega: { color: '#51f2c5', fontFamily: 'monospace', fontSize: 17, fontWeight: '900' }, brand: { color: '#f3f6f5', fontFamily: 'monospace', fontWeight: '900', fontSize: 13, letterSpacing: 1.4 }, brandSub: { color: '#66757b', fontFamily: 'monospace', fontWeight: '700', fontSize: 6, letterSpacing: 1 },
+  goBar: { flex: 1, minWidth: 0, height: 32, borderWidth: 1, borderColor: '#26343a', backgroundColor: '#0a0f11', flexDirection: 'row', alignItems: 'center', paddingHorizontal: 8, gap: 7 }, goPrompt: { color: '#42e8b4', fontFamily: 'monospace', fontWeight: '900', fontSize: 10 }, goText: { color: '#7d8c92', fontFamily: 'monospace', fontSize: 9, flex: 1 }, keycap: { borderWidth: 1, borderColor: '#2d3a3f', paddingHorizontal: 4, paddingVertical: 2, backgroundColor: '#0f1517' }, keycapText: { color: '#829197', fontFamily: 'monospace', fontSize: 7, fontWeight: '800' }, livePill: { flexDirection: 'row', alignItems: 'center', gap: 4, borderWidth: 1, borderColor: '#214b3d', backgroundColor: '#081510', paddingHorizontal: 6, height: 26 }, liveDot: { width: 5, height: 5, borderRadius: 99, backgroundColor: '#31e6a3' }, liveText: { color: '#7ff5ce', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' },
+  tape: { maxHeight: 40, borderBottomWidth: 1, borderBottomColor: '#172126', backgroundColor: '#040708' }, tapeContent: { alignItems: 'stretch' }, indexChip: { minWidth: 168, height: 39, paddingHorizontal: 9, flexDirection: 'row', alignItems: 'center', gap: 8, borderRightWidth: 1, borderRightColor: '#172126' }, indexName: { color: '#c7d1ce', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, indexRegion: { color: '#45545a', fontFamily: 'monospace', fontSize: 6, marginTop: 1 }, indexPrice: { color: '#e2e9e7', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, indexChange: { color: '#77868b', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, positive: { color: '#4de7b4' }, negative: { color: '#e47c7c' }, gateTape: { height: 39, minWidth: 260, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 10 }, gateLabel: { color: '#54efbd', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, gateText: { color: '#69787d', fontFamily: 'monospace', fontSize: 7 },
+  contextBar: { minHeight: 34, flexDirection: 'row', alignItems: 'center', gap: 7, paddingHorizontal: 9, borderBottomWidth: 1, borderBottomColor: '#172126', backgroundColor: '#060a0c' }, contextCode: { width: 34, height: 22, borderWidth: 1, borderColor: '#285544', backgroundColor: '#07110d', alignItems: 'center', justifyContent: 'center' }, contextCodeText: { color: '#54efbd', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, contextText: { flex: 1, minWidth: 90 }, contextTitle: { color: '#dce5e2', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, contextHint: { color: '#4f6066', fontFamily: 'monospace', fontSize: 6, marginTop: 1 }, quickRow: { gap: 4, paddingVertical: 5 }, quickChip: { minWidth: 34, height: 22, borderWidth: 1, borderColor: '#253238', backgroundColor: '#080d0f', alignItems: 'center', justifyContent: 'center' }, quickCode: { color: '#718087', fontFamily: 'monospace', fontSize: 6, fontWeight: '900' },
+  moduleStrip: { maxHeight: 36, borderBottomWidth: 1, borderBottomColor: '#182328', backgroundColor: '#040708' }, moduleStripContent: { paddingHorizontal: 6, alignItems: 'center', gap: 4 }, moduleChip: { height: 28, flexDirection: 'row', alignItems: 'center', gap: 5, borderWidth: 1, borderColor: '#1d2a2f', backgroundColor: '#070b0d', paddingHorizontal: 7 }, moduleChipActive: { borderColor: '#2d6754', backgroundColor: '#07130f' }, moduleCode: { color: '#516167', fontFamily: 'monospace', fontSize: 6, fontWeight: '900' }, moduleCodeActive: { color: '#50e6b5' }, moduleLabel: { color: '#728087', fontFamily: 'monospace', fontSize: 7, fontWeight: '800' }, moduleLabelActive: { color: '#cbe5dc' },
+  rail: { width: 224, borderRightWidth: 1, borderRightColor: '#172126', backgroundColor: '#040708' }, railContent: { paddingVertical: 8 }, railGroup: { marginBottom: 10 }, railTitle: { color: '#405158', fontFamily: 'monospace', fontSize: 6, fontWeight: '900', letterSpacing: 1.2, paddingHorizontal: 9, marginBottom: 4 }, railItem: { minHeight: 42, flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 8, borderLeftWidth: 2, borderLeftColor: 'transparent' }, railItemActive: { backgroundColor: '#07110d', borderLeftColor: '#42dca9' }, railCode: { width: 34, color: '#526269', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, railCodeActive: { color: '#52e8b7' }, railTextWrap: { flex: 1 }, railLabel: { color: '#96a4a1', fontFamily: 'monospace', fontSize: 8, fontWeight: '900' }, railLabelActive: { color: '#e2ece8' }, railHint: { color: '#46565b', fontSize: 6, marginTop: 2 },
+  bottomNav: { minHeight: 49, flexDirection: 'row', borderTopWidth: 1, borderTopColor: '#1b292e', backgroundColor: '#050809' }, bottomItem: { flex: 1, minWidth: 0, alignItems: 'center', justifyContent: 'center', gap: 2, borderTopWidth: 2, borderTopColor: 'transparent' }, bottomItemActive: { backgroundColor: '#07110d', borderTopColor: '#43dbaa' }, bottomShort: { color: '#5d6d72', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, bottomShortActive: { color: '#58e8b8' }, bottomLabel: { color: '#637278', fontFamily: 'monospace', fontSize: 6 }, bottomLabelActive: { color: '#c8ddd5' },
+  modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.78)', alignItems: 'center', paddingTop: 66, paddingHorizontal: 12 }, palette: { width: '100%', maxWidth: 700, maxHeight: '82%', borderWidth: 1, borderColor: '#304048', backgroundColor: '#060a0c' }, paletteHeader: { height: 36, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 9, borderBottomWidth: 1, borderBottomColor: '#1b292e' }, paletteLabel: { color: '#55e9b9', fontFamily: 'monospace', fontSize: 8, fontWeight: '900', letterSpacing: 1 }, closeButton: { borderWidth: 1, borderColor: '#26353b', paddingHorizontal: 7, paddingVertical: 4 }, closeText: { color: '#718087', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, paletteInput: { height: 46, borderBottomWidth: 1, borderBottomColor: '#1b292e', color: '#e3ebe8', fontFamily: 'monospace', fontSize: 11, paddingHorizontal: 10, backgroundColor: '#050809' }, paletteResults: { maxHeight: 520 }, commandGroup: { color: '#42545b', fontFamily: 'monospace', fontSize: 6, fontWeight: '900', letterSpacing: 1.2, paddingHorizontal: 10, paddingTop: 10, paddingBottom: 4 }, commandRow: { minHeight: 49, flexDirection: 'row', alignItems: 'center', gap: 9, paddingHorizontal: 9, borderBottomWidth: 1, borderBottomColor: '#10191c' }, commandCodeBox: { width: 39, height: 27, borderWidth: 1, borderColor: '#285544', backgroundColor: '#07110d', alignItems: 'center', justifyContent: 'center' }, commandCode: { color: '#54efbd', fontFamily: 'monospace', fontSize: 7, fontWeight: '900' }, commandTextWrap: { flex: 1 }, commandTitle: { color: '#dbe5e1', fontFamily: 'monospace', fontSize: 9, fontWeight: '900' }, commandHint: { color: '#54656a', fontSize: 7, marginTop: 2 }, commandArrow: { color: '#4ddfad', fontFamily: 'monospace', fontSize: 13 },
 });

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,14 +19,15 @@
     "expo-status-bar": "57.0.1",
     "react": "19.2.3",
     "react-native": "0.86.2",
-    "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "5.7.0",
-    "react-native-screens": "4.26.0",
-    "react-native-worklets": "0.10.1"
+    "react-native-screens": "4.26.0"
   },
   "devDependencies": {
     "@types/react": "19.2.2",
     "babel-preset-expo": "57.0.4",
     "typescript": "6.0.3"
+  },
+  "overrides": {
+    "expo-modules-core": "57.0.12"
   }
 }

--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,0 +1,30 @@
+from api.screener import _passes
+
+
+def _row(**overrides):
+    base = {
+        "marketCap": 50.0,
+        "pe": 20.0,
+        "beta": 1.0,
+        "roic": 25.0,
+        "day": 1.0,
+        "above200dma": True,
+        "ret1y": 15.0,
+        "ret2y": 30.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_all_active_filters_pass_only_when_every_field_passes():
+    assert _passes(_row(), 10, 25, 1.2, 20, True, True, True, True)
+    assert not _passes(_row(beta=1.3), 10, 25, 1.2, 20, True, True, True, True)
+
+
+def test_missing_value_never_passes_an_active_filter():
+    assert not _passes(_row(roic=None), None, None, None, 20, False, False, False, False)
+    assert not _passes(_row(ret2y=None), None, None, None, None, False, False, False, True)
+
+
+def test_missing_value_is_allowed_when_filter_is_inactive():
+    assert _passes(_row(roic=None, beta=None, pe=None), None, None, None, None, False, False, False, False)


### PR DESCRIPTION
Implements both requested layers:

1. Screener Engine Ω backend with real observed technical history, Finnhub fundamentals, strict missing-data gates, exact-ROIC rule, presets and sortable outputs.
2. Screener Terminal UI inspired by Investing-style workflow but governed by ATLAS evidence rules.

Also upgrades the global TerminalShell so every route inherits grouped menus, GO palette, current-workspace context bar, live index tape, quick cross-workspace navigation and mobile/desktop terminal framing. Screener is promoted to a first-class route `/screener`.

Adds canonical Screener Terminal Ω spec and backend hard-filter tests.

Guardrails: screener pass != BUY; missing data never passes active filters; no direct order action from screener.