### PR TITLE
ATLAS Ω — harden Δ divergence with adversarial independence falsation

### DIFF
--- a/.github/workflows/delta-divergence-falsation-omega-ci.yml
+++ b/.github/workflows/delta-divergence-falsation-omega-ci.yml
@@ -1,0 +1,18 @@
+name: Delta Divergence Falsation Omega CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/algorithm/delta-divergence-falsation-omega.ts'
+      - 'src/atlas/algorithm/delta-divergence-falsation-omega.test.ts'
+      - 'src/atlas/algorithm/delta-divergence-boundary-omega.test.ts'
+      - 'src/atlas/algorithm/greek-contracts-omega.ts'
+      - '.github/workflows/delta-divergence-falsation-omega-ci.yml'
+
+jobs:
+  falsation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Delta falsation matrix
+        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/delta-divergence-falsation-omega.test.ts src/atlas/algorithm/delta-divergence-boundary-omega.test.ts src/atlas/algorithm/greek-contracts-omega.test.ts

--- a/.github/workflows/delta-divergence-falsation-omega-ci.yml
+++ b/.github/workflows/delta-divergence-falsation-omega-ci.yml
@@ -6,6 +6,8 @@ on:
       - 'src/atlas/algorithm/delta-divergence-falsation-omega.ts'
       - 'src/atlas/algorithm/delta-divergence-falsation-omega.test.ts'
       - 'src/atlas/algorithm/delta-divergence-boundary-omega.test.ts'
+      - 'src/atlas/algorithm/delta-independence-authority-omega.ts'
+      - 'src/atlas/algorithm/delta-independence-authority-omega.test.ts'
       - 'src/atlas/algorithm/greek-contracts-omega.ts'
       - '.github/workflows/delta-divergence-falsation-omega-ci.yml'
 
@@ -15,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Delta falsation matrix
-        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/delta-divergence-falsation-omega.test.ts src/atlas/algorithm/delta-divergence-boundary-omega.test.ts src/atlas/algorithm/greek-contracts-omega.test.ts
+        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/delta-divergence-falsation-omega.test.ts src/atlas/algorithm/delta-divergence-boundary-omega.test.ts src/atlas/algorithm/delta-independence-authority-omega.test.ts src/atlas/algorithm/greek-contracts-omega.test.ts

--- a/CURRENT_CANON/2026-09-05_DELTA_DIVERGENCE_FALSATION_OMEGA_V1_1.md
+++ b/CURRENT_CANON/2026-09-05_DELTA_DIVERGENCE_FALSATION_OMEGA_V1_1.md
@@ -1,0 +1,56 @@
+# ATLAS Ω — Δ Divergence Falsation Ω v1.1
+
+**Date:** 2026-09-05  
+**Status:** CANDIDATE pending CI and merge.
+
+Δ measures disagreement. It does not decide truth, quality, valuation, admission, allocation or execution.
+
+## Canonical eligibility
+
+`independent: true` is not evidence of independence.
+
+A canonical Δ result now requires an auditable lineage envelope per pass:
+- evaluator ID;
+- model family;
+- model instance;
+- prompt lineage;
+- reasoning template;
+- aligned evidence graph;
+- frozen evidence snapshot hash;
+- upstream provider IDs;
+- independence attestation ID.
+
+## States
+
+- `MEDIBLE`: canonical divergence may be computed and may feed Core Confidence.
+- `SHADOW_ONLY`: descriptive raw dispersion only; cannot feed Core Confidence.
+- `NO_MEDIBLE`: no canonical divergence.
+
+## Hard failures
+
+- fewer than three passes;
+- declarative independence without attestation;
+- duplicate evaluator;
+- shared model instance;
+- shared prompt lineage;
+- evidence graph mismatch;
+- evidence snapshot mismatch;
+- numerical near-duplicate pass;
+- severe dimension undercoverage;
+- invalid lineage.
+
+## Shadow degradations
+
+- shared model family;
+- shared reasoning template;
+- identical upstream provider sets;
+- incomplete dimension coverage;
+- non-zero divergence with mean probability at <=2% or >=98%, where normalized divergence is boundary-sensitive.
+
+## Core Confidence firewall
+
+Only hardened `MEDIBLE` Δ can enter Core Confidence. `SHADOW_ONLY`, `Δ_PROXY`, `SHADOW_DISPERSION` and `NO_MEDIBLE` return no effective confidence.
+
+## Falsation matrix
+
+D1–D10 are executable tests, not narrative checks. The contract remains candidate until CI demonstrates that each attack fails closed as specified.

--- a/CURRENT_CANON/2026-09-05_DELTA_DIVERGENCE_FALSATION_OMEGA_V1_1.md
+++ b/CURRENT_CANON/2026-09-05_DELTA_DIVERGENCE_FALSATION_OMEGA_V1_1.md
@@ -1,15 +1,15 @@
 # ATLAS Ω — Δ Divergence Falsation Ω v1.1
 
 **Date:** 2026-09-05  
-**Status:** CANDIDATE pending CI and merge.
+**Status:** SHADOW_ONLY until independence is evidenced by authority outside the common orchestration domain.
 
 Δ measures disagreement. It does not decide truth, quality, valuation, admission, allocation or execution.
 
 ## Canonical eligibility
 
-`independent: true` is not evidence of independence.
+`independent: true` is never evidence of independence.
 
-A canonical Δ result now requires an auditable lineage envelope per pass:
+A potentially canonical Δ result requires an auditable lineage envelope per pass:
 - evaluator ID;
 - model family;
 - model instance;
@@ -20,16 +20,29 @@ A canonical Δ result now requires an auditable lineage envelope per pass:
 - upstream provider IDs;
 - independence attestation ID.
 
+Those fields are necessary but not sufficient. An attestation minted by the same orchestrator that produced the evaluations does not establish independence; it merely self-describes it. Until ATLAS can obtain execution receipts or attestations from genuinely separate authority domains, Δ cannot assert canonical independence.
+
 ## States
 
