### PR TITLE
ATLAS Ω — make T0 the constitutional first gate

### DIFF
--- a/.github/workflows/t0-anti-megacap-discovery-gate-ci.yml
+++ b/.github/workflows/t0-anti-megacap-discovery-gate-ci.yml
@@ -1,0 +1,41 @@
+name: T0 Anti-Megacap Discovery Gate Omega CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts'
+      - 'src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts'
+      - 'src/atlas/algorithm/atlas-primary-engine-hierarchy.ts'
+      - 'CURRENT_CANON/2026-09-05_T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.md'
+      - '.github/workflows/t0-anti-megacap-discovery-gate-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts'
+      - 'src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts'
+      - 'src/atlas/algorithm/atlas-primary-engine-hierarchy.ts'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run T0 regression tests
+        run: npx --yes vitest@3.2.4 run src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
+      - name: Assert constitutional order
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const source = fs.readFileSync('src/atlas/algorithm/atlas-primary-engine-hierarchy.ts', 'utf8');
+          const sequence = source.slice(source.indexOf('export const ATLAS_CANONICAL_DECISION_SEQUENCE'));
+          const t0 = sequence.indexOf("'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1'");
+          const discovery = sequence.indexOf("'GLOBAL_DISCOVERY_OMEGA'");
+          const principal = sequence.indexOf("'PRINCIPAL_OMEGA'");
+          if (t0 < 0 || discovery < 0 || principal < 0 || !(t0 < discovery && t0 < principal)) {
+            console.error('T0 is not first constitutional gate');
+            process.exit(1);
+          }
+          NODE

--- a/CURRENT_CANON/2026-09-05_T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.md
+++ b/CURRENT_CANON/2026-09-05_T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.md
@@ -1,0 +1,94 @@
+# T0 — Anti-Megacap Discovery Gate Ω v1.0
+
+**Date:** 2026-09-05  
+**Status:** CANONICAL · CONSTITUTIONAL FIRST GATE  
+**Direct Structural ATLAS weight:** 0  
+**Authority:** discovery-bias prevention only; no BUY/SELL, no score bonus/penalty, no allocation authority.
+
+## Constitutional rule
+
+Every ATLAS path begins at T0 before Φ, Δ, Κ, Γ, Ρ, Ξ, Υ, Expected Return, challenger search, factor research, predictive engines, Competition for Capital or execution.
+
+T0 solves a discovery problem, not a valuation problem: zeroing market-cap points after the candidate universe has already been selected does not neutralize megacap bias.
+
+## Point Zero
+
+Every company enters post-T0 analysis at zero.
+
+The following contribute exactly zero to discovery priority and exactly zero to score:
+
+- market capitalization;
+- index membership;
+- analyst coverage;
+- brand/familiarity;
+- raw data convenience/availability.
+
+A megacap is never penalized for being large. It can finish #1 if it wins on economic evidence after T0.
+
+## Discovery coverage
+
+Discovery must deliberately cover capitalization buckets. Bucket balancing is a coverage mechanism only; it cannot change a frozen company score.
+
+Canonical audit buckets:
+
+- MICRO: < $300M
+- SMALL: $300M–<$2B
+- MID: $2B–<$10B
+- LARGE: $10B–<$200B
+- MEGA: >= $200B
+
+The bucket is assigned after discovery priority is frozen.
+
+For `CHALLENGER` and `NO_AI` discovery, absent explicit evidence justifying a different composition, megacaps may not exceed 20% of the first discovery tranche. A breach yields `DISCOVERY_BIAS_DETECTED`; it is not a penalty to the megacap company itself.
+
+## Audit trail
+
+Every discovery candidate preserves:
+
+- `discovery_source`
+- `candidate_rank_before_size`
+- `market_cap_bucket_after_freeze`
+- `entered_before_size_known`
+- `selection_reason`
+- `size_influenced_discovery`
+- any analyst-coverage, familiarity or data-availability contamination.
+
+## Admissible size economics
+
+T0 does not erase real economics associated with scale. After discovery, ATLAS may penalize or reward evidence about:
+
+- market saturation;
+- reinvestment runway;
+- liquidity/execution capacity;
+- customer concentration;
+- capital intensity;
+- incremental ROIC;
+- competitive scale advantages.
+
+But the causal variable must be demonstrated. `Large company` is never itself proof of lower return, higher quality or lower risk.
+
+## Relationship to existing engines
+
+- `SIZE_NEUTRAL_RETURN_RANKING_OMEGA_V1` continues to enforce zero size contribution in ranking.
+- `SIZE_NEUTRALITY_AUDIT_OMEGA_V1` remains a downstream audit.
+- T0 is upstream and constitutional: it prevents the candidate universe from being biased before either of those engines sees it.
+- Greek contracts remain orthogonal. T0 governs which evidence/candidates enter the pipeline; it does not alter Δ/Κ/Γ/Ρ/Υ contract boundaries.
+
+## Canonical pipeline
+
+`INPUT -> T0 -> integrity/evidence gates -> GLOBAL_DISCOVERY -> GREEN -> PRINCIPAL -> all other applicable engines -> Decision/Execution`
+
+No engine may claim a size-neutral result if its input universe failed T0.
+
+## Implementation
+
+- `src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts`
+- `src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts`
+- `src/atlas/algorithm/atlas-primary-engine-hierarchy.ts` -> v4.17.0
+- `.github/workflows/t0-anti-megacap-discovery-gate-ci.yml`
+
+## Decision / Governance
+
+**2026-09-05 — Issue #102**  
+User instruction: all ATLAS discovery and evaluation must start at T0; no default tendency toward megacaps.  
+Decision: constitutionalize T0 as the first gate while explicitly preserving the right of a megacap to win after evidence-based evaluation.

