### PR TITLE
ATLAS Ω: Size-Blind Point Zero + Breadth Rotation

### DIFF
--- a/.github/workflows/size-blind-p0-ci.yml
+++ b/.github/workflows/size-blind-p0-ci.yml
@@ -1,0 +1,39 @@
+name: Size-Blind P0 Omega CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/algorithm/size-blind-point-zero-omega.ts'
+      - 'src/atlas/algorithm/size-blind-point-zero-omega.test.ts'
+      - 'src/atlas/algorithm/capex-asymmetry-omega.ts'
+      - 'src/atlas/algorithm/capex-asymmetry-omega.test.ts'
+      - 'CURRENT_CANON/SIZE_BLIND_POINT_ZERO_OMEGA.md'
+      - '.github/workflows/size-blind-p0-ci.yml'
+  push:
+    branches:
+      - 'feat/size-blind-p0-omega'
+    paths:
+      - 'src/atlas/algorithm/size-blind-point-zero-omega.ts'
+      - 'src/atlas/algorithm/size-blind-point-zero-omega.test.ts'
+      - 'src/atlas/algorithm/capex-asymmetry-omega.ts'
+      - 'src/atlas/algorithm/capex-asymmetry-omega.test.ts'
+      - 'CURRENT_CANON/SIZE_BLIND_POINT_ZERO_OMEGA.md'
+      - '.github/workflows/size-blind-p0-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  size-blind-p0-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run Size-Blind P0 and Expectations Debt tests
+        run: >-
+          npx --yes vitest@3.2.4 run --globals
+          src/atlas/algorithm/size-blind-point-zero-omega.test.ts
+          src/atlas/algorithm/capex-asymmetry-omega.test.ts