-- `MEDIBLE`: canonical divergence may be computed and may feed Core Confidence.
-- `SHADOW_ONLY`: descriptive raw dispersion only; cannot feed Core Confidence.
-- `NO_MEDIBLE`: no canonical divergence.
+- `MEDIBLE`: reserved for future runs whose independence is evidenced outside the common orchestration domain; only this state may feed Core Confidence.
+- `SHADOW_ONLY`: descriptive raw dispersion/sensitivity only; cannot feed Core Confidence.
+- `NO_MEDIBLE`: blocking falsation finding or invalid common-evidence preconditions.
+
+## Current kernel rule
+
+Δ remains available as a SHADOW diagnostic contract, but no current same-orchestrator multi-pass execution may produce canonical `D_Ω` or modify Core Confidence.
+
+COHR therefore remains:
+- `Δ_PROXY`
+- `D_Ω = NO_MEDIBLE`
+- `SHADOW_DISPERSION = 0.149`
+- `Conf_Ω = NO_CALCULABLE`
+- `DisagreementAxis = QUALITATIVE_HYPOTHESIS`
 
 ## Hard failures
 
 - fewer than three passes;
-- declarative independence without attestation;
+- declarative independence without auditable lineage;
 - duplicate evaluator;
 - shared model instance;
 - shared prompt lineage;
@@ -45,12 +58,13 @@ A canonical Δ result now requires an auditable lineage envelope per pass:
 - shared reasoning template;
 - identical upstream provider sets;
 - incomplete dimension coverage;
-- non-zero divergence with mean probability at <=2% or >=98%, where normalized divergence is boundary-sensitive.
+- non-zero divergence with mean probability at <=2% or >=98%, where normalized divergence is boundary-sensitive;
+- independence attestation controlled by the same orchestration authority.
 
 ## Core Confidence firewall
 
-Only hardened `MEDIBLE` Δ can enter Core Confidence. `SHADOW_ONLY`, `Δ_PROXY`, `SHADOW_DISPERSION` and `NO_MEDIBLE` return no effective confidence.
+Only hardened `MEDIBLE` Δ may enter Core Confidence. `SHADOW_ONLY`, `Δ_PROXY`, `SHADOW_DISPERSION` and `NO_MEDIBLE` return no effective confidence.
 
 ## Falsation matrix
 
-D1–D10 are executable tests, not narrative checks. The contract remains candidate until CI demonstrates that each attack fails closed as specified.
+D1–D10 are executable tests, not narrative checks. CI passed the adversarial implementation. The result of the audit is not automatic promotion: the remaining independence-authority problem is infrastructural, so Δ stays SHADOW_ONLY until that external proof exists.

--- a/docs/governance/GOVERNANCE-2026-09-05-DELTA-DIVERGENCE-FALSATION.md
+++ b/docs/governance/GOVERNANCE-2026-09-05-DELTA-DIVERGENCE-FALSATION.md
@@ -1,0 +1,54 @@
+# Governance Log Ω — Δ Divergence falsation matrix
+
+**Date:** 2026-09-05  
+**Issue:** #110  
+**Status:** CANDIDATE pending adversarial CI.
+
+## Problem
+
+`DELTA_DIVERGENCE_OMEGA_V1` currently accepts `independent: true` as part of its canonical eligibility test. That flag is declarative. It does not prove independence of evaluator lineage, model family, model instance, prompt lineage, reasoning template, evidence snapshot or upstream source dependencies.
+
+Therefore the existing contract can understate common-mode error and can manufacture apparent consensus from multiple personas or wrappers around one underlying reasoning source.
+
+## Δ v1.1 assurance states
+
+- `MEDIBLE`: no blocking or shadow independence finding remains. Only this state may feed Core Confidence.
+- `SHADOW_ONLY`: raw dispersion may be retained diagnostically but `D_Ω` is not canonical and cannot modify Core Confidence.
+- `NO_MEDIBLE`: blocking falsation finding. No canonical or confidence use.
+
+## Falsation attacks
+
+1. D1 — declarative independence without auditable attestation.
+2. D2 — duplicate evaluator or shared model instance.
+3. D3 — shared model family.
+4. D4 — shared prompt lineage or reasoning template.
+5. D5 — common upstream provider set.
+6. D6 — graph alignment without identical frozen evidence snapshot.
+7. D7 — numerical near-duplicate passes.
+8. D8 — selective dimension omission / cherry-picking.
+9. D9 — normalized divergence near Bernoulli boundaries.
+10. D10 — fewer than three passes.
+
+## Independence rule
+
+Distinct evaluator IDs are necessary but insufficient. Canonical independence requires traceable lineage separation. `independent: true` never proves independence by itself.
+
+A shared model instance is a hard failure. A shared model family is SHADOW because separate instances/prompts can still provide useful sensitivity analysis but not strongest independence evidence. Shared prompt lineage is a hard common-mode failure. Shared reasoning templates or identical upstream provider sets are SHADOW common-mode risks.
+
+All evaluators must operate on the same aligned evidence graph and the same frozen evidence snapshot hash. Otherwise disagreement may measure changing evidence rather than evaluator disagreement.
+
+## Dimension integrity
+
+Per-dimension disagreement requires complete dimension coverage for canonical use. Missing dimensions create cherry-picking risk. A dimension observed in fewer than two-thirds of passes is a blocking integrity failure; any incomplete coverage degrades the overall result to SHADOW_ONLY under v1.1.
+
+## Boundary handling
+
+The normalized statistic `sigma / sqrt(mean*(1-mean))` is mathematically bounded for probabilities in [0,1], but its denominator becomes small close to 0 or 1. Near those boundaries, small absolute dispersion can become disproportionately salient. v1.1 therefore treats mean probability <=2% or >=98% with non-zero sigma as SHADOW_ONLY for normalized divergence; raw sigma/IQR remain descriptive.
+
+## Core Confidence firewall
+
+`calculateHardenedCoreConfidence` accepts only a `MEDIBLE` hardened Δ result. `SHADOW_ONLY`, proxy dispersion and `NO_MEDIBLE` fail closed and return no effective confidence.
+
+## Governance decision rule
+
+Δ remains Kernel-canonical only if the adversarial CI passes and the hardened wrapper becomes the required boundary before Core Confidence. If the tests expose a contradiction that cannot be resolved without unverifiable assumptions, Δ must be degraded to SHADOW rather than preserved by exception.

--- a/docs/governance/GOVERNANCE-2026-09-05-DELTA-DIVERGENCE-FALSATION.md
+++ b/docs/governance/GOVERNANCE-2026-09-05-DELTA-DIVERGENCE-FALSATION.md
@@ -2,19 +2,19 @@
 
 **Date:** 2026-09-05  
 **Issue:** #110  
