### PR TITLE
ATLAS Ω — close residual Δ falsation gaps

### DIFF
--- a/.github/workflows/delta-residual-preconditions-omega-ci.yml
+++ b/.github/workflows/delta-residual-preconditions-omega-ci.yml
@@ -1,0 +1,16 @@
+name: Delta Residual Preconditions Omega CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/algorithm/delta-divergence-preconditions-omega.ts'
+      - 'src/atlas/algorithm/delta-divergence-preconditions-omega.test.ts'
+      - '.github/workflows/delta-residual-preconditions-omega-ci.yml'
+
+jobs:
+  residual-falsation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run residual Delta falsation gates
+        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/delta-divergence-preconditions-omega.test.ts

--- a/src/atlas/algorithm/delta-divergence-preconditions-omega.test.ts
+++ b/src/atlas/algorithm/delta-divergence-preconditions-omega.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateDeltaPreconditions, type DeltaExecutionSeal } from './delta-divergence-preconditions-omega';
+import type { DeltaHardenedPass } from './delta-divergence-falsation-omega';
+
+function p(i:number): DeltaHardenedPass {
+  const id=`e${i}`;
+  return {
+    evaluatorId:id, alignedEvidenceGraphId:'graph', independent:true,
+    probability:0.40+i*0.08, confidence:0.70+i*0.01,
+    dimensionProbabilities:{ thesis:0.40+i*0.08 },
+    lineage:{ evaluatorId:id, modelFamilyId:`f${i}`, modelInstanceId:`m${i}`, promptLineageId:`p${i}`, reasoningTemplateId:`r${i}`, evidenceGraphId:'graph', evidenceSnapshotHash:'snap', upstreamProviderIds:[`src${i}`], independenceAttestationId:`att${i}` },
+  };
+}
+const passes=[0,1,2,3,4].map(p);
+const seal:DeltaExecutionSeal={ executionId:'d1',question:'P(revenue growth >= 20% YoY at FY27 close)',atomicClauseCount:1,plannedPassCount:5,alignedEvidenceGraphId:'graph',evidenceSnapshotHash:'snap',phi2aCoverageCertified:true,phi2aCoverageCertificateId:'phi2a-cert',orchestrationAuthorityId:'atlas-orchestrator',independentAuthorityIds:['a','b','c','d','e'] };
+
+describe('Δ residual falsation gaps',()=>{
+  it('D5 blocks N<5',()=>{ const o=evaluateDeltaPreconditions(passes.slice(0,4),{...seal,plannedPassCount:4}); expect(o.state).toBe('NO_MEDIBLE'); expect(o.findings.map(f=>f.code)).toContain('INSUFFICIENT_PASSES'); });
+  it('D9 blocks post-hoc pass selection',()=>{ const o=evaluateDeltaPreconditions(passes,{...seal,plannedPassCount:6}); expect(o.findings.map(f=>f.code)).toContain('PASS_COUNT_MISMATCH'); });
+  it('D7 rejects composite questions',()=>{ const o=evaluateDeltaPreconditions(passes,{...seal,atomicClauseCount:2}); expect(o.findings.map(f=>f.code)).toContain('COMPOSITE_QUESTION_REJECTED'); });
+  it('D6 blocks uncertified shared ignorance',()=>{ const o=evaluateDeltaPreconditions(passes,{...seal,phi2aCoverageCertified:false,phi2aCoverageCertificateId:null}); expect(o.findings.map(f=>f.code)).toContain('COVERAGE_NOT_CERTIFIED'); });
+  it('D2 rejects evidence mismatch',()=>{ const bad=[...passes]; bad[2]={...bad[2],lineage:{...bad[2].lineage,evidenceSnapshotHash:'other'}}; const o=evaluateDeltaPreconditions(bad,seal); expect(o.findings.map(f=>f.code)).toContain('EVIDENCE_SNAPSHOT_MISMATCH'); });
+  it('same orchestrator remains SHADOW_ONLY even when all mechanical preconditions pass',()=>{ const o=evaluateDeltaPreconditions(passes,{...seal,independentAuthorityIds:['atlas-orchestrator','b','c','d','e']}); expect(o.state).toBe('SHADOW_ONLY'); expect(o.coreConfidenceEligible).toBe(false); });
+});