--- a/CURRENT_CANON/SIZE_BLIND_POINT_ZERO_OMEGA.md
+++ b/CURRENT_CANON/SIZE_BLIND_POINT_ZERO_OMEGA.md
@@ -1,0 +1,325 @@
+# SIZE-BLIND POINT ZERO Ω v1.0
+
+**Status:** ACTIVE / UNIVERSAL DISCOVERY MODULE  
+**Effective date:** 2026-09-04  
+**Authority:** compatible with ATLAS Ω ENTERPRISE, Principal Ω, Investing AI Clone Ω, CAPEX Hunters Ω and P0 Adjusted Ω. It does not override Hard Gates, Replacement Firewall, valuation discipline, portfolio construction or broker safety.
+
+## Mission
+
+Turn the ATLAS rule **“every company starts from zero”** into an executable cross-sector discovery engine.
+
+The module searches for companies where:
+
+**fundamental acceleration + improving per-share economics + valuation runway + durable catalyst + financial quality**
+
+coexist before the market fully capitalizes the future trajectory.
+
+The engine must work identically for a $3B company and a $3T company when their economic inputs are identical.
+
+> **NO MEGACAP BIAS. NO SMALL-CAP BIAS. SIZE IS METADATA, NOT QUALITY.**
+
+## Why this module exists
+
+A mature leadership regime can broaden into smaller and mid-sized companies when earnings acceleration migrates outside the largest index constituents. That regime can create discovery opportunities, but “small cap” is never itself an investment thesis.
+
+A company qualifies because its economics improve faster than expectations, not because it belongs to a capitalization bucket.
+
+Likewise, a megacap is not penalized for size. If FCF/share or EPS/share outruns the stock price and the opportunity remains economically attractive, the company can still rank highly.
+
+## Point-Zero modes
+
+- **P0_IPO:** newly public company where the public market has not fully observed the economic trajectory.
+- **P0_RESET:** older company undergoing a genuine economic/technology/business-model reset.
+- **P0_SPIN:** newly independent asset whose economics were previously hidden inside a parent.
+- **P0_EARLY_PUBLIC:** already public company entering a structural acceleration phase.
+- **MATURE:** mature company retained as a control; maturity itself is not a penalty.
+
+## Market-cap buckets
+
+ATLAS records market cap for implementation, liquidity and research routing only:
+
+- `XS_LT_2B`
+- `S_2_10B`
+- `M_10_50B`
+- `L_50_200B`
+- `XL_GE_200B`
+
+**Market-cap score contribution = 0.**
+
+A smaller company may receive the discovery label `SMALL_MID_SPRINTER`, but the label cannot alter the numeric opportunity score.
+
+---
+
+# BREADTH ROTATION Ω v1.0
+
+## Mission
+
+Measure whether market leadership is genuinely broadening from large/mega caps toward smaller and mid-sized companies because of earnings, valuation, revisions and relative strength — not merely because of a short-covering or low-quality speculative bounce.
+
+## Inputs
+
+1. Small/mid forward EPS growth.
+2. Large/mega forward EPS growth.
+3. Small/mid forward P/E.
+4. Large/mega forward P/E.
+5. Small/mid 6-month relative strength vs large/mega universe.
+6. Positive earnings-revision breadth.
+
+## Formula
+
+`EPS_GROWTH_SPREAD_PP = SMALL_MID_FORWARD_EPS_GROWTH - LARGE_MEGA_FORWARD_EPS_GROWTH`
+
+Calibration:
+
+`EPS_GROWTH_SPREAD_SCORE = linear(-10pp → 0, +30pp → 100)`
+
+`VALUATION_DISCOUNT_PCT = (LARGE_MEGA_PE - SMALL_MID_PE) / LARGE_MEGA_PE`
+
+`VALUATION_DISCOUNT_SCORE = linear(0% → 0, 35% → 100)`
+
+`RELATIVE_STRENGTH_SCORE = linear(-10pp → 0, +20pp → 100)`
+
+`REVISION_BREADTH_SCORE = POSITIVE_REVISION_BREADTH_PCT`
+
+Master formula:
+
+`BREADTH_ROTATION_SCORE =`
+
+- 35% EPS growth spread
+- 25% valuation discount
+- 20% six-month relative strength
+- 20% positive revision breadth
+
+States:
+
+- **75–100 BROADENING_CONFIRMED**
+- **60–74.9 BROADENING**
+- **40–59.9 MIXED**
+- **<40 NARROWING**
+
+### Constitutional limit
+
+Breadth contributes only **5%** to a company’s Universal P0 score.
+
+Therefore:
+
+> **A strong small-cap regime cannot rescue a weak company.**
+
+---
+
+# UNIVERSAL P0 FUNDAMENTAL INFLECTION Ω
+
+The fundamental inflection subscore is:
+
+`FUNDAMENTAL_INFLECTION =`
+
+- 25% revenue acceleration
+- 35% EPS/FCF acceleration
+- 20% margin inflection
+- 20% per-share economic quality
+
+EPS/FCF receives the largest weight because ATLAS cares about shareholder economics, not only reported top-line growth.
+
+## Per-share law
+
+When comparing stock-price growth with fundamentals, use the strongest available per-share metric:
+
+1. FCF/share
+2. EPS/share
+3. gross profit/share
+4. revenue/share
+
+Aggregate revenue growth cannot offset material dilution.
+
+---
+
+# EXPECTATIONS DEBT Ω — UNIVERSAL APPLICATION
+
+This module reuses the same logic established in CAPEX Asymmetry / P0 Adjusted Ω.
+
+## Excess Rerating
+
+`EXCESS_RERATING_PP = PRICE_CAGR_3Y - FUNDAMENTAL_PER_SHARE_CAGR_3Y`
+
+`EXCESS_RERATING_DEBT = clamp(max(0, EXCESS_RERATING_PP) / 40pp * 100)`
+
+If per-share fundamentals grow as fast as or faster than the stock price, Excess Rerating Debt is **0**.
+
+Therefore:
+
+> **A stock is never penalized merely because it rose a lot.**
+
+## Multiple Expansion Debt
+
+Using exactly the same valuation metric at both dates:
+
+`MULTIPLE_EXPANSION_DEBT = clamp(log2(CURRENT_MULTIPLE / START_MULTIPLE) * 100)`
+
+when the multiple expanded; otherwise 0.
+
+A doubling of a comparable multiple maps to 100 debt.
+
+## Expectations Debt
+
+When comparable multiple history exists:
+
+`EXPECTATIONS_DEBT = 65% EXCESS_RERATING_DEBT + 35% MULTIPLE_EXPANSION_DEBT`
+
+Without comparable multiple history:
+
+`EXPECTATIONS_DEBT = EXCESS_RERATING_DEBT`
+
+## Valuation Opportunity
+
+Absolute valuation and expectations debt remain separate because low valuation can be a value trap.
+
+`VALUATION_OPPORTUNITY =`
+
+- 60% `(100 - EXPECTATIONS_DEBT)`
+- 40% `ABSOLUTE_VALUATION_SCORE`
+
+---
+
+# SIZE-BLIND P0 MASTER FORMULA
+
+## Core Opportunity
+
+`CORE_OPPORTUNITY =`
+
+- **30% Fundamental Inflection**
+- **20% Valuation Opportunity**
+- **12% Capital Efficiency**
+- **10% Balance-Sheet Quality**
+- **8% Catalyst Durability**
+- **7% Earnings Revisions**
+- **5% Breadth Regime**
+- **3% Relative Momentum**
+- **5% Liquidity Quality**
+- **0% Market Cap**
+
+## Risk Penalty
+
+`RISK_PENALTY =`
+
+- 12% Value-Trap Risk
+- 8% Drawdown Risk
+- 8% Dilution Risk
+
+## Final score
+
+`SIZE_BLIND_P0_SCORE = clamp(CORE_OPPORTUNITY - RISK_PENALTY)`
+
+---
+
+# FAIL-CLOSED CAPS
+
+A mathematically attractive cheap stock must not game the engine.
+
+- Value-Trap Risk >=80 → score capped at 64.9 and `VALUE_TRAP_RISK`.
+- Balance-Sheet Quality <30 → score capped at 59.9 and `FUNDING_RISK`.
+- Liquidity Quality <25 → score capped at 59.9 and `ILLIQUID_RISK`.
+- Dilution Risk >=80 → score capped at 69.9.
+- Expectations Debt >=85 → score capped at 69.9.
+
+These caps are deliberately asymmetric: severe fragility can veto elite status, while strong market breadth cannot create elite status.
+
+---
+
+# STATES
+
+After evidence and hard-risk checks:
+
+- **>=82 P0_ELITE**, with Expectations Debt <=45.
+- **>=72 P0_STRONG**.
+- **>=62 P1_EARLY**.
+- **>=52 WATCH**.
+- **<52 NO_EDGE**.
+
+Separate failure states:
+
+- `VALUE_TRAP_RISK`
+- `FUNDING_RISK`
+- `ILLIQUID_RISK`
+- `EVIDENCE_PENDING`
+
+## Evidence Gate
+
+At least **four traceable evidence records** are required for a confirmed ranking.
+
+External newsletters, AI-generated lists, social posts and model outputs are discovery inputs only. They do not become canonical facts without evidence validation.
+
+---
+
+# SPRINTER LABEL
+
+A company can receive `SMALL_MID_SPRINTER` when:
+
+- market cap < $50B;
+- Size-Blind P0 Score >=72;
+- Breadth Regime Score >=60.
+
+This is a routing label for research priority only.
+
+The same company with identical economics at a mega-cap market value receives exactly the same numeric score and may be labeled `SIZE_BLIND_P0` instead.
+
+> **LABEL ≠ SCORE. SIZE ≠ QUALITY.**
+
+---
+
+# Anti-error laws
+
+- **SMALL CAP ≠ CHEAP.**
+- **MEGACAP ≠ EXPENSIVE.**
+- **LOW P/E ≠ VALUE.**
+- **HIGH P/E ≠ OVERVALUED without expectations/fundamental analysis.**
+- **PRICE RUN-UP ≠ EXPECTATIONS DEBT if per-share economics caught up.**
+- **REVENUE GROWTH ≠ SHAREHOLDER GROWTH if dilution absorbs it.**
+- **ONE EARNINGS BEAT ≠ STRUCTURAL INFLECTION.**
+- **ONE-OFF GEOPOLITICAL WINDFALL ≠ DURABLE CATALYST.**
+- **BREADTH RALLY ≠ COMPANY QUALITY.**
+- **DISCOVERY WINNER ≠ AUTOMATIC BUY.**
+
+---
+
+# Falsifiers
+
+The P0 thesis must be downgraded when any of these become true:
+
+- fundamental acceleration reverses before cash flow confirms;
+- EPS/FCF acceleration is accounting-driven or one-off;
+- revenue does not translate to per-share economics;
+- cheap valuation is explained by structural deterioration;
+- balance-sheet/refinancing risk increases materially;
+- dilution offsets operating growth;
+- catalyst proves temporary or mean-reverting;
+- earnings revisions weaken while breadth leadership reverses;
+- stock price outruns per-share fundamentals and comparable multiples expand materially.
+
+---
+
+# Mandatory output per ticker
+
+`Ticker | P0 Mode | Market-Cap Bucket | Fundamental Inflection | Price CAGR 3Y | Fundamental/share CAGR 3Y | Excess Rerating | Multiple Debt | Expectations Debt | Valuation Opportunity | Capital Efficiency | Balance | Catalyst | Revisions | Breadth | Momentum | Liquidity | Value-Trap Risk | Drawdown Risk | Dilution Risk | Size-Blind P0 Score | Evidence Gate | State | Action | Discovery Tag`
+
+---
+
+# Integration
+
+Implementation:
+
+- `src/atlas/algorithm/size-blind-point-zero-omega.ts`
+
+Tests:
+
+- `src/atlas/algorithm/size-blind-point-zero-omega.test.ts`
+
+Related engines:
+
+- `CAPEX_ASYMMETRY_OMEGA_V1`
+- `CAPEX_HUNTERS_OMEGA_V1`
+- `CAPEX_CAPTURE_ELASTICITY_OMEGA_V1`
+- Principal Ω / Replacement Firewall / Falsifiers Ω retain independent authority.
+
+## Final law
+
+> **Do not ask whether the next winner is a small cap or a megacap. Ask where per-share economics are entering a new acceleration phase before expectations have fully caught up.**