-**Status:** CANDIDATE pending adversarial CI.
+**Status:** SHADOW_ONLY after adversarial CI; canonical independence not yet demonstrated.
 
 ## Problem
 
-`DELTA_DIVERGENCE_OMEGA_V1` currently accepts `independent: true` as part of its canonical eligibility test. That flag is declarative. It does not prove independence of evaluator lineage, model family, model instance, prompt lineage, reasoning template, evidence snapshot or upstream source dependencies.
+`DELTA_DIVERGENCE_OMEGA_V1` accepted `independent: true` as part of canonical eligibility. That flag is declarative and does not prove independence of evaluator lineage, model family, model instance, prompt lineage, reasoning template, evidence snapshot or upstream source dependencies.
 
-Therefore the existing contract can understate common-mode error and can manufacture apparent consensus from multiple personas or wrappers around one underlying reasoning source.
+The COHR experiment additionally used different evidence per pass, so its observed dispersion mixed reasoning disagreement and information disagreement. It is permanently classified as `Δ_PROXY`, not canonical Δ.
 
 ## Δ v1.1 assurance states
 
-- `MEDIBLE`: no blocking or shadow independence finding remains. Only this state may feed Core Confidence.
+- `MEDIBLE`: no blocking or shadow independence finding remains and independence is evidenced by an authority outside the common orchestration domain. Only this state may feed Core Confidence.
 - `SHADOW_ONLY`: raw dispersion may be retained diagnostically but `D_Ω` is not canonical and cannot modify Core Confidence.
-- `NO_MEDIBLE`: blocking falsation finding. No canonical or confidence use.
+- `NO_MEDIBLE`: blocking falsation finding or invalid common-evidence preconditions. No canonical or confidence use.
 
 ## Falsation attacks
 
@@ -29,17 +29,23 @@ Therefore the existing contract can understate common-mode error and can manufac
 9. D9 — normalized divergence near Bernoulli boundaries.
 10. D10 — fewer than three passes.
 
+CI passed the executable D1–D10 matrix. That proves the firewall implementation behaves as specified; it does not prove the existence of independent evaluators.
+
 ## Independence rule
 
-Distinct evaluator IDs are necessary but insufficient. Canonical independence requires traceable lineage separation. `independent: true` never proves independence by itself.
+Distinct evaluator IDs are necessary but insufficient. `independent: true` never proves independence by itself.
 
-A shared model instance is a hard failure. A shared model family is SHADOW because separate instances/prompts can still provide useful sensitivity analysis but not strongest independence evidence. Shared prompt lineage is a hard common-mode failure. Shared reasoning templates or identical upstream provider sets are SHADOW common-mode risks.
+A lineage envelope and `independenceAttestationId` are also not sufficient when the same orchestrator can mint all of them. An attestation controlled by the same authority as the evaluation is a self-assertion, not external evidence.
 
-All evaluators must operate on the same aligned evidence graph and the same frozen evidence snapshot hash. Otherwise disagreement may measure changing evidence rather than evaluator disagreement.
+Canonical `MEDIBLE` therefore remains unavailable to same-orchestrator multi-pass runs until ATLAS can obtain execution receipts or attestations from genuinely separate authority domains.
+
+A shared model instance is a hard failure. Shared model family, reasoning template or identical upstream provider set are common-mode risks and degrade to SHADOW. Shared prompt lineage is a hard failure.
+
+All evaluators must operate on the same aligned evidence graph and identical frozen evidence snapshot hash. Otherwise observed dispersion mixes `D_razonamiento` and `D_información`.
 
 ## Dimension integrity
 
-Per-dimension disagreement requires complete dimension coverage for canonical use. Missing dimensions create cherry-picking risk. A dimension observed in fewer than two-thirds of passes is a blocking integrity failure; any incomplete coverage degrades the overall result to SHADOW_ONLY under v1.1.
+Per-dimension disagreement requires complete dimension coverage for canonical use. Missing dimensions create cherry-picking risk. A dimension observed in fewer than two-thirds of passes is blocking; any incomplete coverage degrades the overall result to SHADOW_ONLY under v1.1.
 
 ## Boundary handling
 
@@ -47,8 +53,18 @@ The normalized statistic `sigma / sqrt(mean*(1-mean))` is mathematically bounded
 
 ## Core Confidence firewall
 
-`calculateHardenedCoreConfidence` accepts only a `MEDIBLE` hardened Δ result. `SHADOW_ONLY`, proxy dispersion and `NO_MEDIBLE` fail closed and return no effective confidence.
+`calculateHardenedCoreConfidence` accepts only a `MEDIBLE` hardened Δ result. `SHADOW_ONLY`, `Δ_PROXY`, `SHADOW_DISPERSION` and `NO_MEDIBLE` fail closed and return no effective confidence.
 
-## Governance decision rule
+## COHR retained historical result
 
-Δ remains Kernel-canonical only if the adversarial CI passes and the hardened wrapper becomes the required boundary before Core Confidence. If the tests expose a contradiction that cannot be resolved without unverifiable assumptions, Δ must be degraded to SHADOW rather than preserved by exception.
+- `Δ_PROXY`
+- `D_Ω = NO_MEDIBLE`
+- `SHADOW_DISPERSION = 0.149`
+- `Conf_Ω = NO_CALCULABLE`
+- `DisagreementAxis = QUALITATIVE_HYPOTHESIS`
+
+The former claim that the observed disagreement was a lower bound is revoked. Correlation can compress disagreement, while adversarial role assignment can overgenerate it; the direction of bias is undetermined.
+
+## Governance decision
+
+Δ remains in the Kernel only as a SHADOW diagnostic boundary. It is forbidden from modulating Core Confidence until external independence is demonstrated. Future promotion to `MEDIBLE` requires a new Governance entry identifying the independent execution/attestation authorities and showing that the common-orchestrator threat is actually removed.

