### PR TITLE
Rescue: consolidate T212 + Finnhub resilience from stale mobile PRs

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -1,0 +1,5 @@
+"""External market/broker provider adapters for ATLAS Ω.
+
+Provider modules keep credentials and upstream rate-limit handling on the server.
+The mobile application must never contain provider secrets.
+"""

--- a/api/providers/finnhub_resilient.py
+++ b/api/providers/finnhub_resilient.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import HTTPException
+
+FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    stored_at: float
+    value: Any
+
+
+@dataclass(frozen=True, slots=True)
+class FinnhubPolicy:
+    ttl_seconds: float
+    stale_seconds: float
+
+
+_POLICIES: tuple[tuple[str, FinnhubPolicy], ...] = (
+    ("/quote", FinnhubPolicy(8.0, 300.0)),
+    ("/stock/profile2", FinnhubPolicy(86_400.0, 7 * 86_400.0)),
+    ("/stock/metric", FinnhubPolicy(21_600.0, 3 * 86_400.0)),
+    ("/stock/recommendation", FinnhubPolicy(3_600.0, 86_400.0)),
+    ("/company-news", FinnhubPolicy(900.0, 21_600.0)),
+    ("/search", FinnhubPolicy(300.0, 3_600.0)),
+)
+_DEFAULT_POLICY = FinnhubPolicy(60.0, 900.0)
+
+
+def policy_for(path: str) -> FinnhubPolicy:
+    for prefix, policy in _POLICIES:
+        if path.startswith(prefix):
+            return policy
+    return _DEFAULT_POLICY
+
+
+class FinnhubResilientClient:
+    """Server-side Finnhub adapter designed for ATLAS Ω fan-out workloads.
+
+    Guarantees:
+    - one in-flight upstream request per unique endpoint/parameter key;
+    - short/long TTLs according to data volatility;
+    - conservative calls-per-second throttle below Finnhub's global ceiling;
+    - temporary cooldown after HTTP 429;
+    - stale-last-good fallback when an upstream limit/outage occurs.
+
+    No provider token is ever returned to clients.
+    """
+
+    def __init__(self, *, max_calls_per_second: int | None = None) -> None:
+        configured = max_calls_per_second or int(os.getenv("FINNHUB_MAX_CALLS_PER_SECOND", "20"))
+        self.max_calls_per_second = max(1, min(configured, 29))
+        self._cache: dict[str, _CacheEntry] = {}
+        self._key_locks: dict[str, asyncio.Lock] = {}
+        self._rate_lock = asyncio.Lock()
+        self._recent_calls: deque[float] = deque()
+        self._cooldown_until = 0.0
+
+    @staticmethod
+    def _token() -> str:
+        token = os.getenv("FINNHUB_TOKEN", "").strip()
+        if not token:
+            raise HTTPException(status_code=503, detail="FINNHUB_TOKEN is not configured")
+        return token
+
+    @staticmethod
+    def _key(path: str, params: dict[str, Any]) -> str:
+        normalized = urlencode(sorted((str(k), str(v)) for k, v in params.items()))
+        return f"{path}?{normalized}"
+
+    async def _throttle(self) -> None:
+        while True:
+            wait = 0.0
+            async with self._rate_lock:
+                now = time.monotonic()
+                while self._recent_calls and now - self._recent_calls[0] >= 1.0:
+                    self._recent_calls.popleft()
+                if len(self._recent_calls) < self.max_calls_per_second:
+                    self._recent_calls.append(now)
+                    return
+                wait = max(0.01, 1.0 - (now - self._recent_calls[0]))
+            await asyncio.sleep(wait)
+
+    @staticmethod
+    def _age(entry: _CacheEntry | None, now: float) -> float | None:
+        return None if entry is None else now - entry.stored_at
+
+    async def fetch(
+        self,
+        path: str,
+        params: dict[str, Any],
+        *,
+        policy: FinnhubPolicy | None = None,
+    ) -> tuple[Any, str]:
+        selected = policy or policy_for(path)
+        key = self._key(path, params)
+        now = time.monotonic()
+        cached = self._cache.get(key)
+        age = self._age(cached, now)
+        if cached is not None and age is not None and age <= selected.ttl_seconds:
+            return cached.value, "CACHE:FRESH"
+
+        lock = self._key_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            now = time.monotonic()
+            cached = self._cache.get(key)
+            age = self._age(cached, now)
+            if cached is not None and age is not None and age <= selected.ttl_seconds:
+                return cached.value, "CACHE:FRESH"
+
+            if now < self._cooldown_until:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, "CACHE:STALE:RATE_LIMIT"
+                retry_after = max(1, int(self._cooldown_until - now))
+                raise HTTPException(status_code=429, detail=f"Finnhub cooling down; retry in ~{retry_after}s")
+
+            await self._throttle()
+            headers = {"X-Finnhub-Token": self._token(), "Accept": "application/json"}
+            timeout = httpx.Timeout(20.0, connect=10.0)
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    response = await client.get(f"{FINNHUB_BASE_URL}{path}", params=params, headers=headers)
+            except httpx.RequestError as exc:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, f"CACHE:STALE:{exc.__class__.__name__}"
+                raise HTTPException(status_code=502, detail=f"Finnhub connection failed: {exc.__class__.__name__}") from exc
+
+            if response.status_code == 429:
+                retry_header = response.headers.get("retry-after")
+                try:
+                    retry_seconds = max(2.0, float(retry_header)) if retry_header else 5.0
+                except ValueError:
+                    retry_seconds = 5.0
+                self._cooldown_until = time.monotonic() + min(retry_seconds, 60.0)
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, "CACHE:STALE:429"
+                raise HTTPException(status_code=429, detail="Finnhub rate limit reached")
+
+            if response.status_code >= 500:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, f"CACHE:STALE:HTTP_{response.status_code}"
+                raise HTTPException(status_code=502, detail=f"Finnhub upstream HTTP {response.status_code}")
+            if response.status_code >= 400:
+                raise HTTPException(status_code=502, detail=f"Finnhub upstream HTTP {response.status_code}")
+
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                if cached is not None and age is not None and age <= selected.stale_seconds:
+                    return cached.value, "CACHE:STALE:NON_JSON"
+                raise HTTPException(status_code=502, detail="Finnhub returned non-JSON data") from exc
+
+            self._cache[key] = _CacheEntry(stored_at=time.monotonic(), value=payload)
+            return payload, "LIVE"
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._cooldown_until = 0.0
+
+
+finnhub_client = FinnhubResilientClient()
+
+
+async def finnhub_get(path: str, params: dict[str, Any]) -> Any:
+    payload, _ = await finnhub_client.fetch(path, params)
+    return payload
+
+
+async def finnhub_optional(path: str, params: dict[str, Any]) -> tuple[Any, str]:
+    try:
+        return await finnhub_client.fetch(path, params)
+    except HTTPException as exc:
+        return None, f"UNAVAILABLE:{exc.status_code}"

--- a/api/test_trading212_v2.py
+++ b/api/test_trading212_v2.py
@@ -34,23 +34,31 @@ def test_live_execution_is_locked_by_default(monkeypatch):
     monkeypatch.setattr(broker, "TRADING212_ENV", "live")
     monkeypatch.setattr(broker, "TRADING212_LIVE_TRADING_ENABLED", False)
     with pytest.raises(HTTPException) as exc:
-        broker._require_order_permission("EXECUTE_LIVE")
+        broker._require_order_permission("EXECUTE_LIVE", "market")
     assert exc.value.status_code == 403
+
+
+def test_live_non_market_orders_fail_closed(monkeypatch):
+    monkeypatch.setattr(broker, "TRADING212_ENV", "live")
+    monkeypatch.setattr(broker, "TRADING212_LIVE_TRADING_ENABLED", True)
+    with pytest.raises(HTTPException) as exc:
+        broker._require_order_permission("EXECUTE_LIVE", "limit")
+    assert exc.value.status_code == 403
+    broker._require_order_permission("EXECUTE_LIVE", "market")
 
 
 def test_demo_requires_demo_confirmation(monkeypatch):
     monkeypatch.setattr(broker, "TRADING212_ENV", "demo")
     with pytest.raises(HTTPException) as exc:
-        broker._require_order_permission("EXECUTE_LIVE")
+        broker._require_order_permission("EXECUTE_LIVE", "market")
     assert exc.value.status_code == 400
 
 
-def test_history_next_page_path_is_restricted_to_t212_history():
-    path, params = broker._next_page_request(
+def test_history_next_page_path_is_preserved_literal():
+    path = broker._next_page_request(
         "/api/v0/equity/history/orders?limit=20&cursor=1760346100000"
     )
-    assert path == "/equity/history/orders"
-    assert params == {"limit": "20", "cursor": "1760346100000"}
+    assert path == "/equity/history/orders?limit=20&cursor=1760346100000"
 
     with pytest.raises(HTTPException):
         broker._next_page_request("https://evil.example/api/v0/equity/history/orders?limit=20")
@@ -65,3 +73,34 @@ def test_duplicate_order_request_id_is_blocked(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         broker._register_order_request_id("request-123456")
     assert exc.value.status_code == 409
+
+
+def test_preview_sell_is_negative_and_never_executes(monkeypatch):
+    monkeypatch.setattr(broker, "TRADING212_ENV", "demo")
+    request = broker.OrderPreviewRequest(orderType="market", ticker="AAPL_US_EQ", quantity=-2)
+    preview = broker._build_preview(
+        request,
+        {"ticker": "AAPL_US_EQ", "name": "Apple", "currencyCode": "USD"},
+    )
+    assert preview["side"] == "SELL"
+    assert preview["previewOnly"] is True
+    assert preview["willExecute"] is False
+    assert preview["upstreamPayload"]["quantity"] == -2
+
+
+def test_reconcile_flags_missing_expected():
+    positions = [
+        {
+            "quantity": 2,
+            "currentPrice": 100,
+            "averagePricePaid": 80,
+            "instrument": {"ticker": "AAPL_US_EQ", "name": "Apple", "currencyCode": "USD"},
+            "walletImpact": {"currentValue": 200, "unrealizedProfitLoss": 40},
+        }
+    ]
+    account = {"currency": "EUR", "totalValue": 500, "investments": {"currentValue": 200}}
+    output = broker._reconcile_positions(positions, account, ["AAPL", "MSFT"])
+    assert output["holdingCount"] == 1
+    assert output["holdings"][0]["symbol"] == "AAPL"
+    assert output["holdings"][0]["weight"] == 1.0
+    assert output["missingExpected"] == ["MSFT"]

--- a/api/trading212_v2.py
+++ b/api/trading212_v2.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import hmac
 import os
 import time
 from typing import Any, Literal
-from urllib.parse import parse_qsl, urlsplit
+from urllib.parse import urlsplit
 
 import httpx
 from fastapi import APIRouter, Header, HTTPException, Query
@@ -30,9 +31,12 @@ _INSTRUMENT_CACHE: tuple[float, list[dict[str, Any]]] = (0.0, [])
 _INSTRUMENT_CACHE_TTL_SECONDS = 900
 _ORDER_REQUEST_IDS: dict[str, float] = {}
 _ORDER_REQUEST_ID_TTL_SECONDS = 300
+_RATE_LIMIT_READY_AT: dict[str, float] = {}
+_RATE_LIMIT_MAX_AUTO_WAIT_SECONDS = 3.0
 
 TimeValidity = Literal["DAY", "GOOD_TILL_CANCEL"]
 OrderConfirmation = Literal["EXECUTE_DEMO", "EXECUTE_LIVE"]
+OrderType = Literal["market", "limit", "stop", "stop_limit"]
 
 
 class MarketOrderRequest(BaseModel):
@@ -71,6 +75,20 @@ class StopLimitOrderRequest(BaseModel):
     clientRequestId: str = Field(min_length=8, max_length=128)
 
 
+class OrderPreviewRequest(BaseModel):
+    orderType: OrderType = "market"
+    ticker: str = Field(min_length=1, max_length=64)
+    quantity: float
+    extendedHours: bool = False
+    limitPrice: float | None = Field(default=None, gt=0)
+    stopPrice: float | None = Field(default=None, gt=0)
+    timeValidity: TimeValidity = "DAY"
+
+
+class ReconcileRequest(BaseModel):
+    expectedTickers: list[str] = Field(default_factory=list, max_length=250)
+
+
 def _credentials_configured() -> bool:
     return bool(TRADING212_API_KEY and TRADING212_API_SECRET)
 
@@ -91,7 +109,7 @@ def _require_control_token(token: str | None) -> None:
         raise HTTPException(status_code=401, detail="Invalid ATLAS broker control token")
 
 
-def _require_order_permission(confirmation: OrderConfirmation) -> None:
+def _require_order_permission(confirmation: OrderConfirmation, order_type: OrderType = "market") -> None:
     expected: OrderConfirmation = "EXECUTE_LIVE" if TRADING212_ENV == "live" else "EXECUTE_DEMO"
     if confirmation != expected:
         raise HTTPException(status_code=400, detail=f"confirmation must be {expected} for this environment")
@@ -99,6 +117,11 @@ def _require_order_permission(confirmation: OrderConfirmation) -> None:
         raise HTTPException(
             status_code=403,
             detail="Live Trading 212 execution is locked server-side. Paper validation must be completed before enabling live trading.",
+        )
+    if TRADING212_ENV == "live" and order_type != "market":
+        raise HTTPException(
+            status_code=403,
+            detail="ATLAS blocks non-market live orders until the current Trading 212 live OpenAPI contract is explicitly re-certified.",
         )
 
 
@@ -125,15 +148,14 @@ def _normalize_upstream_path(path: str) -> str:
     return value
 
 
-def _next_page_request(next_page_path: str) -> tuple[str, dict[str, str]]:
-    parsed = urlsplit(next_page_path.strip())
+def _next_page_request(next_page_path: str) -> str:
+    value = next_page_path.strip()
+    parsed = urlsplit(value)
     if parsed.scheme or parsed.netloc or parsed.fragment:
         raise HTTPException(status_code=400, detail="nextPagePath must be a relative Trading 212 API path")
     if not parsed.path.startswith("/api/v0/equity/history/"):
         raise HTTPException(status_code=400, detail="nextPagePath is outside the Trading 212 history API")
-    path = _normalize_upstream_path(parsed.path)
-    params = {key: value for key, value in parse_qsl(parsed.query, keep_blank_values=False)}
-    return path, params
+    return _normalize_upstream_path(value)
 
 
 def _rate_limit_headers(headers: httpx.Headers) -> dict[str, str | None]:
@@ -144,6 +166,47 @@ def _rate_limit_headers(headers: httpx.Headers) -> dict[str, str | None]:
         "reset": headers.get("x-ratelimit-reset"),
         "used": headers.get("x-ratelimit-used"),
     }
+
+
+def _parse_reset_epoch(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        stamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    if stamp > 10_000_000_000:
+        stamp /= 1000.0
+    return stamp
+
+
+def _update_rate_limit_state(key: str, rate: dict[str, str | None]) -> None:
+    if rate.get("remaining") != "0":
+        return
+    reset = _parse_reset_epoch(rate.get("reset"))
+    if reset:
+        _RATE_LIMIT_READY_AT[key] = reset
+
+
+async def _respect_rate_limit(key: str) -> None:
+    ready_at = _RATE_LIMIT_READY_AT.get(key)
+    if not ready_at:
+        return
+    wait_seconds = ready_at - time.time()
+    if wait_seconds <= 0:
+        _RATE_LIMIT_READY_AT.pop(key, None)
+        return
+    if wait_seconds <= _RATE_LIMIT_MAX_AUTO_WAIT_SECONDS:
+        await asyncio.sleep(wait_seconds)
+        _RATE_LIMIT_READY_AT.pop(key, None)
+        return
+    raise HTTPException(
+        status_code=429,
+        detail={
+            "message": "Trading 212 account rate limit is cooling down",
+            "retryAfterSeconds": round(wait_seconds, 3),
+        },
+    )
 
 
 async def _request(
@@ -157,6 +220,8 @@ async def _request(
         raise HTTPException(status_code=503, detail="Trading 212 API key pair is not configured on the server")
 
     normalized_path = _normalize_upstream_path(path)
+    route_key = f"{method.upper()}:{urlsplit(normalized_path).path}"
+    await _respect_rate_limit(route_key)
     headers = {
         "Authorization": _auth_header(),
         "Accept": "application/json",
@@ -177,8 +242,18 @@ async def _request(
         raise HTTPException(status_code=502, detail=f"Trading 212 connection failed: {exc.__class__.__name__}") from exc
 
     rate = _rate_limit_headers(response.headers)
+    _update_rate_limit_state(route_key, rate)
     if response.status_code == 429:
-        raise HTTPException(status_code=429, detail={"message": "Trading 212 rate limit reached", "rateLimit": rate})
+        reset = _parse_reset_epoch(rate.get("reset"))
+        retry_after = max(0.0, reset - time.time()) if reset else None
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "message": "Trading 212 rate limit reached",
+                "retryAfterSeconds": round(retry_after, 3) if retry_after is not None else None,
+                "rateLimit": rate,
+            },
+        )
     if response.status_code >= 400:
         try:
             upstream = response.json()
@@ -218,6 +293,146 @@ def _envelope(data: Any, rate: dict[str, str | None]) -> dict[str, Any]:
     }
 
 
+def _canonical_symbol(instrument: dict[str, Any]) -> str:
+    ticker = str(instrument.get("ticker") or "").strip().upper()
+    if not ticker:
+        return ""
+    return ticker.split("_", 1)[0]
+
+
+def _position_account_value(position: dict[str, Any]) -> float | None:
+    wallet = position.get("walletImpact")
+    if isinstance(wallet, dict):
+        for key in ("currentValue", "value", "marketValue"):
+            value = wallet.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+        total_cost = wallet.get("totalCost")
+        upl = wallet.get("unrealizedProfitLoss")
+        if isinstance(total_cost, (int, float)) and isinstance(upl, (int, float)):
+            return float(total_cost) + float(upl)
+    return None
+
+
+def _reconcile_positions(
+    positions_data: Any,
+    account_data: Any,
+    expected_tickers: list[str],
+) -> dict[str, Any]:
+    rows = positions_data if isinstance(positions_data, list) else []
+    account = account_data if isinstance(account_data, dict) else {}
+    account_currency = account.get("currency")
+    holdings: list[dict[str, Any]] = []
+    observed_symbols: set[str] = set()
+    known_account_values: list[float] = []
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        instrument = row.get("instrument") if isinstance(row.get("instrument"), dict) else {}
+        t212_ticker = str(instrument.get("ticker") or row.get("ticker") or "").strip()
+        symbol = _canonical_symbol(instrument) or (t212_ticker.split("_", 1)[0].upper() if t212_ticker else "")
+        if symbol:
+            observed_symbols.add(symbol)
+        account_value = _position_account_value(row)
+        if account_value is not None:
+            known_account_values.append(account_value)
+        quantity = row.get("quantity")
+        current_price = row.get("currentPrice")
+        instrument_value = None
+        if isinstance(quantity, (int, float)) and isinstance(current_price, (int, float)):
+            instrument_value = float(quantity) * float(current_price)
+        wallet = row.get("walletImpact") if isinstance(row.get("walletImpact"), dict) else {}
+        holdings.append(
+            {
+                "symbol": symbol,
+                "trading212Ticker": t212_ticker,
+                "name": instrument.get("name") or instrument.get("shortName"),
+                "isin": instrument.get("isin"),
+                "instrumentCurrency": instrument.get("currencyCode"),
+                "accountCurrency": account_currency,
+                "quantity": quantity,
+                "quantityAvailableForTrading": row.get("quantityAvailableForTrading"),
+                "quantityInPies": row.get("quantityInPies"),
+                "averagePricePaid": row.get("averagePricePaid"),
+                "currentPrice": current_price,
+                "instrumentMarketValue": instrument_value,
+                "accountMarketValue": account_value,
+                "unrealizedProfitLoss": wallet.get("unrealizedProfitLoss"),
+                "weight": None,
+            }
+        )
+
+    total_known_value = sum(known_account_values)
+    if total_known_value:
+        for holding in holdings:
+            value = holding.get("accountMarketValue")
+            if isinstance(value, (int, float)):
+                holding["weight"] = float(value) / total_known_value
+
+    expected = [ticker.strip().upper() for ticker in expected_tickers if ticker and ticker.strip()]
+    expected_set = set(expected)
+    missing = [ticker for ticker in expected if ticker not in observed_symbols]
+    unexpected = sorted(symbol for symbol in observed_symbols if expected and symbol not in expected_set)
+    holdings.sort(key=lambda item: (item.get("weight") is None, -(item.get("weight") or 0), item.get("symbol") or ""))
+
+    investments = account.get("investments") if isinstance(account.get("investments"), dict) else {}
+    return {
+        "accountCurrency": account_currency,
+        "accountTotalValue": account.get("totalValue"),
+        "investmentsCurrentValue": investments.get("currentValue"),
+        "holdings": holdings,
+        "holdingCount": len(holdings),
+        "expectedTickers": expected,
+        "missingExpected": missing,
+        "unexpectedHeld": unexpected,
+        "weightBasis": "walletImpact-account-currency" if total_known_value else "unavailable",
+        "weightsComplete": bool(holdings) and all(item.get("weight") is not None for item in holdings),
+    }
+
+
+def _build_preview(order: OrderPreviewRequest, instrument: dict[str, Any]) -> dict[str, Any]:
+    if order.quantity == 0:
+        raise HTTPException(status_code=400, detail="quantity must be non-zero")
+    if order.orderType in ("limit", "stop_limit") and order.limitPrice is None:
+        raise HTTPException(status_code=400, detail="limitPrice is required for limit and stop_limit previews")
+    if order.orderType in ("stop", "stop_limit") and order.stopPrice is None:
+        raise HTTPException(status_code=400, detail="stopPrice is required for stop and stop_limit previews")
+    if TRADING212_ENV == "live" and order.orderType != "market":
+        live_compatibility = "BLOCKED_PENDING_LIVE_OPENAPI_RECERTIFICATION"
+    else:
+        live_compatibility = "ALLOWED_BY_ATLAS_GATE"
+    payload: dict[str, Any] = {
+        "ticker": str(instrument.get("ticker") or order.ticker).strip(),
+        "quantity": order.quantity,
+    }
+    if order.orderType == "market":
+        payload["extendedHours"] = order.extendedHours
+    if order.limitPrice is not None and order.orderType in ("limit", "stop_limit"):
+        payload["limitPrice"] = order.limitPrice
+    if order.stopPrice is not None and order.orderType in ("stop", "stop_limit"):
+        payload["stopPrice"] = order.stopPrice
+    if order.orderType != "market":
+        payload["timeValidity"] = order.timeValidity
+    return {
+        "previewOnly": True,
+        "willExecute": False,
+        "environment": TRADING212_ENV,
+        "orderType": order.orderType,
+        "side": "SELL" if order.quantity < 0 else "BUY",
+        "instrument": {
+            "ticker": instrument.get("ticker"),
+            "name": instrument.get("name") or instrument.get("shortName"),
+            "isin": instrument.get("isin"),
+            "currencyCode": instrument.get("currencyCode"),
+            "type": instrument.get("type"),
+        },
+        "upstreamPayload": payload,
+        "liveCompatibility": live_compatibility,
+        "nextStep": "EXECUTE_DEMO" if TRADING212_ENV == "demo" else "EXECUTE_LIVE",
+    }
+
+
 @router.get("/status")
 async def status() -> dict[str, Any]:
     return {
@@ -234,6 +449,8 @@ async def status() -> dict[str, Any]:
         "guardrails": [
             "Trading 212 credentials remain server-side and are never embedded in the APK.",
             "Demo is the default environment.",
+            "Portfolio reconciliation is read-only and cannot execute orders.",
+            "Preview never sends an order to Trading 212.",
             "Live orders require server-side live enablement plus EXECUTE_LIVE on every request.",
             "Every order requires a unique clientRequestId because Trading 212 beta order endpoints are not idempotent.",
             "Positive quantity buys; negative quantity sells.",
@@ -257,6 +474,21 @@ async def positions(
     params = {"ticker": ticker.strip()} if ticker and ticker.strip() else None
     data, rate = await _request("GET", "/equity/positions", params=params)
     return _envelope(data, rate)
+
+
+@router.post("/portfolio/reconcile")
+async def reconcile_portfolio(
+    request: ReconcileRequest,
+    x_atlas_broker_token: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _require_control_token(x_atlas_broker_token)
+    positions_data, positions_rate = await _request("GET", "/equity/positions")
+    account_data, account_rate = await _request("GET", "/equity/account/summary")
+    data = _reconcile_positions(positions_data, account_data, request.expectedTickers)
+    result = _envelope(data, positions_rate)
+    result["rateLimits"] = {"positions": positions_rate, "account": account_rate}
+    result["readOnly"] = True
+    return result
 
 
 @router.get("/orders")
@@ -311,6 +543,32 @@ async def instrument_search(
             break
     payload = {"query": q.strip(), "count": len(matches), "items": matches}
     return _envelope(payload, rate)
+
+
+@router.post("/orders/preview")
+async def preview_order(
+    order: OrderPreviewRequest,
+    x_atlas_broker_token: str | None = Header(default=None),
+) -> dict[str, Any]:
+    _require_control_token(x_atlas_broker_token)
+    instruments_data, rate = await _get_instruments_cached()
+    requested = order.ticker.strip().upper()
+    exact = [item for item in instruments_data if str(item.get("ticker") or "").upper() == requested]
+    if not exact:
+        candidates = [item for item in instruments_data if _canonical_symbol(item) == requested]
+        if len(candidates) == 1:
+            exact = candidates
+        elif len(candidates) > 1:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "Ticker is ambiguous in Trading 212 metadata; use the exact Trading 212 ticker",
+                    "candidates": [item.get("ticker") for item in candidates[:20]],
+                },
+            )
+    if not exact:
+        raise HTTPException(status_code=404, detail="Ticker not found in Trading 212 instrument metadata")
+    return _envelope(_build_preview(order, exact[0]), rate)
 
 
 @router.get("/history/orders")
@@ -370,8 +628,8 @@ async def history_next(
     x_atlas_broker_token: str | None = Header(default=None),
 ) -> dict[str, Any]:
     _require_control_token(x_atlas_broker_token)
-    path, params = _next_page_request(nextPagePath)
-    data, rate = await _request("GET", path, params=params)
+    path = _next_page_request(nextPagePath)
+    data, rate = await _request("GET", path)
     return _envelope(data, rate)
 
 
@@ -383,7 +641,10 @@ async def _place_order(
     control_token: str | None,
 ) -> dict[str, Any]:
     _require_control_token(control_token)
-    _require_order_permission(confirmation)
+    order_type = endpoint.rsplit("/", 1)[-1]
+    if order_type not in {"market", "limit", "stop", "stop_limit"}:
+        raise HTTPException(status_code=400, detail="Unsupported order type")
+    _require_order_permission(confirmation, order_type)  # type: ignore[arg-type]
     if not body.get("ticker") or body.get("quantity") == 0:
         raise HTTPException(status_code=400, detail="ticker and non-zero quantity are required")
     _register_order_request_id(client_request_id)
@@ -391,7 +652,7 @@ async def _place_order(
     result = _envelope(data, rate)
     result["audit"] = {
         "clientRequestIdHash": hashlib.sha256(client_request_id.encode("utf-8")).hexdigest()[:16],
-        "orderType": endpoint.rsplit("/", 1)[-1].upper(),
+        "orderType": order_type.upper(),
         "ticker": body.get("ticker"),
         "quantity": body.get("quantity"),
     }

--- a/docs/2026-08-11-provider-key-cutover.md
+++ b/docs/2026-08-11-provider-key-cutover.md
@@ -1,0 +1,48 @@
+# ATLAS Ω — Provider key cutover checklist
+
+Use only after the paid market-data plan and Trading 212 read-only key exist.
+
+## Server variables
+
+Configure on the backend environment only:
+
+- `FINNHUB_TOKEN=<paid token>`
+- `FINNHUB_MAX_CALLS_PER_SECOND=20`
+- `TRADING212_ENV=live`
+- `TRADING212_API_KEY=<read-only live key>`
+- `TRADING212_API_SECRET=<matching secret>`
+- `ATLAS_T212_SYMBOL_OVERRIDES={}` initially
+- `TRADING212_LIVE_TRADING_ENABLED=false`
+
+Do not configure `ATLAS_BROKER_CONTROL_TOKEN` for this read-only rollout.
+
+## First live checks before any mobile promotion
+
+1. `GET /health` -> backend online.
+2. `GET /v1/portfolio/status` -> `environment=live`, `configured=true`, `readOnly=true`.
+3. `GET /v1/portfolio/live` -> position count and values match Trading 212.
+4. Record every `analysisSymbolStatus=NEEDS_VERIFIED_MAPPING` instrument.
+5. Resolve those instruments using Trading 212 ticker + ISIN + exchange metadata; add only verified mappings to `ATLAS_T212_SYMBOL_OVERRIDES`.
+6. `GET /v1/mobile/universe` -> `portfolioMeta.provider=Trading212` and watchlist remains independent.
+7. Analyze portfolio in pages of at most eight via `/v1/mobile/monitor/portfolio`.
+8. Analyze the phone's editable watchlist in pages of at most eight via `/v1/mobile/analyze-symbols?context=watchlist`.
+9. Re-run pages to confirm Finnhub cache/dedupe prevents a request storm and valid data survives 429 as stale-last-good.
+10. Verify `/v1/market/history/{symbol}`, `/v1/market/rotation`, and `/v1/market/dislocation` before enabling their new mobile client paths.
+
+## Mobile promotion
+
+Only after the backend checks pass:
+
+- switch portfolio source to `AtlasPremiumSyncApi.universe()` / `monitor('portfolio')`;
+- keep local SQLite watchlist identity and analyze current local symbols with `AtlasPremiumSyncApi.analyzeSymbols()`;
+- switch historical chart and Radar to the premium sync methods;
+- preserve old v0.4 fallback during staged rollout;
+- build release APK;
+- inspect compiled APK for provider credentials (must be none);
+- run Android emulator ONLINE gate;
+- compare portfolio count and representative values with Trading 212;
+- merge PR #45 only after all gates pass.
+
+## Rollback
+
+If any mismatch, credential issue, wrong international mapping, provider blanking or OFFLINE regression appears, keep the certified existing APK/main and roll back the backend candidate. No portfolio mutation or order placement is part of this rollout.

--- a/docs/BROKER_OMEGA_TRADING212.md
+++ b/docs/BROKER_OMEGA_TRADING212.md
@@ -2,55 +2,78 @@
 
 ATLAS Ω keeps broker credentials server-side. The Android APK never contains the Trading 212 API key or secret.
 
-## Current implementation — 16 Aug 2026
+## Canonical architecture — 16 Aug 2026
 
-The clean mobile runtime now exposes an isolated Trading 212 bridge under:
+The isolated mobile runtime is:
 
-- `/v1/mobile/broker/*`
+`Trading212Adapter -> Account + Instruments + Positions + Orders + History`
 
-The legacy `/v1/broker/*` routes remain available for compatibility, but new APK work should use the isolated mobile contract.
+`Portfolio Reconciler -> canonical tickers <-> Trading 212 ticker IDs -> holdings -> P/L -> weights`
 
-The implementation follows the Trading 212 Public API v0 beta contract:
+`Execution Service -> Preview -> Demo -> Live`
+
+Analysis and execution are deliberately separated. No ATLAS signal, score, recommendation, rotation engine or portfolio optimizer is allowed to call an order endpoint directly.
+
+The mobile broker bridge lives under `/v1/mobile/broker/*`. Legacy `/v1/broker/*` routes remain only for compatibility; new APK work must use the isolated mobile contract.
+
+## Upstream contract
+
+Current Trading 212 Public API v0 beta integration uses:
 
 - Demo: `https://demo.trading212.com/api/v0`
 - Live: `https://live.trading212.com/api/v0`
 - HTTP Basic authentication from `API_KEY:API_SECRET`.
-- Invest / Stocks ISA only.
-- Orders are quantity-based and execute only in the primary account currency.
+- `GET /equity/account/summary` for account state.
+- `GET /equity/positions` for current positions.
+- `GET /equity/metadata/instruments` and exchanges for instrument resolution.
+- Orders under `/equity/orders/*`.
+- History under `/equity/history/*`.
 - Positive quantity = buy; negative quantity = sell.
-- Historical list endpoints use cursor pagination and the upstream `nextPagePath` contract.
-- Pies are intentionally not integrated because the current Pies API is deprecated.
+- Orders execute only in the primary account currency; API multi-currency execution is not assumed.
 
-## Default mode
+### Portfolio endpoint compatibility
 
-The repository defaults to Trading 212 **demo/paper**:
+An older official Trading 212 reference exposed a `Personal Portfolio` block under `/equity/portfolio`. The newer reference exposes `/equity/positions` as the current positions surface. ATLAS therefore does **not** make the core reconciler depend on the older Personal Portfolio contract.
+
+If Trading 212 later re-certifies `/equity/portfolio` in the current OpenAPI schema, it can be added behind a compatibility adapter without changing the app-level reconciler contract.
+
+### Pies
+
+Pies are not part of the canonical integration. Trading 212 marks the Pies API deprecated. Any future compatibility support must live behind an isolated `LegacyPiesAdapter` and must never become a dependency of portfolio reconciliation or execution.
+
+## Default mode and live fail-closed policy
+
+Repository defaults:
 
 - `TRADING212_ENV=demo`
 - `TRADING212_LIVE_TRADING_ENABLED=false`
 
-Live execution is therefore fail-closed.
+Live execution therefore fails closed.
+
+Trading 212 beta documentation has shown inconsistent wording across revisions regarding non-market live orders. ATLAS consequently blocks limit, stop and stop-limit orders in live until the current live OpenAPI contract is explicitly re-certified. Demo can exercise all exposed order shapes.
 
 ## Required Render secrets
 
-Configure these as server-side secrets in Render:
+Configure server-side only:
 
-- `FINANCIALDATANET_API_KEY` — market/fundamental data provider used by the mobile app.
-- `TRADING212_API_KEY` — Trading 212 API key.
-- `TRADING212_API_SECRET` — Trading 212 API secret.
-- `ATLAS_BROKER_CONTROL_TOKEN` — a long random token used to authorize private broker calls.
+- `FINANCIALDATANET_API_KEY`
+- `TRADING212_API_KEY`
+- `TRADING212_API_SECRET`
+- `ATLAS_BROKER_CONTROL_TOKEN`
 
-`render.yaml` declares all of these as `sync: false`; their values must never be committed to Git or embedded in Expo public variables.
+`render.yaml` declares secrets as `sync: false`. Never commit their values or expose them through Expo public variables.
 
 ## Read-only broker contract
 
-Public status only:
+Public status:
 
 - `GET /v1/mobile/broker/status`
 
-Control-token protected (`X-Atlas-Broker-Token`):
+Control-token protected:
 
 - `GET /v1/mobile/broker/account`
 - `GET /v1/mobile/broker/positions?ticker=...`
+- `POST /v1/mobile/broker/portfolio/reconcile`
 - `GET /v1/mobile/broker/orders`
 - `GET /v1/mobile/broker/orders/{id}`
 - `GET /v1/mobile/broker/metadata/exchanges`
@@ -61,13 +84,35 @@ Control-token protected (`X-Atlas-Broker-Token`):
 - `GET /v1/mobile/broker/history/transactions?limit=...&cursor=...&time=...`
 - `GET /v1/mobile/broker/history/next?nextPagePath=...`
 
-`history/next` only accepts relative paths under `/api/v0/equity/history/`; arbitrary hosts and non-history paths are rejected.
+`portfolio/reconcile` is read-only. It combines current positions and account summary, preserves Trading 212 internal tickers, derives canonical symbols, surfaces quantity/current price/P&L fields where available, computes account-currency weights only when the upstream wallet-impact data makes them safe, and reports `missingExpected` / `unexpectedHeld` against a supplied canonical ticker list.
 
-The upstream Trading 212 rate-limit headers are returned to the client as `rateLimit.limit`, `period`, `remaining`, `reset`, and `used`.
+## Pagination rule
 
-## Order contract — prepared, not live-enabled
+For historical collections ATLAS follows Trading 212's `nextPagePath` literally. The bridge validates that it is a relative `/api/v0/equity/history/...` path and then forwards the complete returned query string without reconstructing the cursor.
 
-All order routes are protected by the broker control token and require an explicit environment confirmation.
+## Rate-limit discipline
+
+Trading 212 applies rate limits per account. ATLAS reads and returns:
+
+- `x-ratelimit-limit`
+- `x-ratelimit-period`
+- `x-ratelimit-remaining`
+- `x-ratelimit-reset`
+- `x-ratelimit-used`
+
+The backend also records endpoint cooldowns. If a reset is only a few seconds away it waits automatically; longer cooldowns fail fast with HTTP 429 and a retry-after value instead of consuming the mobile request timeout. Order POSTs are never blindly retried.
+
+## Execution contract
+
+### Preview
+
+`POST /v1/mobile/broker/orders/preview`
+
+Preview resolves the instrument against Trading 212 metadata and returns the exact proposed upstream payload, BUY/SELL direction, environment and compatibility state. It **never calls a Trading 212 order POST**.
+
+### Demo and Live execution
+
+Execution routes:
 
 - `POST /v1/mobile/broker/orders/market`
 - `POST /v1/mobile/broker/orders/limit`
@@ -75,68 +120,54 @@ All order routes are protected by the broker control token and require an explic
 - `POST /v1/mobile/broker/orders/stop_limit`
 - `DELETE /v1/mobile/broker/orders/{id}`
 
-Order requests require:
+Every order requires:
 
-- exact Trading 212 instrument ticker, e.g. `AAPL_US_EQ`;
+- exact Trading 212 instrument ticker;
 - non-zero quantity;
+- negative quantity for sells;
 - `EXECUTE_DEMO` in demo or `EXECUTE_LIVE` in live;
-- a unique `clientRequestId`.
+- a fresh `clientRequestId`;
+- valid ATLAS broker control token.
 
-Trading 212 states that its beta order endpoints are not idempotent. ATLAS hashes and holds recent `clientRequestId` values for five minutes and returns HTTP 409 for a duplicate request, reducing accidental double submission caused by repeated taps/retries.
+Live additionally requires `TRADING212_LIVE_TRADING_ENABLED=true`. The server kill-switch and per-request confirmation are independent gates.
 
-This local guard is an additional safety layer, not a substitute for server-side order reconciliation.
+ATLAS hashes recent `clientRequestId` values and rejects duplicates for five minutes to reduce accidental repeated submission.
 
-## Paper activation
+## Tomorrow connection procedure — 17 Aug 2026
 
-1. Create Trading 212 demo API credentials with the minimum permissions needed.
-2. Set `TRADING212_API_KEY`, `TRADING212_API_SECRET`, and `ATLAS_BROKER_CONTROL_TOKEN` in Render.
-3. Keep `TRADING212_ENV=demo` and `TRADING212_LIVE_TRADING_ENABLED=false`.
-4. Deploy the API.
-5. Confirm `/v1/mobile/broker/status` reports `readReady=true` and `mode=PAPER`.
-6. Sync account / positions / orders.
-7. Resolve every security through Trading 212 instrument metadata rather than assuming ticker formatting.
-8. Validate paper orders and cancellation before any consideration of live enablement.
+When the real portfolio is ready:
 
-## Live activation
+1. Keep Render in `TRADING212_ENV=demo` and `TRADING212_LIVE_TRADING_ENABLED=false`.
+2. Add the Trading 212 **demo** `API Key` and `API Secret` plus an `ATLAS_BROKER_CONTROL_TOKEN` in Render.
+3. Deploy and verify `/v1/mobile/broker/status` returns `readReady=true`, `mode=PAPER`, and `liveTradingEnabled=false`.
+4. Fetch account and positions.
+5. Send the final canonical ticker list to `/portfolio/reconcile` and inspect ticker mapping, missing holdings, P/L and weights.
+6. Resolve every ambiguous security through metadata; never guess Trading 212 ticker IDs.
+7. Run order **preview** only.
+8. Place a deliberately small demo order with `EXECUTE_DEMO`, then reconcile orders/history/positions.
+9. Validate cancellation and duplicate-request protection.
+10. Leave live disabled until the full demo path is clean.
 
-Only after paper validation:
+Only after that validation should live credentials be installed. First validate live in read-only mode with the kill-switch still `false`; real execution is enabled deliberately and separately.
 
-1. Replace server credentials with live Trading 212 credentials.
-2. Set `TRADING212_ENV=live`.
-3. Keep `TRADING212_LIVE_TRADING_ENABLED=false` and validate read-only account/positions first.
-4. Deliberately set `TRADING212_LIVE_TRADING_ENABLED=true` only when real execution is intended.
-5. Every order still requires `EXECUTE_LIVE` and a fresh `clientRequestId`.
+## 24/5 and extended-hours discipline
 
-## 24/5 prices and extended-hours discipline
-
-Canonical portfolio execution policy:
-
-- Trading 212 `Precios 24/5`: OFF by default.
-- 24/5 prices are radar information, not a decision engine.
-- Structural portfolio construction should be executed primarily during regular market hours.
-- Extended-hours movement is not sufficient evidence for BUY or SELL.
-- Market orders during thin liquidity should be avoided; if an exceptional off-hours action is ever required, use explicit limit-price discipline and verify the catalyst/spread.
-
-## APK integration
-
-The mobile Settings screen calls only the public broker status route. It displays:
-
-- demo/live environment;
-- credential readiness;
-- control-token readiness;
-- read readiness;
-- live-order lock state.
-
-The APK contains neither FinancialData.Net nor Trading 212 upstream URLs or provider credentials. CI unpacks the release bundle and fails the build if direct FinancialData.Net or Trading 212 API endpoints leak into the APK.
+- Trading 212 24/5 prices are radar information, not an ATLAS decision engine.
+- Structural portfolio construction should normally execute during regular market hours.
+- Extended-hours movement alone is never sufficient evidence for BUY or SELL.
+- Thin-liquidity market orders should be avoided.
 
 ## Guardrails
 
-- Provider credentials remain server-side.
-- Demo is the default environment.
-- Live execution has an independent server-side kill switch.
-- Read endpoints carrying private portfolio/account information require the ATLAS control token.
-- Trading 212 rate-limit state is surfaced to the caller.
-- Upstream errors are surfaced rather than silently retried.
-- Order POSTs are never blindly retried.
-- Duplicate `clientRequestId` values are blocked locally for five minutes.
-- Pies are not built into new ATLAS code because Trading 212 marks that API deprecated.
+- Provider credentials stay server-side.
+- Demo is default.
+- Live has an independent server kill-switch.
+- Private broker data requires the ATLAS control token.
+- Portfolio reconciliation cannot execute orders.
+- Preview cannot execute orders.
+- Analysis engines cannot execute orders.
+- History pagination follows upstream `nextPagePath` literally.
+- Rate-limit state is surfaced and respected.
+- Order POSTs are never automatically retried.
+- Duplicate `clientRequestId` values are blocked locally.
+- Pies remain outside the canonical path.

--- a/mobile/core/api/brokerApi.ts
+++ b/mobile/core/api/brokerApi.ts
@@ -14,18 +14,51 @@ export type BrokerStatus = {
   guardrails: string[];
 };
 
+export type BrokerRateLimit = {
+  limit: string | null;
+  period: string | null;
+  remaining: string | null;
+  reset: string | null;
+  used: string | null;
+};
+
 export type BrokerEnvelope<T = unknown> = {
   provider: 'Trading212';
   environment: 'demo' | 'live';
   mode: 'PAPER' | 'LIVE';
   data: T;
-  rateLimit: {
-    limit: string | null;
-    period: string | null;
-    remaining: string | null;
-    reset: string | null;
-    used: string | null;
-  };
+  rateLimit: BrokerRateLimit;
+};
+
+export type ReconciledHolding = {
+  symbol: string;
+  trading212Ticker: string;
+  name?: string | null;
+  isin?: string | null;
+  instrumentCurrency?: string | null;
+  accountCurrency?: string | null;
+  quantity?: number | null;
+  quantityAvailableForTrading?: number | null;
+  quantityInPies?: number | null;
+  averagePricePaid?: number | null;
+  currentPrice?: number | null;
+  instrumentMarketValue?: number | null;
+  accountMarketValue?: number | null;
+  unrealizedProfitLoss?: number | null;
+  weight?: number | null;
+};
+
+export type PortfolioReconciliation = {
+  accountCurrency?: string | null;
+  accountTotalValue?: number | null;
+  investmentsCurrentValue?: number | null;
+  holdings: ReconciledHolding[];
+  holdingCount: number;
+  expectedTickers: string[];
+  missingExpected: string[];
+  unexpectedHeld: string[];
+  weightBasis: string;
+  weightsComplete: boolean;
 };
 
 export type MarketOrderInput = {
@@ -56,89 +89,60 @@ export type StopOrderInput = {
 
 export type StopLimitOrderInput = StopOrderInput & { limitPrice: number };
 
-const EMPTY_RATE: BrokerEnvelope['rateLimit'] = {
-  limit: null,
-  period: null,
-  remaining: null,
-  reset: null,
-  used: null,
+export type OrderPreviewInput = {
+  orderType: 'market' | 'limit' | 'stop' | 'stop_limit';
+  ticker: string;
+  quantity: number;
+  extendedHours?: boolean;
+  limitPrice?: number;
+  stopPrice?: number;
+  timeValidity?: 'DAY' | 'GOOD_TILL_CANCEL';
 };
 
-class ApiHttpError extends Error {
-  status: number;
-  payload: unknown;
+export type OrderPreview = {
+  previewOnly: true;
+  willExecute: false;
+  environment: 'demo' | 'live';
+  orderType: OrderPreviewInput['orderType'];
+  side: 'BUY' | 'SELL';
+  instrument: {
+    ticker?: string | null;
+    name?: string | null;
+    isin?: string | null;
+    currencyCode?: string | null;
+    type?: string | null;
+  };
+  upstreamPayload: Record<string, unknown>;
+  liveCompatibility: string;
+  nextStep: 'EXECUTE_DEMO' | 'EXECUTE_LIVE';
+};
 
-  constructor(message: string, status: number, payload: unknown) {
-    super(message);
-    this.name = 'ApiHttpError';
-    this.status = status;
-    this.payload = payload;
-  }
-}
-
-function row(value: unknown): Record<string, unknown> {
-  return value && typeof value === 'object' ? value as Record<string, unknown> : {};
-}
-
-function asText(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  return typeof value === 'string' ? value : String(value);
-}
-
-function environment(value: unknown): 'demo' | 'live' {
-  return typeof value === 'string' && value.toLowerCase() === 'live' ? 'live' : 'demo';
-}
-
-function mode(value: unknown, env: 'demo' | 'live'): 'PAPER' | 'LIVE' {
-  if (value === 'LIVE' || value === 'PAPER') return value;
-  return env === 'live' ? 'LIVE' : 'PAPER';
-}
-
-function errorDetail(payload: unknown, fallback: string): string {
-  const body = row(payload);
-  const detail = body.detail;
-  if (typeof detail === 'string') return detail;
-  if (detail && typeof detail === 'object') {
-    const nested = row(detail);
-    const message = nested.message ?? nested.error ?? nested.provider;
-    if (message) return `${fallback}: ${String(message)}`;
-  }
-  return fallback;
-}
-
-async function request<T>(path: string, init?: RequestInit, timeoutMs = 20000, fallbacks: string[] = []): Promise<T> {
-  const paths = [path, ...fallbacks];
-  let lastError: unknown = null;
-
-  for (const candidate of paths) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const response = await fetch(`${apiBaseUrl()}${candidate}`, {
-        ...init,
-        headers: {
-          accept: 'application/json',
-          ...(init?.body ? { 'content-type': 'application/json' } : {}),
-          ...(init?.headers || {}),
-        },
-        signal: controller.signal,
-      });
-      const payload: unknown = await response.json().catch(() => ({}));
-      if (!response.ok) {
-        throw new ApiHttpError(errorDetail(payload, `Trading 212 bridge HTTP ${response.status}`), response.status, payload);
-      }
-      return payload as T;
-    } catch (error) {
-      lastError = error;
-      if (!(error instanceof ApiHttpError && error.status === 404)) throw error;
-    } finally {
-      clearTimeout(timer);
+async function request<T>(path: string, init?: RequestInit, timeoutMs = 20000): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${apiBaseUrl()}${path}`, {
+      ...init,
+      headers: {
+        accept: 'application/json',
+        ...(init?.body ? { 'content-type': 'application/json' } : {}),
+        ...(init?.headers || {}),
+      },
+      signal: controller.signal,
+    });
+    const payload: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const row = payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+      const detail = typeof row.detail === 'string' ? row.detail : `Trading 212 bridge HTTP ${response.status}`;
+      throw new Error(detail);
     }
+    return payload as T;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') throw new Error('Trading 212 bridge no respondió a tiempo.');
+    throw error;
+  } finally {
+    clearTimeout(timer);
   }
-
-  if (lastError instanceof Error && lastError.name === 'AbortError') throw new Error('Trading 212 bridge no respondió a tiempo.');
-  if (lastError instanceof Error) throw lastError;
-  throw new Error('Trading 212 bridge no respondió.');
 }
 
 function controlHeaders(controlToken: string): HeadersInit {
@@ -147,71 +151,26 @@ function controlHeaders(controlToken: string): HeadersInit {
   return { 'x-atlas-broker-token': value };
 }
 
-function normalizeStatus(payload: unknown): BrokerStatus {
-  const data = row(payload);
-  const env = environment(data.environment);
-  const currentMode = mode(data.mode, env);
-  const legacyConfigured = data.configured === true;
-  const credentialsConfigured = data.credentialsConfigured === true || legacyConfigured;
-  const controlTokenConfigured = data.controlTokenConfigured === true || legacyConfigured;
-  const liveTradingEnabled = data.liveTradingEnabled === true;
-  const guardrails = Array.isArray(data.guardrails)
-    ? data.guardrails.filter((item): item is string => typeof item === 'string')
-    : typeof data.guardrail === 'string'
-      ? [data.guardrail]
-      : [];
-
-  return {
-    provider: 'Trading212',
-    apiVersion: typeof data.apiVersion === 'string' ? data.apiVersion : 'v0-beta-compat',
-    environment: env,
-    mode: currentMode,
-    credentialsConfigured,
-    controlTokenConfigured,
-    readReady: data.readReady === true || legacyConfigured,
-    liveTradingEnabled,
-    liveExecutionLocked: typeof data.liveExecutionLocked === 'boolean' ? data.liveExecutionLocked : !(env === 'live' && liveTradingEnabled),
-    secretsExposed: data.secretsExposed === true,
-    guardrails,
-  };
-}
-
-function normalizeEnvelope<T = unknown>(payload: unknown): BrokerEnvelope<T> {
-  const data = row(payload);
-  const env = environment(data.environment);
-  const rate = row(data.rateLimit);
-  const outputRate: BrokerEnvelope['rateLimit'] = {
-    limit: asText(rate.limit) ?? EMPTY_RATE.limit,
-    period: asText(rate.period) ?? EMPTY_RATE.period,
-    remaining: asText(rate.remaining) ?? EMPTY_RATE.remaining,
-    reset: asText(rate.reset) ?? EMPTY_RATE.reset,
-    used: asText(rate.used) ?? EMPTY_RATE.used,
-  };
-  return {
-    provider: 'Trading212',
-    environment: env,
-    mode: mode(data.mode, env),
-    data: (Object.prototype.hasOwnProperty.call(data, 'data') ? data.data : payload) as T,
-    rateLimit: outputRate,
-  };
-}
-
 export const BrokerApi = {
-  status: async () => normalizeStatus(await request<unknown>('/v1/mobile/broker/status', undefined, 12000, ['/v1/broker/status'])),
-  account: async (controlToken: string) => normalizeEnvelope(await request<unknown>('/v1/mobile/broker/account', { headers: controlHeaders(controlToken) }, 20000, ['/v1/broker/account'])),
-  positions: async (controlToken: string, ticker?: string) => {
-    const query = ticker ? `?ticker=${encodeURIComponent(ticker)}` : '';
-    return normalizeEnvelope(await request<unknown>(`/v1/mobile/broker/positions${query}`, { headers: controlHeaders(controlToken) }, 20000, [`/v1/broker/positions${query}`]));
-  },
-  orders: async (controlToken: string) => normalizeEnvelope(await request<unknown>('/v1/mobile/broker/orders', { headers: controlHeaders(controlToken) }, 20000, ['/v1/broker/orders'])),
-  instruments: async (controlToken: string, query: string) => {
-    const q = encodeURIComponent(query.trim());
-    return normalizeEnvelope(await request<unknown>(`/v1/mobile/broker/metadata/instruments/search?q=${q}`, { headers: controlHeaders(controlToken) }, 20000, [`/v1/broker/instruments/search?q=${q}`]));
-  },
+  status: () => request<BrokerStatus>('/v1/mobile/broker/status', undefined, 12000),
+  account: (controlToken: string) => request<BrokerEnvelope>('/v1/mobile/broker/account', { headers: controlHeaders(controlToken) }),
+  positions: (controlToken: string, ticker?: string) => request<BrokerEnvelope>(`/v1/mobile/broker/positions${ticker ? `?ticker=${encodeURIComponent(ticker)}` : ''}`, { headers: controlHeaders(controlToken) }),
+  reconcilePortfolio: (controlToken: string, expectedTickers: string[] = []) => request<BrokerEnvelope<PortfolioReconciliation>>('/v1/mobile/broker/portfolio/reconcile', {
+    method: 'POST',
+    headers: controlHeaders(controlToken),
+    body: JSON.stringify({ expectedTickers }),
+  }),
+  orders: (controlToken: string) => request<BrokerEnvelope>('/v1/mobile/broker/orders', { headers: controlHeaders(controlToken) }),
+  instruments: (controlToken: string, query: string) => request<BrokerEnvelope>(`/v1/mobile/broker/metadata/instruments/search?q=${encodeURIComponent(query.trim())}`, { headers: controlHeaders(controlToken) }),
   historyOrders: (controlToken: string, limit = 20) => request<BrokerEnvelope>(`/v1/mobile/broker/history/orders?limit=${Math.min(50, Math.max(1, limit))}`, { headers: controlHeaders(controlToken) }),
   historyDividends: (controlToken: string, limit = 20) => request<BrokerEnvelope>(`/v1/mobile/broker/history/dividends?limit=${Math.min(50, Math.max(1, limit))}`, { headers: controlHeaders(controlToken) }),
   historyTransactions: (controlToken: string, limit = 20) => request<BrokerEnvelope>(`/v1/mobile/broker/history/transactions?limit=${Math.min(50, Math.max(1, limit))}`, { headers: controlHeaders(controlToken) }),
   nextHistoryPage: (controlToken: string, nextPagePath: string) => request<BrokerEnvelope>(`/v1/mobile/broker/history/next?nextPagePath=${encodeURIComponent(nextPagePath)}`, { headers: controlHeaders(controlToken) }),
+  previewOrder: (controlToken: string, input: OrderPreviewInput) => request<BrokerEnvelope<OrderPreview>>('/v1/mobile/broker/orders/preview', {
+    method: 'POST',
+    headers: controlHeaders(controlToken),
+    body: JSON.stringify(input),
+  }),
   marketOrder: (controlToken: string, input: MarketOrderInput) => request<BrokerEnvelope>('/v1/mobile/broker/orders/market', { method: 'POST', headers: controlHeaders(controlToken), body: JSON.stringify(input) }),
   limitOrder: (controlToken: string, input: LimitOrderInput) => request<BrokerEnvelope>('/v1/mobile/broker/orders/limit', { method: 'POST', headers: controlHeaders(controlToken), body: JSON.stringify(input) }),
   stopOrder: (controlToken: string, input: StopOrderInput) => request<BrokerEnvelope>('/v1/mobile/broker/orders/stop', { method: 'POST', headers: controlHeaders(controlToken), body: JSON.stringify(input) }),


### PR DESCRIPTION
Consolidates only the still-valid functionality from stale PRs #45, #50, #63 and #65 onto current main without merging their obsolete histories.

Rescued:
- Trading 212 portfolio reconciliation, order preview, literal validated nextPagePath handling, account rate-limit cooldowns, and live non-market fail-closed gate from #50.
- Matching backend tests, mobile BrokerApi client contract, and Broker Ω documentation.
- Finnhub resilient provider module from #45: endpoint-aware TTLs, in-flight dedupe, conservative CPS throttle, 429 cooldown, stale-last-good fallback, plus provider cutover runbook.

Intentionally not ported:
- obsolete Trading 212 read-only routers/mobile sync from #45 because current Broker Ω supersedes them.
- old #63/#65 shell/UI files that are already represented by newer TerminalShell/workspace/audit/results implementations in main. This prevents regressions and duplicate navigation.

This PR is based directly on current main and should replace the need to merge #45/#50/#63/#65 histories.