--- a/src/atlas/algorithm/size-blind-point-zero-omega.test.ts
+++ b/src/atlas/algorithm/size-blind-point-zero-omega.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
   evaluateBreadthRotation,
   evaluateUniversalPointZero,

--- a/src/atlas/algorithm/size-blind-point-zero-omega.test.ts
+++ b/src/atlas/algorithm/size-blind-point-zero-omega.test.ts
@@ -1,0 +1,156 @@
+import {
+  evaluateBreadthRotation,
+  evaluateUniversalPointZero,
+  type UniversalPointZeroInput,
+} from './size-blind-point-zero-omega';
+
+const baseCase: UniversalPointZeroInput = {
+  ticker: 'P0_CASE',
+  pointZeroMode: 'P0_RESET',
+  marketCapUsd: 4_000_000_000,
+  evidenceTraceable: true,
+  evidenceIds: ['earnings', 'cash-flow', 'valuation-history', 'catalyst'],
+  revenueAccelerationScore: 88,
+  epsFcfAccelerationScore: 94,
+  marginInflectionScore: 90,
+  perShareEconomicQualityScore: 92,
+  absoluteValuationScore: 82,
+  priceCagr3yPct: 32,
+  fundamentalPerShareCagr3yPct: 40,
+  startValuationMultiple: 18,
+  currentValuationMultiple: 20,
+  capitalEfficiencyScore: 90,
+  balanceSheetQualityScore: 90,
+  catalystDurabilityScore: 88,
+  earningsRevisionScore: 84,
+  breadthRegimeScore: 72,
+  relativeMomentumScore: 70,
+  liquidityQualityScore: 86,
+  drawdownRiskScore: 25,
+  valueTrapRiskScore: 15,
+  dilutionRiskScore: 10,
+};
+
+describe('Size-Blind Point Zero Omega v1', () => {
+  it('gives identical economics the same score regardless of market cap', () => {
+    const small = evaluateUniversalPointZero({ ...baseCase, marketCapUsd: 3_000_000_000 });
+    const mega = evaluateUniversalPointZero({ ...baseCase, marketCapUsd: 3_000_000_000_000 });
+
+    expect(small.marketCapBucket).not.toBe(mega.marketCapBucket);
+    expect(small.sizeBiasContribution).toBe(0);
+    expect(mega.sizeBiasContribution).toBe(0);
+    expect(small.sizeBlindP0Score).toBe(mega.sizeBlindP0Score);
+  });
+
+  it('does not punish a large stock-price run-up when per-share fundamentals grew faster', () => {
+    const result = evaluateUniversalPointZero({
+      ...baseCase,
+      priceCagr3yPct: 70,
+      fundamentalPerShareCagr3yPct: 82,
+      startValuationMultiple: 24,
+      currentValuationMultiple: 24,
+    });
+
+    expect(result.excessReratingPp).toBeLessThanOrEqual(0);
+    expect(result.excessReratingDebtScore).toBe(0);
+    expect(result.multipleExpansionDebtScore).toBe(0);
+    expect(result.expectationsDebtScore).toBe(0);
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.stringContaining('raw run-up is therefore not penalized'),
+    ]));
+  });
+
+  it('blocks a cheap stock from elite status when value-trap risk is extreme', () => {
+    const result = evaluateUniversalPointZero({
+      ...baseCase,
+      absoluteValuationScore: 100,
+      valueTrapRiskScore: 90,
+    });
+
+    expect(result.sizeBlindP0Score).toBeLessThanOrEqual(64.9);
+    expect(result.state).toBe('VALUE_TRAP_RISK');
+    expect(result.action).toBe('REJECT_FOR_NOW');
+  });
+
+  it('fails closed when balance-sheet quality is below the funding gate', () => {
+    const result = evaluateUniversalPointZero({
+      ...baseCase,
+      balanceSheetQualityScore: 20,
+    });
+
+    expect(result.sizeBlindP0Score).toBeLessThanOrEqual(59.9);
+    expect(result.state).toBe('FUNDING_RISK');
+    expect(result.action).toBe('REJECT_FOR_NOW');
+  });
+
+  it('keeps breadth as a minor input that cannot rescue weak company economics', () => {
+    const weak = evaluateUniversalPointZero({
+      ...baseCase,
+      revenueAccelerationScore: 20,
+      epsFcfAccelerationScore: 20,
+      marginInflectionScore: 20,
+      perShareEconomicQualityScore: 20,
+      absoluteValuationScore: 40,
+      capitalEfficiencyScore: 30,
+      catalystDurabilityScore: 30,
+      earningsRevisionScore: 25,
+      relativeMomentumScore: 25,
+      breadthRegimeScore: 100,
+    });
+
+    expect(weak.sizeBlindP0Score).toBeLessThan(62);
+    expect(['WATCH', 'NO_EDGE']).toContain(weak.state);
+  });
+
+  it('fails closed when evidence is not sufficiently traceable', () => {
+    const result = evaluateUniversalPointZero({
+      ...baseCase,
+      evidenceIds: ['single-source'],
+    });
+
+    expect(result.evidenceGate).toBe('PROVISIONAL');
+    expect(result.state).toBe('EVIDENCE_PENDING');
+    expect(result.action).toBe('EVIDENCE_REQUIRED');
+  });
+
+  it('labels a strong smaller company as a sprinter without changing its score', () => {
+    const small = evaluateUniversalPointZero({ ...baseCase, marketCapUsd: 8_000_000_000 });
+    const mega = evaluateUniversalPointZero({ ...baseCase, marketCapUsd: 800_000_000_000 });
+
+    expect(small.sizeBlindP0Score).toBe(mega.sizeBlindP0Score);
+    expect(small.discoveryTag).toBe('SMALL_MID_SPRINTER');
+    expect(mega.discoveryTag).toBe('SIZE_BLIND_P0');
+  });
+});
+
+describe('Breadth Rotation Omega v1', () => {
+  it('detects a genuine broadening regime from earnings, valuation, revisions and relative strength', () => {
+    const result = evaluateBreadthRotation({
+      smallMidForwardEpsGrowthPct: 28,
+      largeMegaForwardEpsGrowthPct: 12,
+      smallMidForwardPe: 17,
+      largeMegaForwardPe: 23,
+      smallMidRelativeStrength6mPp: 10,
+      positiveRevisionBreadthPct: 75,
+    });
+
+    expect(result.epsGrowthSpreadPp).toBe(16);
+    expect(result.valuationDiscountPct).toBeGreaterThan(20);
+    expect(result.breadthRotationScore).toBeGreaterThanOrEqual(60);
+    expect(['BROADENING', 'BROADENING_CONFIRMED']).toContain(result.state);
+  });
+
+  it('does not call a regime broadening when small/mid earnings and relative strength lag', () => {
+    const result = evaluateBreadthRotation({
+      smallMidForwardEpsGrowthPct: 5,
+      largeMegaForwardEpsGrowthPct: 18,
+      smallMidForwardPe: 20,
+      largeMegaForwardPe: 22,
+      smallMidRelativeStrength6mPp: -12,
+      positiveRevisionBreadthPct: 30,
+    });
+
+    expect(result.breadthRotationScore).toBeLessThan(40);
+    expect(result.state).toBe('NARROWING');
+  });
+});