--- a/src/atlas/algorithm/delta-divergence-boundary-omega.test.ts
+++ b/src/atlas/algorithm/delta-divergence-boundary-omega.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { falsifyDeltaIndependence, type DeltaHardenedPass } from './delta-divergence-falsation-omega';
+
+function p(id:string, probability:number, family:string, provider:string): DeltaHardenedPass {
+  return {
+    evaluatorId:id, alignedEvidenceGraphId:'g', independent:true, probability, confidence:0.7,
+    dimensionProbabilities:{ thesis: probability },
+    lineage:{
+      evaluatorId:id, modelFamilyId:family, modelInstanceId:`i-${id}`, promptLineageId:`p-${id}`,
+      reasoningTemplateId:`r-${id}`, evidenceGraphId:'g', evidenceSnapshotHash:'snap',
+      upstreamProviderIds:[provider], independenceAttestationId:`att-${id}`,
+    },
+  };
+}
+
+describe('Δ D9 boundary normalization attack', () => {
+  it('degrades near-one mean with nonzero dispersion to SHADOW_ONLY', () => {
+    const out = falsifyDeltaIndependence([
+      p('a',1.00,'fa','SEC'),
+      p('b',0.99,'fb','COMPANY'),
+      p('c',0.96,'fc','TRANSCRIPT'),
+    ]);
+    expect(out.shadowDelta?.meanProbability as number).toBeGreaterThanOrEqual(0.98);
+    expect(out.shadowDelta?.dOmega as number).toBeGreaterThan(0);
+    expect(out.state).toBe('SHADOW_ONLY');
+    expect(out.findings.map(f=>f.code)).toContain('BOUNDARY_NORMALIZATION_UNSTABLE');
+    expect(out.coreConfidenceEligible).toBe(false);
+  });
+});

--- a/src/atlas/algorithm/delta-divergence-falsation-omega.test.ts
+++ b/src/atlas/algorithm/delta-divergence-falsation-omega.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateHardenedCoreConfidence,
+  falsifyDeltaIndependence,
+  type DeltaHardenedPass,
+} from './delta-divergence-falsation-omega';
+
+const makePass = (id: string, probability: number, family: string, instance: string, prompt: string, template: string, providers: string[] = ['SEC','COMPANY']) : DeltaHardenedPass => ({
+  evaluatorId: id,
+  alignedEvidenceGraphId: 'graph-1',
+  independent: true,
+  probability,
+  confidence: 0.75,
+  dimensionProbabilities: { moat: probability, valuation: Math.max(0, probability - 0.1), expectations: Math.min(1, probability + 0.05) },
+  lineage: {
+    evaluatorId: id,
+    modelFamilyId: family,
+    modelInstanceId: instance,
+    promptLineageId: prompt,
+    reasoningTemplateId: template,
+    evidenceGraphId: 'graph-1',
+    evidenceSnapshotHash: 'snapshot-abc',
+    upstreamProviderIds: providers,
+    independenceAttestationId: `att-${id}`,
+  },
+});
+
+const good = [
+  makePass('fundamental', 0.84, 'family-a', 'instance-a', 'prompt-a', 'template-a', ['SEC','COMPANY']),
+  makePass('expectations', 0.61, 'family-b', 'instance-b', 'prompt-b', 'template-b', ['SEC','TRANSCRIPTS']),
+  makePass('bear-risk', 0.49, 'family-c', 'instance-c', 'prompt-c', 'template-c', ['SEC','MACRO']),
+];
+
+describe('Δ falsation matrix Ω', () => {
+  it('D1 rejects declarative independence without auditable attestation', () => {
+    const bad = good.map((p) => ({ ...p, lineage: { ...p.lineage, independenceAttestationId: null } }));
+    const out = falsifyDeltaIndependence(bad);
+    expect(out.state).toBe('NO_MEDIBLE');
+    expect(out.findings.map((f) => f.code)).toContain('DECLARATIVE_INDEPENDENCE_ONLY');
+    expect(out.coreConfidenceEligible).toBe(false);
+  });
+
+  it('D2 rejects shared model instance even with unique evaluator IDs', () => {
+    const bad = good.map((p, i) => i === 2 ? ({ ...p, lineage: { ...p.lineage, modelInstanceId: 'instance-a' } }) : p);
+    const out = falsifyDeltaIndependence(bad);
+    expect(out.state).toBe('NO_MEDIBLE');
+    expect(out.findings.map((f) => f.code)).toContain('SHARED_MODEL_INSTANCE');
+  });
+
+  it('D3 degrades shared model family to SHADOW_ONLY rather than canonical MEDIBLE', () => {
+    const shadow = good.map((p) => ({ ...p, lineage: { ...p.lineage, modelFamilyId: 'same-family' } }));
+    const out = falsifyDeltaIndependence(shadow);
+    expect(out.state).toBe('SHADOW_ONLY');
+    expect(out.shadowDelta?.state).toBe('MEDIBLE');
+    expect(out.canonicalDelta).toBeNull();
+    expect(out.coreConfidenceEligible).toBe(false);
+  });
+
+  it('D4 rejects shared prompt lineage and does not let personas manufacture independence', () => {
+    const bad = good.map((p) => ({ ...p, lineage: { ...p.lineage, promptLineageId: 'same-prompt' } }));
+    const out = falsifyDeltaIndependence(bad);
+    expect(out.state).toBe('NO_MEDIBLE');
+    expect(out.findings.map((f) => f.code)).toContain('SHARED_PROMPT_LINEAGE');
+  });
+
+  it('D5 shared upstream source set becomes SHADOW_ONLY because common-source risk remains', () => {
+    const shadow = good.map((p) => ({ ...p, lineage: { ...p.lineage, upstreamProviderIds: ['SEC','COMPANY'] } }));
+    const out = falsifyDeltaIndependence(shadow);
+    expect(out.state).toBe('SHADOW_ONLY');
+    expect(out.findings.map((f) => f.code)).toContain('SHARED_UPSTREAM_PROVIDER_SET');
+  });
+
+  it('D6 rejects different frozen evidence snapshots even if graph ID is the same', () => {
+    const bad = good.map((p, i) => i === 1 ? ({ ...p, lineage: { ...p.lineage, evidenceSnapshotHash: 'snapshot-other' } }) : p);
+    const out = falsifyDeltaIndependence(bad);
+    expect(out.state).toBe('NO_MEDIBLE');
+    expect(out.findings.map((f) => f.code)).toContain('EVIDENCE_SNAPSHOT_MISMATCH');
+  });
+
+  it('D7 rejects numerical near-duplicates', () => {
+    const bad = [good[0], { ...good[0], evaluatorId: 'copy', lineage: { ...good[0].lineage, evaluatorId:'copy', modelFamilyId:'family-x', modelInstanceId:'instance-x', promptLineageId:'prompt-x', reasoningTemplateId:'template-x', independenceAttestationId:'att-copy' } }, good[2]];
+    const out = falsifyDeltaIndependence(bad);
+    expect(out.state).toBe('NO_MEDIBLE');
+    expect(out.findings.map((f) => f.code)).toContain('NEAR_DUPLICATE_PASS');
+  });
+
+  it('D8 incomplete dimensions cannot be cherry-picked into canonical per-dimension disagreement', () => {
+    const bad = good.map((p, i) => i === 2 ? ({ ...p, dimensionProbabilities: { moat: 0.49 } }) : p);
+    const out = falsifyDeltaIndependence(bad);
+    expect(out.state).toBe('SHADOW_ONLY');
+    expect(out.findings.map((f) => f.code)).toContain('DIMENSION_CHERRY_PICK_RISK');
+  });
+
+  it('D10 fewer than three passes remains NO_MEDIBLE regardless of clean lineage', () => {
+    const out = falsifyDeltaIndependence(good.slice(0,2));
+    expect(out.state).toBe('NO_MEDIBLE');
+    expect(out.findings.map((f) => f.code)).toContain('INSUFFICIENT_PASSES');
+  });
+
+  it('canonical MEDIBLE requires no block or shadow findings', () => {
+    const out = falsifyDeltaIndependence(good);
+    expect(out.state).toBe('MEDIBLE');
+    expect(out.canonicalDelta?.state).toBe('MEDIBLE');
+    expect(out.coreConfidenceEligible).toBe(true);
+  });
+
+  it('Core confidence fails closed for SHADOW_ONLY even when raw dispersion is numerically available', () => {
+    const shadow = good.map((p) => ({ ...p, lineage: { ...p.lineage, modelFamilyId: 'same-family' } }));
+    const delta = falsifyDeltaIndependence(shadow);
+    const conf = calculateHardenedCoreConfidence([0.75,0.75,0.75], delta, { divergencePenaltyK:2, policyId:'test' });
+    expect(conf.state).toBe('NO_MEDIBLE');
+    expect(conf.effectiveConfidence).toBeNull();
+  });
+});

