### PR TITLE
Certify mobile clean rebuild after strict tuple fix

### DIFF
--- a/.github/workflows/mobile-ci-eas-apk.yml
+++ b/.github/workflows/mobile-ci-eas-apk.yml
@@ -1,4 +1,4 @@
-# Rebuild marker: 2026-08-23 strict tuple fix validation on current main
+# Rebuild marker: 2026-08-23 certification PR after strict tuple fix
 name: ATLAS Ω Mobile v1 Clean Rebuild
 
 on:


### PR DESCRIPTION
Certification-only PR from current main. Purpose: run the full ATLAS Ω Mobile v1 Clean Rebuild against the strict tuple fix already present in main, then merge only if Backend, TypeScript, APK build and Android navigation are all green. No product logic is changed beyond the workflow marker comment.