--- a/docs/governance/GOVERNANCE-2026-09-05-T0-ANTI-MEGACAP-DISCOVERY.md
+++ b/docs/governance/GOVERNANCE-2026-09-05-T0-ANTI-MEGACAP-DISCOVERY.md
@@ -1,0 +1,44 @@
+# Governance Log Ω
+
+| Campo | Valor |
+|---|---|
+| ID | GOV-2026-0905-T0 |
+| Qué | Constitucionalización de T0 — Anti-Megacap Discovery Gate Ω |
+| Quién | Vicente / ATLAS Ω |
+| Cuándo | 2026-09-05 |
+| Issue | #102 |
+| Estado | APROBADO · pendiente de merge técnico al abrir esta entrada |
+
+## Acción
+
+Promover T0 de regla de neutralidad de tamaño a **gate constitucional de descubrimiento**, ejecutado antes de todos los motores analíticos, contratos griegos, ranking, allocation y ejecución.
+
+## Problema corregido
+
+Un sistema puede declarar `market cap contribution = 0` y seguir estando sesgado si el universo inicial fue construido a partir de índices, cobertura de analistas, familiaridad de marca o disponibilidad de datos. El sesgo de descubrimiento sucede antes del score.
+
+## Nueva regla
+
+1. Toda empresa parte de cero después de T0.
+2. Market cap, pertenencia a índice, cobertura, familiaridad y comodidad de datos aportan 0 a descubrimiento y score.
+3. T0 fuerza cobertura por buckets de capitalización.
+4. En búsquedas `CHALLENGER` y `NO_AI`, la primera tanda no puede superar 20% de megacaps salvo justificación explícita basada en evidencia.
+5. Los buckets se asignan después de congelar la prioridad de descubrimiento.
+6. La cobertura por bucket jamás modifica el score final.
+7. Una megacap puede quedar #1 si gana después por evidencia económica.
+8. Saturación, runway, liquidez o ventajas de escala sólo pueden entrar por una cadena causal demostrada, no por tamaño en abstracto.
+
+## Audit trail obligatorio
+
+- source de descubrimiento;
+- rank anterior a conocer tamaño;
+- bucket posterior al freeze;
+- si el tamaño era conocido antes de la entrada;
+- razón de selección;
+- contaminación por tamaño, índice, cobertura, marca o disponibilidad de datos.
+
+## Rollback
+
+Revertir T0 como gate constitucional devolvería el sistema a una neutralidad sólo post-selección y permitiría que un universo sesgado por megacaps llegara limpio al score. Los scores ya calculados no se reescriben automáticamente, pero futuras búsquedas perderían la garantía de descubrimiento size-blind.
+
+Rollback permitido sólo mediante revisión metodológica registrada.

--- a/src/atlas/algorithm/atlas-primary-engine-hierarchy.ts
+++ b/src/atlas/algorithm/atlas-primary-engine-hierarchy.ts
@@ -1,5 +1,6 @@
 export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
-  version: '2026-09-05-v4.16.0',
+  version: '2026-09-05-v4.17.0',
+  firstConstitutionalGate: 'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1',
   firstAnalyticalEngine: 'GREEN_VERIFIED_CONTINUITY_OMEGA_V1_0',
   greenVerificationStack: ['GREEN_PROVIDER_QUORUM_OMEGA_V1_1', 'GREEN_CONTINUITY_OMEGA_V1_4'] as const,
   primaryEngine: 'PRINCIPAL_OMEGA',