--- a/src/atlas/algorithm/delta-divergence-falsation-omega.ts
+++ b/src/atlas/algorithm/delta-divergence-falsation-omega.ts
@@ -1,0 +1,191 @@
+import {
+  calculateCoreConfidenceFromDelta,
+  evaluateDeltaDivergence,
+  type CoreConfidencePolicy,
+  type CoreConfidenceResult,
+  type DeltaDivergenceResult,
+  type DeltaEvaluatorPass,
+} from './greek-contracts-omega';
+
+export const DELTA_FALSATION_OMEGA_VERSION = '2026-09-05-v1.1.0' as const;
+
+export type DeltaAssuranceState = 'MEDIBLE' | 'SHADOW_ONLY' | 'NO_MEDIBLE';
+
+export interface DeltaLineageEvidence {
+  evaluatorId: string;
+  modelFamilyId: string;
+  modelInstanceId: string;
+  promptLineageId: string;
+  reasoningTemplateId: string;
+  evidenceGraphId: string;
+  evidenceSnapshotHash: string;
+  upstreamProviderIds: string[];
+  generationSeedId?: string | null;
+  independenceAttestationId?: string | null;
+}
+
+export interface DeltaHardenedPass extends DeltaEvaluatorPass {
+  lineage: DeltaLineageEvidence;
+}
+
+export type DeltaFalsationCode =
+  | 'PASS'
+  | 'INSUFFICIENT_PASSES'
+  | 'DECLARATIVE_INDEPENDENCE_ONLY'
+  | 'DUPLICATE_EVALUATOR'
+  | 'SHARED_MODEL_INSTANCE'
+  | 'SHARED_MODEL_FAMILY'
+  | 'SHARED_PROMPT_LINEAGE'
+  | 'SHARED_REASONING_TEMPLATE'
+  | 'SHARED_UPSTREAM_PROVIDER_SET'
+  | 'EVIDENCE_GRAPH_MISMATCH'
+  | 'EVIDENCE_SNAPSHOT_MISMATCH'
+  | 'NEAR_DUPLICATE_PASS'
+  | 'DIMENSION_COVERAGE_TOO_LOW'
+  | 'DIMENSION_CHERRY_PICK_RISK'
+  | 'BOUNDARY_NORMALIZATION_UNSTABLE'
+  | 'INVALID_LINEAGE';
+
+export interface DeltaFalsationFinding {
+  code: DeltaFalsationCode;
+  severity: 'INFO' | 'SHADOW' | 'BLOCK';
+  detail: string;
+}
+
+export interface DeltaFalsationResult {
+  state: DeltaAssuranceState;
+  canonicalDelta: DeltaDivergenceResult | null;
+  shadowDelta: DeltaDivergenceResult | null;
+  findings: DeltaFalsationFinding[];
+  dimensionCoverage: Record<string, number>;
+  effectiveIndependentPasses: number;
+  coreConfidenceEligible: boolean;
+  canConclude: false;
+  directAtlasScoreDelta: 0;
+}
+
+function signature(values: readonly string[]): string {
+  return [...new Set(values)].sort().join('|');
+}
+
+function nearDuplicate(a: DeltaHardenedPass, b: DeltaHardenedPass): boolean {
+  const p = Math.abs(a.probability - b.probability);
+  const c = Math.abs(a.confidence - b.confidence);
+  const dims = new Set([...Object.keys(a.dimensionProbabilities ?? {}), ...Object.keys(b.dimensionProbabilities ?? {})]);
+  let maxDim = 0;
+  for (const d of dims) {
+    const av = a.dimensionProbabilities?.[d];
+    const bv = b.dimensionProbabilities?.[d];
+    if (av == null || bv == null) return false;
+    maxDim = Math.max(maxDim, Math.abs(av - bv));
+  }
+  return p <= 0.005 && c <= 0.005 && maxDim <= 0.01;
+}
+
+function validLineage(p: DeltaHardenedPass): boolean {
+  const l = p.lineage;
+  return !!l && [l.evaluatorId, l.modelFamilyId, l.modelInstanceId, l.promptLineageId, l.reasoningTemplateId,
+    l.evidenceGraphId, l.evidenceSnapshotHash].every((x) => typeof x === 'string' && x.trim().length > 0)
+    && Array.isArray(l.upstreamProviderIds) && l.upstreamProviderIds.length > 0
+    && l.evaluatorId === p.evaluatorId && l.evidenceGraphId === p.alignedEvidenceGraphId;
+}
+
+export function falsifyDeltaIndependence(passes: readonly DeltaHardenedPass[]): DeltaFalsationResult {
+  const findings: DeltaFalsationFinding[] = [];
+  if (passes.length < 3) findings.push({ code: 'INSUFFICIENT_PASSES', severity: 'BLOCK', detail: 'At least three passes are necessary but not sufficient.' });
+  if (passes.some((p) => !validLineage(p))) findings.push({ code: 'INVALID_LINEAGE', severity: 'BLOCK', detail: 'Every pass must carry internally consistent lineage evidence.' });
+  if (passes.some((p) => !p.lineage.independenceAttestationId?.trim())) findings.push({ code: 'DECLARATIVE_INDEPENDENCE_ONLY', severity: 'BLOCK', detail: '`independent: true` without an auditable attestation never proves independence.' });
+
+  const duplicateField = (selector: (p: DeltaHardenedPass) => string, code: DeltaFalsationCode, detail: string, severity: 'BLOCK'|'SHADOW' = 'BLOCK') => {
+    const vals = passes.map(selector);
+    if (new Set(vals).size !== vals.length) findings.push({ code, severity, detail });
+  };
+  duplicateField((p) => p.evaluatorId, 'DUPLICATE_EVALUATOR', 'Evaluator IDs must be unique.');
+  duplicateField((p) => p.lineage.modelInstanceId, 'SHARED_MODEL_INSTANCE', 'Two passes share the same model instance.');
+  duplicateField((p) => p.lineage.modelFamilyId, 'SHARED_MODEL_FAMILY', 'Canonical independence requires distinct model families; same-family diversity is shadow evidence only.', 'SHADOW');
+  duplicateField((p) => p.lineage.promptLineageId, 'SHARED_PROMPT_LINEAGE', 'Shared prompt lineage creates common-mode dependence.');
+  duplicateField((p) => p.lineage.reasoningTemplateId, 'SHARED_REASONING_TEMPLATE', 'Shared reasoning templates create common-mode dependence.', 'SHADOW');
+
+  const graphs = new Set(passes.map((p) => p.lineage.evidenceGraphId));
+  if (graphs.size !== 1) findings.push({ code: 'EVIDENCE_GRAPH_MISMATCH', severity: 'BLOCK', detail: 'All passes must evaluate the same aligned evidence graph.' });
+  const snapshots = new Set(passes.map((p) => p.lineage.evidenceSnapshotHash));
+  if (snapshots.size !== 1) findings.push({ code: 'EVIDENCE_SNAPSHOT_MISMATCH', severity: 'BLOCK', detail: 'All passes must see the same frozen evidence snapshot.' });
+
+  const providerSets = passes.map((p) => signature(p.lineage.upstreamProviderIds));
+  if (new Set(providerSets).size === 1 && passes.length >= 3) {
+    findings.push({ code: 'SHARED_UPSTREAM_PROVIDER_SET', severity: 'SHADOW', detail: 'All evaluators share the same upstream provider set; common-source risk prevents strongest independence claim.' });
+  }
+
+  for (let i = 0; i < passes.length; i++) for (let j = i + 1; j < passes.length; j++) {
+    if (nearDuplicate(passes[i], passes[j])) {
+      findings.push({ code: 'NEAR_DUPLICATE_PASS', severity: 'BLOCK', detail: `Passes ${passes[i].evaluatorId} and ${passes[j].evaluatorId} are numerically near-duplicates.` });
+    }
+  }
+
+  const dimensions = new Set<string>();
+  for (const p of passes) Object.keys(p.dimensionProbabilities ?? {}).forEach((d) => dimensions.add(d));
+  const dimensionCoverage: Record<string, number> = {};
+  for (const d of dimensions) dimensionCoverage[d] = passes.filter((p) => p.dimensionProbabilities?.[d] != null).length / Math.max(1, passes.length);
+  const lowCoverage = Object.entries(dimensionCoverage).filter(([, v]) => v < 1);
+  if (lowCoverage.length) findings.push({ code: 'DIMENSION_CHERRY_PICK_RISK', severity: 'SHADOW', detail: `Incomplete dimension coverage: ${lowCoverage.map(([d,v]) => `${d}:${v.toFixed(2)}`).join(', ')}` });
+  if (Object.keys(dimensionCoverage).length > 0 && Object.values(dimensionCoverage).some((v) => v < 2/3)) {
+    findings.push({ code: 'DIMENSION_COVERAGE_TOO_LOW', severity: 'BLOCK', detail: 'A dimension observed in fewer than two-thirds of passes cannot support canonical per-dimension disagreement.' });
+  }
+
+  const raw = evaluateDeltaDivergence(passes);
+  if (raw.state === 'MEDIBLE' && raw.meanProbability != null && raw.normalizedDOmega != null) {
+    const boundary = raw.meanProbability <= 0.02 || raw.meanProbability >= 0.98;
+    if (boundary && raw.normalizedDOmega > 1) {
+      findings.push({ code: 'BOUNDARY_NORMALIZATION_UNSTABLE', severity: 'SHADOW', detail: 'Normalized divergence is unstable near Bernoulli boundaries; retain raw sigma/IQR only in shadow.' });
+    }
+  }
+
+  const hasBlock = findings.some((f) => f.severity === 'BLOCK');
+  const hasShadow = findings.some((f) => f.severity === 'SHADOW');
+  const state: DeltaAssuranceState = hasBlock ? 'NO_MEDIBLE' : hasShadow ? 'SHADOW_ONLY' : 'MEDIBLE';
+  const canonicalDelta = state === 'MEDIBLE' && raw.state === 'MEDIBLE' ? raw : null;
+  const shadowDelta = raw.state === 'MEDIBLE' ? raw : null;
+  if (!findings.length) findings.push({ code: 'PASS', severity: 'INFO', detail: 'No falsation attack triggered under the declared threat model.' });
+
+  return {
+    state,
+    canonicalDelta,
+    shadowDelta,
+    findings,
+    dimensionCoverage,
+    effectiveIndependentPasses: state === 'MEDIBLE' ? passes.length : 0,
+    coreConfidenceEligible: state === 'MEDIBLE' && canonicalDelta?.state === 'MEDIBLE',
+    canConclude: false,
+    directAtlasScoreDelta: 0,
+  };
+}
+
+export function calculateHardenedCoreConfidence(
+  individualConfidences: readonly number[],
+  result: DeltaFalsationResult,
+  policy: CoreConfidencePolicy,
+): CoreConfidenceResult {
+  if (!result.coreConfidenceEligible || !result.canonicalDelta) {
+    return {
+      state: 'NO_MEDIBLE', meanIndividualConfidence: null, effectiveConfidence: null,
+      policyId: policy.policyId, divergencePenaltyK: policy.divergencePenaltyK, formulaOwner: 'CORE_OMEGA',
+    };
+  }
+  return calculateCoreConfidenceFromDelta(individualConfidences, result.canonicalDelta, policy);
+}
+
+export const DELTA_FALSATION_MATRIX_OMEGA_V1 = {
+  attacks: [
+    'D1 declarative independence without auditable lineage',
+    'D2 duplicate evaluator/model instance',
+    'D3 shared model family',
+    'D4 shared prompt lineage/reasoning template',
+    'D5 common upstream provider set',
+    'D6 aligned graph but non-identical frozen evidence snapshot',
+    'D7 numerical near-duplicate passes',
+    'D8 selective dimension omission / cherry-picking',
+    'D9 Bernoulli-boundary normalization instability',
+    'D10 small-N insufficiency',
+  ],
+  transitionRule: 'MEDIBLE only if no BLOCK or SHADOW finding remains; SHADOW_ONLY never feeds Core Confidence.',
+} as const;