--- a/src/atlas/algorithm/delta-divergence-preconditions-omega.ts
+++ b/src/atlas/algorithm/delta-divergence-preconditions-omega.ts
@@ -1,0 +1,70 @@
+import {
+  falsifyDeltaIndependence,
+  type DeltaFalsationResult,
+  type DeltaHardenedPass,
+} from './delta-divergence-falsation-omega';
+
+export const DELTA_PRECONDITIONS_OMEGA_VERSION = '2026-09-05-v1.2.0' as const;
+export const DELTA_MIN_PASSES = 5 as const;
+
+export interface DeltaExecutionSeal {
+  executionId: string;
+  question: string;
+  atomicClauseCount: number;
+  plannedPassCount: number;
+  alignedEvidenceGraphId: string;
+  evidenceSnapshotHash: string;
+  phi2aCoverageCertified: boolean;
+  phi2aCoverageCertificateId?: string | null;
+  orchestrationAuthorityId: string;
+  independentAuthorityIds?: string[];
+}
+
+export type DeltaPreconditionCode =
+  | 'PASS'
+  | 'INSUFFICIENT_PASSES'
+  | 'PASS_COUNT_MISMATCH'
+  | 'COMPOSITE_QUESTION_REJECTED'
+  | 'COVERAGE_NOT_CERTIFIED'
+  | 'EVIDENCE_GRAPH_MISMATCH'
+  | 'EVIDENCE_SNAPSHOT_MISMATCH'
+  | 'COMMON_ORCHESTRATOR_ONLY';
+
+export interface DeltaPreconditionFinding {
+  code: DeltaPreconditionCode;
+  severity: 'BLOCK' | 'SHADOW' | 'INFO';
+  detail: string;
+}
+
+export interface DeltaPreconditionResult {
+  state: 'NO_MEDIBLE' | 'SHADOW_ONLY' | 'ELIGIBLE_FOR_FALSATION';
+  findings: DeltaPreconditionFinding[];
+  downstream: DeltaFalsationResult | null;
+  coreConfidenceEligible: boolean;
+}
+
+export function evaluateDeltaPreconditions(
+  passes: readonly DeltaHardenedPass[],
+  seal: DeltaExecutionSeal,
+): DeltaPreconditionResult {
+  const findings: DeltaPreconditionFinding[] = [];
+  if (passes.length < DELTA_MIN_PASSES) findings.push({ code:'INSUFFICIENT_PASSES', severity:'BLOCK', detail:`Δ requires at least ${DELTA_MIN_PASSES} passes.` });
+  if (seal.plannedPassCount !== passes.length) findings.push({ code:'PASS_COUNT_MISMATCH', severity:'BLOCK', detail:'Actual pass count differs from pre-sealed pass count.' });
+  if (seal.atomicClauseCount !== 1) findings.push({ code:'COMPOSITE_QUESTION_REJECTED', severity:'BLOCK', detail:'PREU requires exactly one atomic clause per Δ execution.' });
+  if (!seal.phi2aCoverageCertified || !seal.phi2aCoverageCertificateId?.trim()) findings.push({ code:'COVERAGE_NOT_CERTIFIED', severity:'BLOCK', detail:'Φ₂a evidence coverage must be certified before Δ runs.' });
+  if (passes.some(p => p.alignedEvidenceGraphId !== seal.alignedEvidenceGraphId || p.lineage.evidenceGraphId !== seal.alignedEvidenceGraphId)) findings.push({ code:'EVIDENCE_GRAPH_MISMATCH', severity:'BLOCK', detail:'Every pass must consume the pre-sealed Aligned Evidence Graph.' });
+  if (passes.some(p => p.lineage.evidenceSnapshotHash !== seal.evidenceSnapshotHash)) findings.push({ code:'EVIDENCE_SNAPSHOT_MISMATCH', severity:'BLOCK', detail:'Every pass must consume the same frozen evidence snapshot.' });
+
+  const authorities = new Set(seal.independentAuthorityIds ?? []);
+  if (authorities.size < DELTA_MIN_PASSES || authorities.has(seal.orchestrationAuthorityId)) {
+    findings.push({ code:'COMMON_ORCHESTRATOR_ONLY', severity:'SHADOW', detail:'Heterogeneous authority domains are not proven; result may only be SHADOW.' });
+  }
+
+  if (findings.some(f => f.severity === 'BLOCK')) return { state:'NO_MEDIBLE', findings, downstream:null, coreConfidenceEligible:false };
+
+  const downstream = falsifyDeltaIndependence(passes);
+  const shadow = findings.some(f => f.severity === 'SHADOW') || downstream.state !== 'MEDIBLE';
+  if (shadow) return { state:'SHADOW_ONLY', findings:[...findings, ...downstream.findings.map(f=>({code:'PASS' as const,severity:f.severity==='BLOCK'?'BLOCK' as const:'SHADOW' as const,detail:`Downstream: ${f.code} — ${f.detail}`}))], downstream, coreConfidenceEligible:false };
+
+  return { state:'ELIGIBLE_FOR_FALSATION', findings:[{code:'PASS',severity:'INFO',detail:'Residual Δ preconditions passed.'}], downstream, coreConfidenceEligible:downstream.coreConfidenceEligible };
+}


### PR DESCRIPTION
Closes #112. Adds a mandatory precondition firewall in front of the v1.1 Δ falsation boundary: N>=5, sealed planned pass count, atomic question, Φ₂a coverage certificate, identical sealed evidence graph/snapshot, and explicit authority-domain check. Same-orchestrator executions remain SHADOW_ONLY and Core Confidence ineligible. Adds executable adversarial tests for D2/D5/D6/D7/D9.