@@ -59,12 +60,21 @@ export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
     'MODEL_LEARNING_GOVERNANCE_OMEGA_V1',
   ] as const,
   transversalGates: [
+    'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1',
     'ANTI_DELUSION_CORE_OMEGA', 'EVIDENCE_INTEGRITY_OMEGA', 'SOURCE_AUTHENTICITY_OMEGA', 'QUANTITATIVE_INTEGRITY_OMEGA',
     'TEMPORAL_NORMALIZATION_OMEGA', 'VALUATION_METHOD_INTEGRITY_OMEGA_V1', 'SIZE_NEUTRALITY_AUDIT_OMEGA_V1', 'SYSTEMIC_CASCADE_OMEGA_V1',
     'CONVEXITY_RUIN_GUARD_OMEGA_V1', 'PRE_MORTEM_INVERSION_OMEGA_V1',
     'FALSIFIER_VETO_OMEGA_V1', 'LIQUIDITY_SPREAD_GATE_OMEGA_V1_1', 'DECISION_SAFETY_GATE_OMEGA',
   ] as const,
   rules: [
+    'T0 ANTI-MEGACAP DISCOVERY GATE is constitutional and precedes every ATLAS analytical, learning, Greek-contract, allocation and execution engine.',
+    'T0 neutralizes discovery bias upstream: market cap, index membership, analyst coverage, brand familiarity and raw data availability contribute exactly zero to discovery priority and exactly zero to score.',
+    'T0 does not penalize megacaps. A megacap may rank first after T0 when evidence-based economics, Expected Return and applicable gates justify it.',
+    'In CHALLENGER and NO-AI discovery, absent explicit evidence justifying a different composition, megacaps may not exceed 20% of the first discovery tranche.',
+    'T0 requires capitalization-bucket coverage as a discovery audit; bucket balancing changes coverage only and never changes a frozen company score.',
+    'Market-cap bucket is assigned only after discovery priority is frozen and remains an audit/risk descriptor rather than a discovery or scoring input.',
+    'Size-related saturation, runway, liquidity or execution-capacity effects are admissible only when demonstrated causally by economic evidence after T0; size itself is never proof.',
+    'A universe already dominated by megacaps because of familiarity, index-first sourcing, analyst coverage or data convenience is DISCOVERY_BIAS_DETECTED even if later scoring starts at zero.',
     'After integrity and ticker-identity normalization, canonical GREEN execution enters through GREEN VERIFIED CONTINUITY Ω, which runs Provider Quorum before GREEN classification.',
     'No caller may promote vendor performance labels, inferred percentages or unsynchronized observations directly into a GREEN score.',
     'GREEN requires 3 core providers per horizon; Trading 212 user evidence is an optional broker cross-check and never counts toward the core-provider minimum.',
@@ -100,7 +110,6 @@ export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
     'Unverified evidence cannot be promoted to a confirmed falsifier.',
     'Price is not evidence and a trigger is not a falsifier.',
     'SIZE-NEUTRAL RETURN RANKING starts every ticker at 0/1000; market cap and generic quality provide zero bonus and zero penalty.',
-    'Market-cap bucket is assigned only after score freeze; size distribution is an audit output, never a score input.',
     'Growth Saturation may reduce expected-return opportunity only from economic evidence, never from size alone.',
     'ENTRY TIMING RETURN-AWARE credits the correction already observed before calculating any remaining pullback requirement.',
     'Current drawdown from ATH or rolling peak is preferred to a negative window return; window return is a fallback only when peak data are unavailable.',
@@ -168,6 +177,7 @@ export const ATLAS_PRIMARY_ENGINE_HIERARCHY = {
 
 export const ATLAS_CANONICAL_DECISION_SEQUENCE = [
   'INPUT',
+  'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1',
   'ANTI_DELUSION_CORE_OMEGA',
   'EVIDENCE_INTEGRITY_OMEGA',
   'SOURCE_AUTHENTICITY_OMEGA',

--- a/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
+++ b/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
@@ -50,6 +50,7 @@ describe('T0 Anti-Megacap Discovery Gate Ω', () => {
     expect(result.marketCapContribution).toBe(0);
     expect(result.directScoreContribution).toBe(0);
     expect(result.state).toBe('PASS_SIZE_NEUTRAL_DISCOVERY');
+    expect(result.downstreamAuthorized).toBe(true);
   });
 
   it('allows a megacap to rank first after T0 when evidence is strongest', () => {
@@ -61,13 +62,15 @@ describe('T0 Anti-Megacap Discovery Gate Ω', () => {
     expect(ranked.map((row) => row.ticker)).toEqual(['MEGA', 'MID', 'SMALL']);
   });
 
-  it('flags explicit upstream size/familiarity bias even if final scores are zeroed later', () => {
+  it('flags upstream size bias and blocks the entire downstream pipeline', () => {
     const result = evaluateT0DiscoveryGate([
       candidate('A', 1, 500_000_000_000, { sizeInfluencedDiscovery: true }),
       candidate('B', 2, 5_000_000_000),
       candidate('C', 3, 1_000_000_000),
     ]);
     expect(result.state).toBe('DISCOVERY_BIAS_DETECTED');
+    expect(result.downstreamAuthorized).toBe(false);
+    expect(result.requiredAction).toBe('REDISCOVER');
     expect(result.reasons).toContain('UPSTREAM_DISCOVERY_BIAS_PRESENT');
   });
 
@@ -81,6 +84,7 @@ describe('T0 Anti-Megacap Discovery Gate Ω', () => {
     ], 'CHALLENGER', 5);
     expect(result.firstTrancheMegaShare).toBe(0.6);
     expect(result.state).toBe('DISCOVERY_BIAS_DETECTED');
+    expect(result.downstreamAuthorized).toBe(false);
     expect(result.reasons).toContain('FIRST_TRANCHE_MEGACAP_SHARE_ABOVE_20_PERCENT');
   });
 
@@ -95,7 +99,7 @@ describe('T0 Anti-Megacap Discovery Gate Ω', () => {
     expect(result.state).not.toBe('DISCOVERY_BIAS_DETECTED');
   });
 
-  it('warns when discovery coverage collapses into too few capitalization buckets', () => {
+  it('warns in general discovery when bucket coverage is narrow but does not change score', () => {
     const result = evaluateT0DiscoveryGate([
       candidate('A', 1, 40_000_000_000),
       candidate('B', 2, 30_000_000_000),
@@ -105,13 +109,42 @@ describe('T0 Anti-Megacap Discovery Gate Ω', () => {
       candidate('F', 6, 11_000_000_000),
     ]);
     expect(result.state).toBe('PASS_WITH_COVERAGE_WARNING');
+    expect(result.downstreamAuthorized).toBe(true);
     expect(result.reasons).toContain('INSUFFICIENT_CAPITALIZATION_BUCKET_COVERAGE');
+  });
+
+  it('blocks challenger discovery when capitalization bucket coverage is insufficient', () => {
+    const result = evaluateT0DiscoveryGate([
+      candidate('A', 1, 40_000_000_000),
+      candidate('B', 2, 30_000_000_000),
+      candidate('C', 3, 20_000_000_000),
+      candidate('D', 4, 15_000_000_000),
+      candidate('E', 5, 12_000_000_000),
+      candidate('F', 6, 11_000_000_000),
+    ], 'CHALLENGER', 6);
+    expect(result.state).toBe('COVERAGE_INSUFFICIENT');
+    expect(result.downstreamAuthorized).toBe(false);
+    expect(result.requiredAction).toBe('EXPAND_BUCKET_COVERAGE');
   });
 
   it('fails closed to evidence pending when there is no discovery universe', () => {
     const result = evaluateT0DiscoveryGate([]);
     expect(result.state).toBe('EVIDENCE_PENDING');
+    expect(result.downstreamAuthorized).toBe(false);
     expect(result.firstTrancheMegaShare).toBeNull();
+  });
+
+  it('fails closed in challenger mode when post-freeze market-cap evidence is incomplete', () => {
+    const unknown = candidate('UNKNOWN', 1, 1_000_000_000);
+    unknown.marketCapUsd = null;
+    const result = evaluateT0DiscoveryGate([
+      unknown,
+      candidate('MID', 2, 5_000_000_000),
+      candidate('SMALL', 3, 1_000_000_000),
+    ], 'NO_AI', 3);
+    expect(result.state).toBe('EVIDENCE_PENDING');
+    expect(result.downstreamAuthorized).toBe(false);
+    expect(result.reasons).toContain('CHALLENGER_MEGA_SHARE_NOT_FULLY_AUDITABLE');
   });
 
   it('records analyst, familiarity and raw-data discovery contamination in the audit trail', () => {

--- a/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
+++ b/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ATLAS_CANONICAL_DECISION_SEQUENCE,
+  ATLAS_PRIMARY_ENGINE_HIERARCHY,
+} from './atlas-primary-engine-hierarchy';
+import {
   classifyMarketCapBucket,
   evaluateT0DiscoveryGate,
   rankAfterT0,
@@ -23,6 +27,19 @@ const candidate = (
 });
 
 describe('T0 Anti-Megacap Discovery Gate Ω', () => {
+  it('is the constitutional first gate before every analytical engine', () => {
+    expect(ATLAS_PRIMARY_ENGINE_HIERARCHY.version).toBe('2026-09-05-v4.17.0');
+    expect(ATLAS_PRIMARY_ENGINE_HIERARCHY.firstConstitutionalGate)
+      .toBe('T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1');
+    expect(ATLAS_CANONICAL_DECISION_SEQUENCE[0]).toBe('INPUT');
+    expect(ATLAS_CANONICAL_DECISION_SEQUENCE[1])
+      .toBe('T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1');
+    expect(ATLAS_CANONICAL_DECISION_SEQUENCE.indexOf('T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1'))
+      .toBeLessThan(ATLAS_CANONICAL_DECISION_SEQUENCE.indexOf('GLOBAL_DISCOVERY_OMEGA'));
+    expect(ATLAS_CANONICAL_DECISION_SEQUENCE.indexOf('T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1'))
+      .toBeLessThan(ATLAS_CANONICAL_DECISION_SEQUENCE.indexOf('PRINCIPAL_OMEGA'));
+  });
+
   it('classifies capitalization only after discovery and gives size zero score contribution', () => {
     expect(classifyMarketCapBucket(250_000_000_000)).toBe('MEGA');
     const result = evaluateT0DiscoveryGate([

--- a/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
+++ b/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyMarketCapBucket,
+  evaluateT0DiscoveryGate,
+  rankAfterT0,
+  type T0DiscoveryCandidate,
+} from './t0-anti-megacap-discovery-gate-omega';
+
+const candidate = (
+  ticker: string,
+  rank: number,
+  marketCapUsd: number,
+  overrides: Partial<T0DiscoveryCandidate> = {},
+): T0DiscoveryCandidate => ({
+  ticker,
+  discoverySource: 'bucket-screen',
+  candidateRankBeforeSize: rank,
+  selectionReason: 'economic evidence candidate',
+  enteredBeforeSizeKnown: true,
+  sizeInfluencedDiscovery: false,
+  marketCapUsd,
+  ...overrides,
+});
+
+describe('T0 Anti-Megacap Discovery Gate Ω', () => {
+  it('classifies capitalization only after discovery and gives size zero score contribution', () => {
+    expect(classifyMarketCapBucket(250_000_000_000)).toBe('MEGA');
+    const result = evaluateT0DiscoveryGate([
+      candidate('MEGA', 1, 250_000_000_000),
+      candidate('MID', 2, 8_000_000_000),
+      candidate('SMALL', 3, 1_000_000_000),
+    ]);
+    expect(result.marketCapContribution).toBe(0);
+    expect(result.directScoreContribution).toBe(0);
+    expect(result.state).toBe('PASS_SIZE_NEUTRAL_DISCOVERY');
+  });
+
+  it('allows a megacap to rank first after T0 when evidence is strongest', () => {
+    const ranked = rankAfterT0([
+      { ticker: 'SMALL', evidenceScore: 84 },
+      { ticker: 'MEGA', evidenceScore: 96 },
+      { ticker: 'MID', evidenceScore: 90 },
+    ]);
+    expect(ranked.map((row) => row.ticker)).toEqual(['MEGA', 'MID', 'SMALL']);
+  });
+
+  it('flags explicit upstream size/familiarity bias even if final scores are zeroed later', () => {
+    const result = evaluateT0DiscoveryGate([
+      candidate('A', 1, 500_000_000_000, { sizeInfluencedDiscovery: true }),
+      candidate('B', 2, 5_000_000_000),
+      candidate('C', 3, 1_000_000_000),
+    ]);
+    expect(result.state).toBe('DISCOVERY_BIAS_DETECTED');
+    expect(result.reasons).toContain('UPSTREAM_DISCOVERY_BIAS_PRESENT');
+  });
+
+  it('enforces the 20% first-tranche megacap ceiling in challenger discovery', () => {
+    const result = evaluateT0DiscoveryGate([
+      candidate('M1', 1, 800_000_000_000),
+      candidate('M2', 2, 500_000_000_000),
+      candidate('M3', 3, 250_000_000_000),
+      candidate('L1', 4, 50_000_000_000),
+      candidate('S1', 5, 1_000_000_000),
+    ], 'CHALLENGER', 5);
+    expect(result.firstTrancheMegaShare).toBe(0.6);
+    expect(result.state).toBe('DISCOVERY_BIAS_DETECTED');
+    expect(result.reasons).toContain('FIRST_TRANCHE_MEGACAP_SHARE_ABOVE_20_PERCENT');
+  });
+
+  it('does not apply the 20% challenger ceiling as a universal portfolio penalty', () => {
+    const result = evaluateT0DiscoveryGate([
+      candidate('M1', 1, 800_000_000_000),
+      candidate('M2', 2, 500_000_000_000),
+      candidate('M3', 3, 250_000_000_000),
+      candidate('L1', 4, 50_000_000_000),
+      candidate('S1', 5, 1_000_000_000),
+    ], 'GENERAL', 5);
+    expect(result.state).not.toBe('DISCOVERY_BIAS_DETECTED');
+  });
+
+  it('warns when discovery coverage collapses into too few capitalization buckets', () => {
+    const result = evaluateT0DiscoveryGate([
+      candidate('A', 1, 40_000_000_000),
+      candidate('B', 2, 30_000_000_000),
+      candidate('C', 3, 20_000_000_000),
+      candidate('D', 4, 15_000_000_000),
+      candidate('E', 5, 12_000_000_000),
+      candidate('F', 6, 11_000_000_000),
+    ]);
+    expect(result.state).toBe('PASS_WITH_COVERAGE_WARNING');
+    expect(result.reasons).toContain('INSUFFICIENT_CAPITALIZATION_BUCKET_COVERAGE');
+  });
+
+  it('fails closed to evidence pending when there is no discovery universe', () => {
+    const result = evaluateT0DiscoveryGate([]);
+    expect(result.state).toBe('EVIDENCE_PENDING');
+    expect(result.firstTrancheMegaShare).toBeNull();
+  });
+
+  it('records analyst, familiarity and raw-data discovery contamination in the audit trail', () => {
+    const result = evaluateT0DiscoveryGate([
+      candidate('X', 1, 100_000_000_000, {
+        analystCoverageInfluencedDiscovery: true,
+        brandFamiliarityInfluencedDiscovery: true,
+        rawDataAvailabilityInfluencedDiscovery: true,
+      }),
+      candidate('Y', 2, 5_000_000_000),
+    ]);
+    expect(result.state).toBe('DISCOVERY_BIAS_DETECTED');
+    expect(result.audit[0].discoveryBiasReasons).toEqual(expect.arrayContaining([
+      'ANALYST_COVERAGE_INFLUENCED_DISCOVERY',
+      'BRAND_FAMILIARITY_INFLUENCED_DISCOVERY',
+      'RAW_DATA_AVAILABILITY_INFLUENCED_DISCOVERY',
+    ]));
+  });
+});

--- a/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts
+++ b/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts
@@ -1,0 +1,194 @@
+export type T0MarketCapBucket = 'MICRO' | 'SMALL' | 'MID' | 'LARGE' | 'MEGA' | 'UNKNOWN';
+
+export type T0DiscoveryMode = 'GENERAL' | 'CHALLENGER' | 'NO_AI';
+
+export interface T0DiscoveryCandidate {
+  ticker: string;
+  discoverySource: string;
+  candidateRankBeforeSize: number;
+  selectionReason: string;
+  enteredBeforeSizeKnown: boolean;
+  sizeInfluencedDiscovery: boolean;
+  marketCapUsd?: number | null;
+  indexMembershipKnownAtDiscovery?: boolean;
+  analystCoverageInfluencedDiscovery?: boolean;
+  brandFamiliarityInfluencedDiscovery?: boolean;
+  rawDataAvailabilityInfluencedDiscovery?: boolean;
+}
+
+export interface T0AuditRecord {
+  ticker: string;
+  discoverySource: string;
+  candidateRankBeforeSize: number;
+  marketCapBucketAfterFreeze: T0MarketCapBucket;
+  enteredBeforeSizeKnown: boolean;
+  selectionReason: string;
+  sizeInfluencedDiscovery: boolean;
+  discoveryBiasReasons: string[];
+}
+
+export type T0State =
+  | 'PASS_SIZE_NEUTRAL_DISCOVERY'
+  | 'PASS_WITH_COVERAGE_WARNING'
+  | 'DISCOVERY_BIAS_DETECTED'
+  | 'EVIDENCE_PENDING';
+
+export interface T0Result {
+  state: T0State;
+  mode: T0DiscoveryMode;
+  directScoreContribution: 0;
+  marketCapContribution: 0;
+  indexMembershipContribution: 0;
+  analystCoverageContribution: 0;
+  brandFamiliarityContribution: 0;
+  rawDataAvailabilityContribution: 0;
+  firstTrancheSize: number;
+  firstTrancheMegaShare: number | null;
+  bucketCounts: Record<T0MarketCapBucket, number>;
+  audit: T0AuditRecord[];
+  reasons: string[];
+}
+
+export const T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1 = {
+  id: 'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1',
+  status: 'CANONICAL_FIRST_GATE',
+  directScoreContribution: 0 as const,
+  challengerFirstTrancheMegaCapLimit: 0.2,
+  invariants: [
+    'Every company starts from zero after T0.',
+    'Market cap gives neither bonus nor penalty.',
+    'Index membership gives neither bonus nor penalty.',
+    'Analyst coverage, brand familiarity and raw data availability give no discovery or score bonus.',
+    'Capitalization buckets are assigned only after discovery priority is frozen.',
+    'Bucket balancing changes discovery coverage only; it never changes final score.',
+    'A megacap may rank first after T0 if it wins on evidence.',
+    'Size-related saturation, runway, liquidity or capacity effects are admissible only through causal economic evidence after discovery.',
+  ] as const,
+} as const;
+
+const finiteNonNegative = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0;
+
+export function classifyMarketCapBucket(marketCapUsd?: number | null): T0MarketCapBucket {
+  if (!finiteNonNegative(marketCapUsd)) return 'UNKNOWN';
+  if (marketCapUsd < 300_000_000) return 'MICRO';
+  if (marketCapUsd < 2_000_000_000) return 'SMALL';
+  if (marketCapUsd < 10_000_000_000) return 'MID';
+  if (marketCapUsd < 200_000_000_000) return 'LARGE';
+  return 'MEGA';
+}
+
+function biasReasons(candidate: T0DiscoveryCandidate): string[] {
+  const reasons: string[] = [];
+  if (candidate.sizeInfluencedDiscovery) reasons.push('SIZE_INFLUENCED_DISCOVERY');
+  if (candidate.indexMembershipKnownAtDiscovery === true) reasons.push('INDEX_MEMBERSHIP_AVAILABLE_AT_DISCOVERY');
+  if (candidate.analystCoverageInfluencedDiscovery) reasons.push('ANALYST_COVERAGE_INFLUENCED_DISCOVERY');
+  if (candidate.brandFamiliarityInfluencedDiscovery) reasons.push('BRAND_FAMILIARITY_INFLUENCED_DISCOVERY');
+  if (candidate.rawDataAvailabilityInfluencedDiscovery) reasons.push('RAW_DATA_AVAILABILITY_INFLUENCED_DISCOVERY');
+  if (!candidate.enteredBeforeSizeKnown) reasons.push('SIZE_KNOWN_BEFORE_DISCOVERY_FREEZE');
+  return reasons;
+}
+
+function countBuckets(audit: T0AuditRecord[]): Record<T0MarketCapBucket, number> {
+  const counts: Record<T0MarketCapBucket, number> = {
+    MICRO: 0,
+    SMALL: 0,
+    MID: 0,
+    LARGE: 0,
+    MEGA: 0,
+    UNKNOWN: 0,
+  };
+  for (const row of audit) counts[row.marketCapBucketAfterFreeze] += 1;
+  return counts;
+}
+
+export function evaluateT0DiscoveryGate(
+  candidates: T0DiscoveryCandidate[],
+  mode: T0DiscoveryMode = 'GENERAL',
+  firstTrancheSize = Math.min(20, candidates.length),
+): T0Result {
+  const reasons: string[] = [];
+
+  if (!Array.isArray(candidates) || candidates.length === 0 || firstTrancheSize <= 0) {
+    return {
+      state: 'EVIDENCE_PENDING',
+      mode,
+      directScoreContribution: 0,
+      marketCapContribution: 0,
+      indexMembershipContribution: 0,
+      analystCoverageContribution: 0,
+      brandFamiliarityContribution: 0,
+      rawDataAvailabilityContribution: 0,
+      firstTrancheSize: 0,
+      firstTrancheMegaShare: null,
+      bucketCounts: { MICRO: 0, SMALL: 0, MID: 0, LARGE: 0, MEGA: 0, UNKNOWN: 0 },
+      audit: [],
+      reasons: ['NO_DISCOVERY_CANDIDATES'],
+    };
+  }
+
+  const ordered = [...candidates].sort((a, b) => a.candidateRankBeforeSize - b.candidateRankBeforeSize);
+  const audit: T0AuditRecord[] = ordered.map((candidate) => ({
+    ticker: candidate.ticker,
+    discoverySource: candidate.discoverySource,
+    candidateRankBeforeSize: candidate.candidateRankBeforeSize,
+    marketCapBucketAfterFreeze: classifyMarketCapBucket(candidate.marketCapUsd),
+    enteredBeforeSizeKnown: candidate.enteredBeforeSizeKnown,
+    selectionReason: candidate.selectionReason,
+    sizeInfluencedDiscovery: candidate.sizeInfluencedDiscovery,
+    discoveryBiasReasons: biasReasons(candidate),
+  }));
+
+  const explicitBias = audit.some((row) => row.discoveryBiasReasons.some((reason) =>
+    reason !== 'INDEX_MEMBERSHIP_AVAILABLE_AT_DISCOVERY'
+  ));
+
+  const tranche = audit.slice(0, Math.min(firstTrancheSize, audit.length));
+  const megaKnown = tranche.filter((row) => row.marketCapBucketAfterFreeze === 'MEGA').length;
+  const knownSize = tranche.filter((row) => row.marketCapBucketAfterFreeze !== 'UNKNOWN').length;
+  const megaShare = knownSize > 0 ? megaKnown / knownSize : null;
+
+  const bucketCounts = countBuckets(audit);
+  const representedBuckets = (Object.entries(bucketCounts) as [T0MarketCapBucket, number][])
+    .filter(([bucket, count]) => bucket !== 'UNKNOWN' && count > 0)
+    .map(([bucket]) => bucket);
+
+  const challengerMode = mode === 'CHALLENGER' || mode === 'NO_AI';
+  const megaCapLimitBreached = challengerMode && megaShare !== null && megaShare > T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.challengerFirstTrancheMegaCapLimit;
+
+  if (explicitBias) reasons.push('UPSTREAM_DISCOVERY_BIAS_PRESENT');
+  if (megaCapLimitBreached) reasons.push('FIRST_TRANCHE_MEGACAP_SHARE_ABOVE_20_PERCENT');
+  if (representedBuckets.length < 3 && audit.length >= 6) reasons.push('INSUFFICIENT_CAPITALIZATION_BUCKET_COVERAGE');
+  if (audit.some((row) => row.marketCapBucketAfterFreeze === 'UNKNOWN')) reasons.push('SOME_MARKET_CAP_BUCKETS_UNKNOWN_AFTER_FREEZE');
+
+  let state: T0State = 'PASS_SIZE_NEUTRAL_DISCOVERY';
+  if (explicitBias || megaCapLimitBreached) state = 'DISCOVERY_BIAS_DETECTED';
+  else if (reasons.length > 0) state = 'PASS_WITH_COVERAGE_WARNING';
+
+  return {
+    state,
+    mode,
+    directScoreContribution: 0,
+    marketCapContribution: 0,
+    indexMembershipContribution: 0,
+    analystCoverageContribution: 0,
+    brandFamiliarityContribution: 0,
+    rawDataAvailabilityContribution: 0,
+    firstTrancheSize: tranche.length,
+    firstTrancheMegaShare: megaShare,
+    bucketCounts,
+    audit,
+    reasons,
+  };
+}
+
+export interface T0PostGateEvidenceScore {
+  ticker: string;
+  evidenceScore: number;
+}
+
+export function rankAfterT0(scores: T0PostGateEvidenceScore[]): T0PostGateEvidenceScore[] {
+  return [...scores]
+    .filter((row) => Number.isFinite(row.evidenceScore))
+    .sort((a, b) => b.evidenceScore - a.evidenceScore || a.ticker.localeCompare(b.ticker));
+}

--- a/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts
+++ b/src/atlas/algorithm/t0-anti-megacap-discovery-gate-omega.ts
@@ -31,11 +31,16 @@ export type T0State =
   | 'PASS_SIZE_NEUTRAL_DISCOVERY'
   | 'PASS_WITH_COVERAGE_WARNING'
   | 'DISCOVERY_BIAS_DETECTED'
+  | 'COVERAGE_INSUFFICIENT'
   | 'EVIDENCE_PENDING';
+
+export type T0RequiredAction = 'PROCEED' | 'REDISCOVER' | 'EXPAND_BUCKET_COVERAGE' | 'COMPLETE_EVIDENCE';
 
 export interface T0Result {
   state: T0State;
   mode: T0DiscoveryMode;
+  downstreamAuthorized: boolean;
+  requiredAction: T0RequiredAction;
   directScoreContribution: 0;
   marketCapContribution: 0;
   indexMembershipContribution: 0;
@@ -54,6 +59,7 @@ export const T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1 = {
   status: 'CANONICAL_FIRST_GATE',
   directScoreContribution: 0 as const,
   challengerFirstTrancheMegaCapLimit: 0.2,
+  minimumCoveredBucketsForBroadDiscovery: 3,
   invariants: [
     'Every company starts from zero after T0.',
     'Market cap gives neither bonus nor penalty.',
@@ -63,6 +69,7 @@ export const T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1 = {
     'Bucket balancing changes discovery coverage only; it never changes final score.',
     'A megacap may rank first after T0 if it wins on evidence.',
     'Size-related saturation, runway, liquidity or capacity effects are admissible only through causal economic evidence after discovery.',
+    'DISCOVERY_BIAS_DETECTED, COVERAGE_INSUFFICIENT and EVIDENCE_PENDING cannot authorize downstream analysis.',
   ] as const,
 } as const;
 
@@ -102,6 +109,13 @@ function countBuckets(audit: T0AuditRecord[]): Record<T0MarketCapBucket, number>
   return counts;
 }
 
+function actionForState(state: T0State): T0RequiredAction {
+  if (state === 'DISCOVERY_BIAS_DETECTED') return 'REDISCOVER';
+  if (state === 'COVERAGE_INSUFFICIENT') return 'EXPAND_BUCKET_COVERAGE';
+  if (state === 'EVIDENCE_PENDING') return 'COMPLETE_EVIDENCE';
+  return 'PROCEED';
+}
+
 export function evaluateT0DiscoveryGate(
   candidates: T0DiscoveryCandidate[],
   mode: T0DiscoveryMode = 'GENERAL',
@@ -113,6 +127,8 @@ export function evaluateT0DiscoveryGate(
     return {
       state: 'EVIDENCE_PENDING',
       mode,
+      downstreamAuthorized: false,
+      requiredAction: 'COMPLETE_EVIDENCE',
       directScoreContribution: 0,
       marketCapContribution: 0,
       indexMembershipContribution: 0,
@@ -146,6 +162,7 @@ export function evaluateT0DiscoveryGate(
   const tranche = audit.slice(0, Math.min(firstTrancheSize, audit.length));
   const megaKnown = tranche.filter((row) => row.marketCapBucketAfterFreeze === 'MEGA').length;
   const knownSize = tranche.filter((row) => row.marketCapBucketAfterFreeze !== 'UNKNOWN').length;
+  const unknownSize = tranche.length - knownSize;
   const megaShare = knownSize > 0 ? megaKnown / knownSize : null;
 
   const bucketCounts = countBuckets(audit);
@@ -154,20 +171,33 @@ export function evaluateT0DiscoveryGate(
     .map(([bucket]) => bucket);
 
   const challengerMode = mode === 'CHALLENGER' || mode === 'NO_AI';
-  const megaCapLimitBreached = challengerMode && megaShare !== null && megaShare > T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.challengerFirstTrancheMegaCapLimit;
+  const megaCapLimitBreached = challengerMode
+    && megaShare !== null
+    && megaShare > T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.challengerFirstTrancheMegaCapLimit;
+  const broadCoverageExpected = audit.length >= 6;
+  const coverageInsufficient = broadCoverageExpected
+    && representedBuckets.length < T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1.minimumCoveredBucketsForBroadDiscovery;
+  const challengerSizeEvidenceIncomplete = challengerMode && unknownSize > 0;
 
   if (explicitBias) reasons.push('UPSTREAM_DISCOVERY_BIAS_PRESENT');
   if (megaCapLimitBreached) reasons.push('FIRST_TRANCHE_MEGACAP_SHARE_ABOVE_20_PERCENT');
-  if (representedBuckets.length < 3 && audit.length >= 6) reasons.push('INSUFFICIENT_CAPITALIZATION_BUCKET_COVERAGE');
-  if (audit.some((row) => row.marketCapBucketAfterFreeze === 'UNKNOWN')) reasons.push('SOME_MARKET_CAP_BUCKETS_UNKNOWN_AFTER_FREEZE');
+  if (coverageInsufficient) reasons.push('INSUFFICIENT_CAPITALIZATION_BUCKET_COVERAGE');
+  if (unknownSize > 0) reasons.push('SOME_MARKET_CAP_BUCKETS_UNKNOWN_AFTER_FREEZE');
+  if (challengerSizeEvidenceIncomplete) reasons.push('CHALLENGER_MEGA_SHARE_NOT_FULLY_AUDITABLE');
 
   let state: T0State = 'PASS_SIZE_NEUTRAL_DISCOVERY';
   if (explicitBias || megaCapLimitBreached) state = 'DISCOVERY_BIAS_DETECTED';
+  else if (challengerSizeEvidenceIncomplete) state = 'EVIDENCE_PENDING';
+  else if (challengerMode && coverageInsufficient) state = 'COVERAGE_INSUFFICIENT';
   else if (reasons.length > 0) state = 'PASS_WITH_COVERAGE_WARNING';
+
+  const downstreamAuthorized = state === 'PASS_SIZE_NEUTRAL_DISCOVERY' || state === 'PASS_WITH_COVERAGE_WARNING';
 
   return {
     state,
     mode,
+    downstreamAuthorized,
+    requiredAction: actionForState(state),
     directScoreContribution: 0,
     marketCapContribution: 0,
     indexMembershipContribution: 0,


### PR DESCRIPTION
Closes #102.

Implements T0 — Anti-Megacap Discovery Gate Ω as the constitutional first gate for ATLAS.

Key changes:
- T0 runs immediately after INPUT and before integrity, discovery, Φ/Greek contracts, Expected Return, ranking, allocation and execution.
- market cap, index membership, analyst coverage, brand familiarity and raw data convenience contribute exactly 0 to discovery priority and score.
- upstream discovery contamination is detected even when later score logic is size-neutral.
- CHALLENGER / NO_AI first tranche has a 20% megacap ceiling absent explicit evidence.
- capitalization buckets are assigned after discovery priority freeze; bucket balancing affects coverage only, never final score.
- fail-closed downstream authorization: DISCOVERY_BIAS_DETECTED / COVERAGE_INSUFFICIENT / EVIDENCE_PENDING cannot proceed.
- megacaps are never penalized: they may rank #1 after T0 if evidence wins.
- adds audit trail, canonical documentation, governance entry and dedicated CI.
- hierarchy promoted to v4.17.0.