--- a/src/atlas/algorithm/delta-divergence-falsation-omega.ts
+++ b/src/atlas/algorithm/delta-divergence-falsation-omega.ts
@@ -133,10 +133,10 @@ export function falsifyDeltaIndependence(passes: readonly DeltaHardenedPass[]): 
   }
 
   const raw = evaluateDeltaDivergence(passes);
-  if (raw.state === 'MEDIBLE' && raw.meanProbability != null && raw.normalizedDOmega != null) {
+  if (raw.state === 'MEDIBLE' && raw.meanProbability != null && raw.dOmega != null) {
     const boundary = raw.meanProbability <= 0.02 || raw.meanProbability >= 0.98;
-    if (boundary && raw.normalizedDOmega > 1) {
-      findings.push({ code: 'BOUNDARY_NORMALIZATION_UNSTABLE', severity: 'SHADOW', detail: 'Normalized divergence is unstable near Bernoulli boundaries; retain raw sigma/IQR only in shadow.' });
+    if (boundary && raw.dOmega > 1e-9) {
+      findings.push({ code: 'BOUNDARY_NORMALIZATION_UNSTABLE', severity: 'SHADOW', detail: 'Near Bernoulli boundaries, normalized divergence is hypersensitive to a small denominator. Retain raw sigma/IQR only as shadow evidence.' });
     }
   }
 

--- a/src/atlas/algorithm/delta-independence-authority-omega.test.ts
+++ b/src/atlas/algorithm/delta-independence-authority-omega.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { certifyDeltaIndependenceAuthority } from './delta-independence-authority-omega';
+import { falsifyDeltaIndependence, type DeltaHardenedPass } from './delta-divergence-falsation-omega';
+
+function p(id:string, family:string, provider:string): DeltaHardenedPass {
+  return {
+    evaluatorId:id, alignedEvidenceGraphId:'g', independent:true, probability:id==='a'?0.8:id==='b'?0.6:0.4, confidence:0.7,
+    dimensionProbabilities:{ thesis:id==='a'?0.8:id==='b'?0.6:0.4 },
+    lineage:{ evaluatorId:id, modelFamilyId:family, modelInstanceId:`i-${id}`, promptLineageId:`p-${id}`, reasoningTemplateId:`r-${id}`,
+      evidenceGraphId:'g', evidenceSnapshotHash:'snap', upstreamProviderIds:[provider], independenceAttestationId:`att-${id}` },
+  };
+}
+
+const passes = [p('a','fa','SEC'),p('b','fb','COMPANY'),p('c','fc','TRANSCRIPT')];
+const delta = falsifyDeltaIndependence(passes);
+
+describe('Δ independence authority Ω', () => {
+  it('defaults to SHADOW_ONLY when no external receipts exist', () => {
+    const out = certifyDeltaIndependenceAuthority(delta,['a','b','c'],'snap',[],new Set());
+    expect(out.state).toBe('SHADOW_ONLY');
+    expect(out.coreConfidenceAuthorized).toBe(false);
+  });
+
+  it('rejects nominal separation under one execution and attestation domain', () => {
+    const receipts = ['a','b','c'].map((id,i)=>({ evaluatorId:id, executionDomainId:'same-domain', attestationAuthorityId:'same-authority', verifierPublicKeyFingerprint:i<2?'key1':'key2', receiptHash:`h${i}`, evidenceSnapshotHash:'snap', issuedAt:'2026-09-05T06:00:00Z' }));
+    const out = certifyDeltaIndependenceAuthority(delta,['a','b','c'],'snap',receipts,new Set(['key1','key2']));
+    expect(out.state).toBe('SHADOW_ONLY');
+    expect(out.reasons.join(' ')).toContain('execution domains');
+    expect(out.reasons.join(' ')).toContain('attestation authorities');
+  });
+
+  it('authorizes canonical Δ only with multiple trusted administration domains', () => {
+    const receipts = [
+      { evaluatorId:'a', executionDomainId:'domain-1', attestationAuthorityId:'auth-1', verifierPublicKeyFingerprint:'key1', receiptHash:'h1', evidenceSnapshotHash:'snap', issuedAt:'2026-09-05T06:00:00Z' },
+      { evaluatorId:'b', executionDomainId:'domain-2', attestationAuthorityId:'auth-2', verifierPublicKeyFingerprint:'key2', receiptHash:'h2', evidenceSnapshotHash:'snap', issuedAt:'2026-09-05T06:00:01Z' },
+      { evaluatorId:'c', executionDomainId:'domain-2', attestationAuthorityId:'auth-2', verifierPublicKeyFingerprint:'key2', receiptHash:'h3', evidenceSnapshotHash:'snap', issuedAt:'2026-09-05T06:00:02Z' },
+    ];
+    const out = certifyDeltaIndependenceAuthority(delta,['a','b','c'],'snap',receipts,new Set(['key1','key2']));
+    expect(out.state).toBe('CANONICAL_MEDIBLE');
+    expect(out.coreConfidenceAuthorized).toBe(true);
+  });
+});

--- a/src/atlas/algorithm/delta-independence-authority-omega.ts
+++ b/src/atlas/algorithm/delta-independence-authority-omega.ts
@@ -1,0 +1,73 @@
+import type { DeltaFalsationResult } from './delta-divergence-falsation-omega';
+
+export const DELTA_INDEPENDENCE_AUTHORITY_OMEGA_VERSION = '2026-09-05-v1.0.0' as const;
+
+export interface DeltaExecutionReceipt {
+  evaluatorId: string;
+  executionDomainId: string;
+  attestationAuthorityId: string;
+  verifierPublicKeyFingerprint: string;
+  receiptHash: string;
+  evidenceSnapshotHash: string;
+  issuedAt: string;
+}
+
+export interface DeltaAuthorityResult {
+  state: 'CANONICAL_MEDIBLE' | 'SHADOW_ONLY' | 'NO_MEDIBLE';
+  reasons: string[];
+  trustedReceiptCount: number;
+  distinctExecutionDomains: number;
+  distinctAttestationAuthorities: number;
+  coreConfidenceAuthorized: boolean;
+}
+
+export function certifyDeltaIndependenceAuthority(
+  delta: DeltaFalsationResult,
+  expectedEvaluatorIds: readonly string[],
+  expectedEvidenceSnapshotHash: string,
+  receipts: readonly DeltaExecutionReceipt[],
+  trustedVerifierFingerprints: ReadonlySet<string>,
+): DeltaAuthorityResult {
+  if (delta.state === 'NO_MEDIBLE') {
+    return { state:'NO_MEDIBLE', reasons:['Underlying Δ falsation result is NO_MEDIBLE.'], trustedReceiptCount:0, distinctExecutionDomains:0, distinctAttestationAuthorities:0, coreConfidenceAuthorized:false };
+  }
+
+  const reasons:string[] = [];
+  const expected = new Set(expectedEvaluatorIds);
+  const trusted = receipts.filter((r) =>
+    expected.has(r.evaluatorId)
+    && r.evidenceSnapshotHash === expectedEvidenceSnapshotHash
+    && trustedVerifierFingerprints.has(r.verifierPublicKeyFingerprint)
+    && r.receiptHash.trim().length > 0
+    && Number.isFinite(Date.parse(r.issuedAt))
+    && r.executionDomainId.trim().length > 0
+    && r.attestationAuthorityId.trim().length > 0
+  );
+
+  if (trusted.length !== expected.size) reasons.push('Every evaluator requires one trusted external execution receipt on the same frozen evidence snapshot.');
+  if (new Set(trusted.map((r)=>r.evaluatorId)).size !== trusted.length) reasons.push('Duplicate evaluator receipts are not independent evidence.');
+  if (new Set(trusted.map((r)=>r.receiptHash)).size !== trusted.length) reasons.push('Receipt hashes must be unique.');
+
+  const domains = new Set(trusted.map((r)=>r.executionDomainId));
+  const authorities = new Set(trusted.map((r)=>r.attestationAuthorityId));
+  if (domains.size < 2) reasons.push('At least two independently administered execution domains are required.');
+  if (authorities.size < 2) reasons.push('At least two independently administered attestation authorities are required.');
+  if (trustedVerifierFingerprints.size < 2) reasons.push('A single trusted verifier registry key is a common-mode trust root; at least two trusted verifier fingerprints are required for canonical Δ.');
+
+  const canonical = delta.state === 'MEDIBLE' && reasons.length === 0;
+  return {
+    state: canonical ? 'CANONICAL_MEDIBLE' : 'SHADOW_ONLY',
+    reasons: canonical ? ['Δ lineage passed falsation and is externally anchored by multiple trusted execution/attestation domains.'] : reasons.length ? reasons : ['Underlying Δ is SHADOW_ONLY.'],
+    trustedReceiptCount: trusted.length,
+    distinctExecutionDomains: domains.size,
+    distinctAttestationAuthorities: authorities.size,
+    coreConfidenceAuthorized: canonical,
+  };
+}
+
+export const DELTA_AUTHORITY_RULE_OMEGA_V1 = {
+  rule: 'Static lineage metadata is necessary but cannot prove its own authenticity. Canonical Δ requires externally verifiable receipts from multiple trusted administration domains.',
+  defaultWithoutReceipts: 'SHADOW_ONLY',
+  directAtlasScoreDelta: 0,
+  canConclude: false,
+} as const;


### PR DESCRIPTION
Closes #110.

Builds an executable falsation boundary around DELTA_DIVERGENCE_OMEGA before further Kernel expansion.

Key changes:
- `independent: true` no longer counts as proof of independence.
- Adds lineage evidence: evaluator, model family/instance, prompt lineage, reasoning template, aligned evidence graph, frozen snapshot hash, upstream providers, independence attestation.
- Introduces MEDIBLE / SHADOW_ONLY / NO_MEDIBLE assurance states.
- Adds D1–D10 adversarial attacks covering pseudo-independence, shared model lineage, shared prompts/templates, common upstream sources, evidence snapshot mismatch, numerical near-duplicates, dimension cherry-picking, boundary normalization sensitivity and small-N insufficiency.
- Core Confidence receives Δ only through `calculateHardenedCoreConfidence`; SHADOW_ONLY / proxy dispersion fail closed.
- Preserves direct structural score weight 0 and canConclude=false.

Important: this PR does not silently rewrite the existing Greek contract implementation. It adds a hardened boundary/wrapper first. Only after CI proves the falsation matrix should hierarchy/governance promote the hardened boundary as mandatory canonical ingress.