--- a/src/atlas/algorithm/size-blind-point-zero-omega.ts
+++ b/src/atlas/algorithm/size-blind-point-zero-omega.ts
@@ -1,0 +1,459 @@
+import { scoreMultipleExpansionDebt } from './capex-asymmetry-omega';
+
+export type PointZeroMode =
+  | 'P0_IPO'
+  | 'P0_RESET'
+  | 'P0_SPIN'
+  | 'P0_EARLY_PUBLIC'
+  | 'MATURE';
+
+export type AtlasMarketCapBucket =
+  | 'XS_LT_2B'
+  | 'S_2_10B'
+  | 'M_10_50B'
+  | 'L_50_200B'
+  | 'XL_GE_200B';
+
+export type BreadthRotationState =
+  | 'BROADENING_CONFIRMED'
+  | 'BROADENING'
+  | 'MIXED'
+  | 'NARROWING';
+
+export type BreadthRotationInput = {
+  smallMidForwardEpsGrowthPct: number;
+  largeMegaForwardEpsGrowthPct: number;
+  smallMidForwardPe: number;
+  largeMegaForwardPe: number;
+  smallMidRelativeStrength6mPp: number;
+  positiveRevisionBreadthPct: number;
+};
+
+export type BreadthRotationResult = {
+  epsGrowthSpreadPp: number;
+  valuationDiscountPct: number;
+  epsGrowthSpreadScore: number;
+  valuationDiscountScore: number;
+  relativeStrengthScore: number;
+  revisionBreadthScore: number;
+  breadthRotationScore: number;
+  state: BreadthRotationState;
+};
+
+export type UniversalP0State =
+  | 'P0_ELITE'
+  | 'P0_STRONG'
+  | 'P1_EARLY'
+  | 'WATCH'
+  | 'VALUE_TRAP_RISK'
+  | 'FUNDING_RISK'
+  | 'ILLIQUID_RISK'
+  | 'NO_EDGE'
+  | 'EVIDENCE_PENDING';
+
+export type UniversalP0Action =
+  | 'ADVANCE_DEEP_RESEARCH'
+  | 'WATCH'
+  | 'NO_CHASE'
+  | 'REJECT_FOR_NOW'
+  | 'EVIDENCE_REQUIRED';
+
+export type UniversalPointZeroInput = {
+  ticker: string;
+  pointZeroMode: PointZeroMode;
+  marketCapUsd: number;
+  evidenceTraceable: boolean;
+  evidenceIds: readonly string[];
+
+  // Fundamental inflection, all 0-100.
+  revenueAccelerationScore: number;
+  epsFcfAccelerationScore: number;
+  marginInflectionScore: number;
+  perShareEconomicQualityScore: number;
+
+  // Valuation and expectations.
+  absoluteValuationScore: number;
+  priceCagr3yPct: number;
+  fundamentalPerShareCagr3yPct: number;
+  startValuationMultiple?: number;
+  currentValuationMultiple?: number;
+
+  // Quality of the opportunity, all 0-100.
+  capitalEfficiencyScore: number;
+  balanceSheetQualityScore: number;
+  catalystDurabilityScore: number;
+  earningsRevisionScore: number;
+  breadthRegimeScore: number;
+  relativeMomentumScore: number;
+  liquidityQualityScore: number;
+
+  // Risk scores, 0 = no risk, 100 = maximum risk.
+  drawdownRiskScore: number;
+  valueTrapRiskScore: number;
+  dilutionRiskScore: number;
+};
+
+export type UniversalPointZeroResult = {
+  ticker: string;
+  pointZeroMode: PointZeroMode;
+  marketCapBucket: AtlasMarketCapBucket;
+  sizeBiasContribution: 0;
+  evidenceGate: 'CONFIRMED' | 'PROVISIONAL' | 'BLOCKED';
+  fundamentalInflectionScore: number;
+  excessReratingPp: number;
+  excessReratingDebtScore: number;
+  multipleExpansionDebtScore: number | null;
+  expectationsDebtScore: number;
+  valuationOpportunityScore: number;
+  coreOpportunityScore: number;
+  riskPenaltyScore: number;
+  sizeBlindP0Score: number;
+  state: UniversalP0State;
+  action: UniversalP0Action;
+  discoveryTag: 'SMALL_MID_SPRINTER' | 'SIZE_BLIND_P0' | 'NONE';
+  reasons: string[];
+  falsifiers: string[];
+};
+
+const clamp = (x: number): number => Math.max(0, Math.min(100, x));
+const round1 = (x: number): number => Math.round(x * 10) / 10;
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+function requireFinite(name: string, x: number): void {
+  if (!Number.isFinite(x)) throw new Error(`${name}_must_be_finite`);
+}
+
+function requireScore(name: string, x: number): void {
+  if (!Number.isFinite(x) || x < 0 || x > 100) {
+    throw new Error(`${name}_must_be_between_0_and_100`);
+  }
+}
+
+function linearScore(x: number, low: number, high: number): number {
+  if (!Number.isFinite(x) || !Number.isFinite(low) || !Number.isFinite(high) || high <= low) {
+    throw new Error('linear_score_invalid_input');
+  }
+  return round1(clamp(((x - low) / (high - low)) * 100));
+}
+
+export function classifyAtlasMarketCap(marketCapUsd: number): AtlasMarketCapBucket {
+  if (!Number.isFinite(marketCapUsd) || marketCapUsd <= 0) {
+    throw new Error('market_cap_must_be_positive_finite');
+  }
+  if (marketCapUsd < 2_000_000_000) return 'XS_LT_2B';
+  if (marketCapUsd < 10_000_000_000) return 'S_2_10B';
+  if (marketCapUsd < 50_000_000_000) return 'M_10_50B';
+  if (marketCapUsd < 200_000_000_000) return 'L_50_200B';
+  return 'XL_GE_200B';
+}
+
+export function evaluateBreadthRotation(input: BreadthRotationInput): BreadthRotationResult {
+  const finiteValues = [
+    input.smallMidForwardEpsGrowthPct,
+    input.largeMegaForwardEpsGrowthPct,
+    input.smallMidForwardPe,
+    input.largeMegaForwardPe,
+    input.smallMidRelativeStrength6mPp,
+    input.positiveRevisionBreadthPct,
+  ];
+  if (finiteValues.some((x) => !Number.isFinite(x))) {
+    throw new Error('breadth_rotation_requires_finite_values');
+  }
+  if (input.smallMidForwardPe <= 0 || input.largeMegaForwardPe <= 0) {
+    throw new Error('breadth_rotation_pe_must_be_positive');
+  }
+  requireScore('positive_revision_breadth_pct', input.positiveRevisionBreadthPct);
+
+  const epsGrowthSpreadPp = round2(
+    input.smallMidForwardEpsGrowthPct - input.largeMegaForwardEpsGrowthPct,
+  );
+  const valuationDiscountPct = round2(
+    ((input.largeMegaForwardPe - input.smallMidForwardPe) / input.largeMegaForwardPe) * 100,
+  );
+
+  // Calibration windows are intentionally broad. They are regime transforms,
+  // not forecasts: -10pp to +30pp EPS-growth spread, 0-35% valuation discount,
+  // and -10pp to +20pp 6m relative strength map to 0-100.
+  const epsGrowthSpreadScore = linearScore(epsGrowthSpreadPp, -10, 30);
+  const valuationDiscountScore = linearScore(valuationDiscountPct, 0, 35);
+  const relativeStrengthScore = linearScore(input.smallMidRelativeStrength6mPp, -10, 20);
+  const revisionBreadthScore = round1(input.positiveRevisionBreadthPct);
+
+  const breadthRotationScore = round1(
+    epsGrowthSpreadScore * 0.35 +
+      valuationDiscountScore * 0.25 +
+      relativeStrengthScore * 0.20 +
+      revisionBreadthScore * 0.20,
+  );
+
+  const state: BreadthRotationState =
+    breadthRotationScore >= 75
+      ? 'BROADENING_CONFIRMED'
+      : breadthRotationScore >= 60
+        ? 'BROADENING'
+        : breadthRotationScore >= 40
+          ? 'MIXED'
+          : 'NARROWING';
+
+  return {
+    epsGrowthSpreadPp,
+    valuationDiscountPct,
+    epsGrowthSpreadScore,
+    valuationDiscountScore,
+    relativeStrengthScore,
+    revisionBreadthScore,
+    breadthRotationScore,
+    state,
+  };
+}
+
+function scoreExcessReratingDebt(priceCagr3yPct: number, fundamentalPerShareCagr3yPct: number): {
+  excessReratingPp: number;
+  excessReratingDebtScore: number;
+} {
+  requireFinite('price_cagr_3y_pct', priceCagr3yPct);
+  requireFinite('fundamental_per_share_cagr_3y_pct', fundamentalPerShareCagr3yPct);
+
+  const excessReratingPp = round2(priceCagr3yPct - fundamentalPerShareCagr3yPct);
+  const excessReratingDebtScore = round1(
+    clamp((Math.max(0, excessReratingPp) / 40) * 100),
+  );
+  return { excessReratingPp, excessReratingDebtScore };
+}
+
+function validateUniversalP0(input: UniversalPointZeroInput): void {
+  classifyAtlasMarketCap(input.marketCapUsd);
+
+  const scoreFields: Array<[string, number]> = [
+    ['revenue_acceleration_score', input.revenueAccelerationScore],
+    ['eps_fcf_acceleration_score', input.epsFcfAccelerationScore],
+    ['margin_inflection_score', input.marginInflectionScore],
+    ['per_share_economic_quality_score', input.perShareEconomicQualityScore],
+    ['absolute_valuation_score', input.absoluteValuationScore],
+    ['capital_efficiency_score', input.capitalEfficiencyScore],
+    ['balance_sheet_quality_score', input.balanceSheetQualityScore],
+    ['catalyst_durability_score', input.catalystDurabilityScore],
+    ['earnings_revision_score', input.earningsRevisionScore],
+    ['breadth_regime_score', input.breadthRegimeScore],
+    ['relative_momentum_score', input.relativeMomentumScore],
+    ['liquidity_quality_score', input.liquidityQualityScore],
+    ['drawdown_risk_score', input.drawdownRiskScore],
+    ['value_trap_risk_score', input.valueTrapRiskScore],
+    ['dilution_risk_score', input.dilutionRiskScore],
+  ];
+  scoreFields.forEach(([name, score]) => requireScore(name, score));
+
+  requireFinite('price_cagr_3y_pct', input.priceCagr3yPct);
+  requireFinite('fundamental_per_share_cagr_3y_pct', input.fundamentalPerShareCagr3yPct);
+}
+
+export function evaluateUniversalPointZero(input: UniversalPointZeroInput): UniversalPointZeroResult {
+  validateUniversalP0(input);
+
+  const marketCapBucket = classifyAtlasMarketCap(input.marketCapUsd);
+  const fundamentalInflectionScore = round1(
+    input.revenueAccelerationScore * 0.25 +
+      input.epsFcfAccelerationScore * 0.35 +
+      input.marginInflectionScore * 0.20 +
+      input.perShareEconomicQualityScore * 0.20,
+  );
+
+  const { excessReratingPp, excessReratingDebtScore } = scoreExcessReratingDebt(
+    input.priceCagr3yPct,
+    input.fundamentalPerShareCagr3yPct,
+  );
+  const multipleExpansionDebtScore = scoreMultipleExpansionDebt(
+    input.startValuationMultiple,
+    input.currentValuationMultiple,
+  );
+  const expectationsDebtScore = round1(
+    multipleExpansionDebtScore == null
+      ? excessReratingDebtScore
+      : excessReratingDebtScore * 0.65 + multipleExpansionDebtScore * 0.35,
+  );
+
+  // Absolute valuation and expectations debt are distinct. A low multiple can be
+  // a trap; a high multiple can still be justified when per-share economics catch up.
+  const valuationOpportunityScore = round1(
+    (100 - expectationsDebtScore) * 0.60 + input.absoluteValuationScore * 0.40,
+  );
+
+  // Market cap contributes exactly zero. Breadth contributes only 5%, so a broad
+  // small/mid-cap rally cannot rescue weak company-level economics.
+  const coreOpportunityScore = round1(
+    fundamentalInflectionScore * 0.30 +
+      valuationOpportunityScore * 0.20 +
+      input.capitalEfficiencyScore * 0.12 +
+      input.balanceSheetQualityScore * 0.10 +
+      input.catalystDurabilityScore * 0.08 +
+      input.earningsRevisionScore * 0.07 +
+      input.breadthRegimeScore * 0.05 +
+      input.relativeMomentumScore * 0.03 +
+      input.liquidityQualityScore * 0.05,
+  );
+
+  const riskPenaltyScore = round1(
+    input.valueTrapRiskScore * 0.12 +
+      input.drawdownRiskScore * 0.08 +
+      input.dilutionRiskScore * 0.08,
+  );
+
+  let sizeBlindP0Score = round1(clamp(coreOpportunityScore - riskPenaltyScore));
+
+  // Fail-closed caps. These prevent cheap/distressed names from gaming the model.
+  if (input.valueTrapRiskScore >= 80) sizeBlindP0Score = Math.min(sizeBlindP0Score, 64.9);
+  if (input.balanceSheetQualityScore < 30) sizeBlindP0Score = Math.min(sizeBlindP0Score, 59.9);
+  if (input.liquidityQualityScore < 25) sizeBlindP0Score = Math.min(sizeBlindP0Score, 59.9);
+  if (input.dilutionRiskScore >= 80) sizeBlindP0Score = Math.min(sizeBlindP0Score, 69.9);
+  if (expectationsDebtScore >= 85) sizeBlindP0Score = Math.min(sizeBlindP0Score, 69.9);
+  sizeBlindP0Score = round1(sizeBlindP0Score);
+
+  const evidenceGate: UniversalPointZeroResult['evidenceGate'] =
+    input.evidenceTraceable && input.evidenceIds.length >= 4
+      ? 'CONFIRMED'
+      : input.evidenceTraceable && input.evidenceIds.length > 0
+        ? 'PROVISIONAL'
+        : 'BLOCKED';
+
+  const reasons: string[] = [];
+  const falsifiers = [
+    'fundamental_acceleration_reverses_before_estimates_or_cash_flow_confirm',
+    'eps_or_fcf_growth_is_non_recurring_or_accounting_driven',
+    'revenue_growth_does_not_translate_to_per_share_economics',
+    'valuation_discount_is_explained_by_structural_business_deterioration',
+    'balance_sheet_or_refinancing_risk_breaks_the_thesis',
+    'dilution_offsets_operating_growth',
+    'catalyst_is_one_off_or_mean_reverting',
+    'breadth_rotation_reverses_while_company_revisions_weaken',
+    'price_outpaces_per_share_fundamentals_and_multiple_expands',
+  ];
+
+  let state: UniversalP0State;
+  let action: UniversalP0Action;
+
+  if (evidenceGate !== 'CONFIRMED') {
+    state = 'EVIDENCE_PENDING';
+    action = 'EVIDENCE_REQUIRED';
+    reasons.push('Universal P0 requires at least four traceable evidence records.');
+  } else if (input.balanceSheetQualityScore < 30) {
+    state = 'FUNDING_RISK';
+    action = 'REJECT_FOR_NOW';
+    reasons.push('Balance-sheet quality fails the Point-Zero funding gate.');
+  } else if (input.liquidityQualityScore < 25) {
+    state = 'ILLIQUID_RISK';
+    action = 'REJECT_FOR_NOW';
+    reasons.push('Liquidity quality fails the implementation gate.');
+  } else if (input.valueTrapRiskScore >= 80) {
+    state = 'VALUE_TRAP_RISK';
+    action = 'REJECT_FOR_NOW';
+    reasons.push('Cheap valuation is not sufficient: value-trap risk is too high.');
+  } else if (sizeBlindP0Score >= 82 && expectationsDebtScore <= 45) {
+    state = 'P0_ELITE';
+    action = 'ADVANCE_DEEP_RESEARCH';
+    reasons.push('Fundamental acceleration, valuation runway and quality align without excessive expectations debt.');
+  } else if (sizeBlindP0Score >= 72) {
+    state = 'P0_STRONG';
+    action = expectationsDebtScore >= 70 ? 'NO_CHASE' : 'ADVANCE_DEEP_RESEARCH';
+    reasons.push('Strong universal Point-Zero profile; at least one risk or expectation dimension remains non-elite.');
+  } else if (sizeBlindP0Score >= 62) {
+    state = 'P1_EARLY';
+    action = expectationsDebtScore >= 70 ? 'NO_CHASE' : 'WATCH';
+    reasons.push('Early economic inflection is visible but the asymmetry is not yet strong enough for elite discovery status.');
+  } else if (sizeBlindP0Score >= 52) {
+    state = 'WATCH';
+    action = 'WATCH';
+    reasons.push('Some useful signals are present, but the total risk-adjusted opportunity remains incomplete.');
+  } else {
+    state = 'NO_EDGE';
+    action = 'REJECT_FOR_NOW';
+    reasons.push('No sufficient size-blind Point-Zero edge is currently demonstrated.');
+  }
+
+  if (excessReratingPp <= 0) {
+    reasons.push('Per-share fundamental CAGR has matched or exceeded the stock-price CAGR; raw run-up is therefore not penalized.');
+  }
+  if (expectationsDebtScore >= 70) {
+    reasons.push('Expectations debt is high: future growth is already materially capitalized in the stock.');
+  }
+  if (input.breadthRegimeScore >= 70) {
+    reasons.push('Market breadth is supportive, but breadth is only a minor discovery input and cannot override company economics.');
+  }
+
+  const isSmallMid = input.marketCapUsd < 50_000_000_000;
+  const discoveryTag: UniversalPointZeroResult['discoveryTag'] =
+    sizeBlindP0Score >= 72
+      ? isSmallMid && input.breadthRegimeScore >= 60
+        ? 'SMALL_MID_SPRINTER'
+        : 'SIZE_BLIND_P0'
+      : 'NONE';
+
+  return {
+    ticker: input.ticker,
+    pointZeroMode: input.pointZeroMode,
+    marketCapBucket,
+    sizeBiasContribution: 0,
+    evidenceGate,
+    fundamentalInflectionScore,
+    excessReratingPp,
+    excessReratingDebtScore,
+    multipleExpansionDebtScore,
+    expectationsDebtScore,
+    valuationOpportunityScore,
+    coreOpportunityScore,
+    riskPenaltyScore,
+    sizeBlindP0Score,
+    state,
+    action,
+    discoveryTag,
+    reasons,
+    falsifiers,
+  };
+}
+
+export const SIZE_BLIND_POINT_ZERO_OMEGA = {
+  id: 'SIZE_BLIND_POINT_ZERO_OMEGA_V1',
+  name: 'Size-Blind Point Zero Ω v1.0',
+  effectiveDate: '2026-09-04',
+  role: 'universal_cross_sector_point_zero_discovery_engine',
+  scoreWeights: {
+    fundamentalInflection: 0.30,
+    valuationOpportunity: 0.20,
+    capitalEfficiency: 0.12,
+    balanceSheetQuality: 0.10,
+    catalystDurability: 0.08,
+    earningsRevisions: 0.07,
+    breadthRegime: 0.05,
+    relativeMomentum: 0.03,
+    liquidityQuality: 0.05,
+    marketCap: 0,
+  },
+  riskPenalties: {
+    valueTrapRisk: 0.12,
+    drawdownRisk: 0.08,
+    dilutionRisk: 0.08,
+  },
+  constitutionalRules: [
+    'EVERY_COMPANY_STARTS_FROM_ZERO',
+    'NO_MEGACAP_BONUS',
+    'NO_SMALLCAP_BONUS',
+    'MARKET_CAP_IS_METADATA_NOT_SCORE',
+    'PRICE_RUN_UP_IS_NOT_A_PENALTY_WHEN_PER_SHARE_ECONOMICS_CATCH_UP',
+    'CHEAP_IS_NOT_VALUE_IF_BUSINESS_ECONOMICS_ARE_DETERIORATING',
+    'BREADTH_IS_A_REGIME_INPUT_NOT_A_STOCK_SELECTION_SHORTCUT',
+    'P0_WINNER_IS_NOT_AUTOMATIC_BUY',
+    'REPLACEMENT_FIREWALL_AND_FALSIFIERS_RETAIN_VETO',
+  ],
+} as const;
+
+export const BREADTH_ROTATION_OMEGA = {
+  id: 'BREADTH_ROTATION_OMEGA_V1',
+  name: 'Breadth Rotation Ω v1.0',
+  effectiveDate: '2026-09-04',
+  scoreWeights: {
+    epsGrowthSpread: 0.35,
+    valuationDiscount: 0.25,
+    relativeStrength6m: 0.20,
+    positiveRevisionBreadth: 0.20,
+  },
+  rule: 'A broadening market increases discovery priority outside megacaps but never overrides company-level economics.',
+} as const;


### PR DESCRIPTION
Closes #94.

## What this makes real
- Universal Point-Zero discovery across all market-cap buckets.
- Market cap contributes **0** to the numeric score: same economics => same score.
- Breadth Rotation Ω detects when earnings/valuation/revisions/relative strength broaden beyond megacaps, but contributes only 5% to company scoring.
- Reuses Excess Rerating / Multiple Expansion Debt so raw price appreciation is not penalized when per-share economics catch up.
- Adds fail-closed value-trap, balance-sheet, liquidity, dilution and expectations-debt caps.
- Adds `SMALL_MID_SPRINTER` as a research-routing label only; labels cannot change score.
- Adds dedicated CI for the new engine plus CAPEX P0 expectations-debt regressions.

## Files
- `src/atlas/algorithm/size-blind-point-zero-omega.ts`
- `src/atlas/algorithm/size-blind-point-zero-omega.test.ts`
- `CURRENT_CANON/SIZE_BLIND_POINT_ZERO_OMEGA.md`
- `.github/workflows/size-blind-p0-ci.yml`

## Core law
**Do not ask whether the next winner is a small cap or a megacap. Ask where per-share economics are entering a new acceleration phase before expectations have fully caught up.**