### PR TITLE
ATLAS Ω — ratify Ρ and add AI demand-provenance hard gates

### DIFF
--- a/.github/workflows/rho-ai-demand-provenance-omega-ci.yml
+++ b/.github/workflows/rho-ai-demand-provenance-omega-ci.yml
@@ -1,0 +1,19 @@
+name: Rho AI Demand Provenance Omega CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/algorithm/counterparty-exposure-omega.ts'
+      - 'src/atlas/algorithm/ai-demand-provenance-omega.ts'
+      - 'src/atlas/algorithm/atlas-kernel-contract-registry-omega.ts'
+      - 'src/atlas/algorithm/rho-ai-demand-provenance-omega.test.ts'
+      - 'CURRENT_CANON/2026-09-05_RHO_AND_AI_DEMAND_PROVENANCE_OMEGA_V1.md'
+      - '.github/workflows/rho-ai-demand-provenance-omega-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Rho and demand provenance tests
+        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/rho-ai-demand-provenance-omega.test.ts

--- a/CURRENT_CANON/2026-09-05_RHO_AND_AI_DEMAND_PROVENANCE_OMEGA_V1.md
+++ b/CURRENT_CANON/2026-09-05_RHO_AND_AI_DEMAND_PROVENANCE_OMEGA_V1.md
@@ -1,0 +1,101 @@
+# ATLAS Ω — Ρ Counterparty Exposure + AI Demand Provenance Hard Gates Ω v1.0
+
+Date: 2026-09-05
+Governance issue: #116
+Status: CANDIDATE_CANONICAL_PENDING_PR_MERGE
+
+## Ratification
+Ρ was previously PENDING_RATIFICATION. The user subsequently gave an explicit instruction to finish all outstanding ATLAS tasks, including the list item requiring Ρ ratification. This issue records that authorization rather than silently treating the earlier draft as canonical.
+
+## Ρ — Counterparty Exposure Ω
+Single question: **to which counterparties is the portfolio economically exposed across multiple positions through declared non-ordinary-sales relationships?**
+
+Ρ aggregates filings-backed guarantees, credit support, financing, material customer concentration, commitments and cross-exposures. It never estimates undisclosed exposure.
+
+It keeps these economic kinds separate:
+- RECOGNIZED
+- DRAWN
+- MAXIMUM_FACILITY
+- CONTINGENT
+- NO_CUANTIFICADA
+
+They are never added into one fake notional. NO_CUANTIFICADA only increases record/position counts.
+
+Ρ cannot BUY/SELL, set weights, admit/exclude, or change structural score.
+
+## AI demand-provenance pre-score architecture
+For companies materially linked to AI CAPEX:
+
+T0 Anti-Megacap Discovery Gate Ω
+→ T1 Fundamental Hard Gates
+→ T2 Financing Quality Gate Ω
+→ T3 Circular Demand Gate Ω
+→ T4 Quality-Adjusted Backlog Ω
+→ T5 Capital Risk Transfer Advantage Ω
+→ ATLAS Fundamental Score
+→ Expectation Gap Ω
+→ CAPEX Asymmetry / P0 Adjusted Ω
+→ Entry Timing Ω
+
+The purpose is to prevent announced CAPEX, gross backlog, funded customer demand and economically independent end-demand from being treated as equivalent.
+
+## Financing Quality Gate Ω
+The gate asks where the money that created the order originated. Ten checks cover buyer/vendor independence, external cash-flow repayment, balance-sheet support, debt sustainability, lease dependence, vendor funding, guarantees/backstops, concentration, termination/prepayment protection and vendor-retained residual risk.
+
+Unknown funding provenance is EVIDENCE_PENDING; it is never presumed organic.
+
+## Circular Demand Gate Ω
+ODQ = 100 - (C + V + G + L + R)
+
+Maximum haircuts:
+- C Circular capital: 25
+- V Vendor financing: 20
+- G Guarantees/backstops: 20
+- L Lease/off-balance dependence: 15
+- R Reflexive revenue/customer funding: 20
+
+A haircut requires a **material economic nexus between support/financing and the demand being evaluated**. Mere equity ownership or commercial proximity does not earn a haircut.
+
+Categories:
+- 90–100 ORGANIC / PASS_HIGH_QUALITY
+- 75–89 FINANCED BUT INDEPENDENT
+- 60–74 SUPPORTED
+- 40–59 REFLEXIVE
+- <40 CIRCULARITY CRITICAL
+
+Circularity is a demand-quality classification, not a fraud allegation.
+
+## Quality-Adjusted Backlog Ω
+`Backlog_Q = Backlog_reported × (ODQ/100) × CQ × FP`
+
+CQ = Contract Quality in [0,1].
+FP = Funding Probability in [0,1].
+
+Example: 100 × 0.65 × 0.80 × 0.90 = 46.8.
+
+Raw backlog may remain an accounting/disclosure fact, but AI-CAPEX economic proof must not bypass the adjusted-backlog layer where these gates are applicable.
+
+## Capital Risk Transfer Advantage Ω
+`CRTA = FCF captured / own capital at risk`
+
+Invalid/zero denominator returns NO_CALCULABLE, not infinity.
+
+For integrators/order quality:
+- `OCQ = Cash collected / AI revenue`
+- `WCI = (ΔAR + ΔInventory - ΔAP) / ΔRevenue`
+
+Invalid denominators return NO_CALCULABLE.
+
+## Canonical distinction
+**Business Quality Ω != Marginal Demand Quality Ω.**
+A high-quality supplier can have supported/reflexive marginal demand; that does not mechanically lower its structural business quality. The demand provenance modifies how much backlog/revenue evidence ATLAS capitalizes and how much funding/counterparty risk is carried forward.
+
+## AI CAPEX PAYBACK opening rule
+> Follow the money backwards. El backlog sólo vale tanto como el flujo de caja independiente que existe al final de la cadena para pagarlo.
+
+## Boundaries
+T0 remains upstream of all gates.
+Falsifier Veto remains independent.
+Decision Safety remains independent.
+Ρ has zero decision/allocation authority.
+No unavailable counterparty amount, ODQ component, CQ, FP, CRTA, OCQ or WCI may be inferred/backfilled merely to complete a score.

--- a/src/atlas/algorithm/ai-demand-provenance-omega.ts
+++ b/src/atlas/algorithm/ai-demand-provenance-omega.ts
@@ -1,0 +1,174 @@
+export const AI_DEMAND_PROVENANCE_OMEGA_VERSION = '2026-09-05-v1.0.0' as const;
+
+export const AI_DEMAND_PROVENANCE_SEQUENCE = [
+  'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1_1',
+  'T1_FUNDAMENTAL_HARD_GATES',
+  'T2_FINANCING_QUALITY_GATE_OMEGA_V1',
+  'T3_CIRCULAR_DEMAND_GATE_OMEGA_V1',
+  'T4_QUALITY_ADJUSTED_BACKLOG_OMEGA_V1',
+  'T5_CAPITAL_RISK_TRANSFER_ADVANTAGE_OMEGA_V1',
+  'ATLAS_FUNDAMENTAL_SCORE',
+  'EXPECTATION_GAP_OMEGA',
+  'CAPEX_ASYMMETRY_P0_ADJUSTED_OMEGA',
+  'ENTRY_TIMING_OMEGA',
+] as const;
+
+export type FinancingQualityState =
+  | 'PASS_HIGH_QUALITY'
+  | 'PASS_INDEPENDENT_FINANCED'
+  | 'REVIEW_SUPPORTED'
+  | 'HARD_REVIEW_REFLEXIVE'
+  | 'FAIL_CIRCULARITY_CRITICAL'
+  | 'EVIDENCE_PENDING';
+
+export interface FinancingQualityEvidence {
+  fundingSourceIdentified: boolean;
+  buyerIndependentFromVendor: boolean | null;
+  repaymentFromExternalBusinessCashFlow: boolean | null;
+  buyerBalanceSheetSupport: boolean | null;
+  debtTermsSustainable: boolean | null;
+  leaseDependencyMaterial: boolean | null;
+  vendorFundingMaterial: boolean | null;
+  guaranteesBackstopsMaterial: boolean | null;
+  customerConcentrationMaterial: boolean | null;
+  terminationPrepaymentProtectionAdequate: boolean | null;
+  residualRiskRetainedByVendor: boolean | null;
+}
+
+export interface FinancingQualityGateResult {
+  state: FinancingQualityState;
+  completedChecks: number;
+  totalChecks: 10;
+  downstreamFundamentalScoreAuthorized: boolean;
+  reasons: string[];
+}
+
+export function evaluateFinancingQualityGate(e: FinancingQualityEvidence): FinancingQualityGateResult {
+  if (!e.fundingSourceIdentified) {
+    return { state: 'EVIDENCE_PENDING', completedChecks: 0, totalChecks: 10, downstreamFundamentalScoreAuthorized: false,
+      reasons: ['Follow the money backwards: funding origin must be identified before AI-CAPEX demand is capitalized.'] };
+  }
+  const checks = [
+    e.buyerIndependentFromVendor,
+    e.repaymentFromExternalBusinessCashFlow,
+    e.buyerBalanceSheetSupport,
+    e.debtTermsSustainable,
+    e.leaseDependencyMaterial == null ? null : !e.leaseDependencyMaterial,
+    e.vendorFundingMaterial == null ? null : !e.vendorFundingMaterial,
+    e.guaranteesBackstopsMaterial == null ? null : !e.guaranteesBackstopsMaterial,
+    e.customerConcentrationMaterial == null ? null : !e.customerConcentrationMaterial,
+    e.terminationPrepaymentProtectionAdequate,
+    e.residualRiskRetainedByVendor == null ? null : !e.residualRiskRetainedByVendor,
+  ] as const;
+  const known = checks.filter((x): x is boolean => x != null);
+  if (known.length < 10) return { state: 'EVIDENCE_PENDING', completedChecks: known.length, totalChecks: 10, downstreamFundamentalScoreAuthorized: false,
+    reasons: ['All ten FQ checks must be resolved; missing financing evidence is not treated as organic demand.'] };
+  const positives = known.filter(Boolean).length;
+  const severeReflexive = e.vendorFundingMaterial === true && (e.guaranteesBackstopsMaterial === true || e.residualRiskRetainedByVendor === true);
+  const state: FinancingQualityState = severeReflexive ? 'HARD_REVIEW_REFLEXIVE'
+    : positives >= 9 ? 'PASS_HIGH_QUALITY'
+      : positives >= 7 ? 'PASS_INDEPENDENT_FINANCED'
+        : positives >= 5 ? 'REVIEW_SUPPORTED'
+          : 'HARD_REVIEW_REFLEXIVE';
+  return {
+    state,
+    completedChecks: 10,
+    totalChecks: 10,
+    downstreamFundamentalScoreAuthorized: state === 'PASS_HIGH_QUALITY' || state === 'PASS_INDEPENDENT_FINANCED' || state === 'REVIEW_SUPPORTED',
+    reasons: ['FQ is a demand-provenance hard gate, not a structural-quality score. Business quality and marginal demand quality remain separate.'],
+  };
+}
+
+export interface CircularDemandHaircuts {
+  circularCapital: number;      // C max 25
+  vendorFinancing: number;      // V max 20
+  guaranteesBackstops: number;  // G max 20
+  leaseDependency: number;      // L max 15
+  reflexiveRevenueFunding: number; // R max 20
+}
+
+export interface CircularDemandInput {
+  materialEconomicNexus: boolean;
+  haircuts: CircularDemandHaircuts;
+  evidenceComplete: boolean;
+}
+
+export interface CircularDemandResult {
+  state: FinancingQualityState;
+  odq: number | null;
+  odqMultiplier: number | null;
+  fundamentalScoreAuthorized: boolean;
+  reasons: string[];
+}
+
+const MAX = { circularCapital: 25, vendorFinancing: 20, guaranteesBackstops: 20, leaseDependency: 15, reflexiveRevenueFunding: 20 } as const;
+
+export function evaluateCircularDemand(input: CircularDemandInput): CircularDemandResult {
+  if (!input.evidenceComplete) return { state: 'EVIDENCE_PENDING', odq: null, odqMultiplier: null, fundamentalScoreAuthorized: false,
+    reasons: ['Circular-demand evidence incomplete; unknown is not organic.'] };
+  const values = Object.entries(input.haircuts) as [keyof CircularDemandHaircuts, number][];
+  if (values.some(([k,v]) => !Number.isFinite(v) || v < 0 || v > MAX[k])) {
+    return { state: 'EVIDENCE_PENDING', odq: null, odqMultiplier: null, fundamentalScoreAuthorized: false,
+      reasons: ['Haircut outside canonical maximum or invalid numeric input.'] };
+  }
+  if (!input.materialEconomicNexus) {
+    return { state: 'PASS_HIGH_QUALITY', odq: 100, odqMultiplier: 1, fundamentalScoreAuthorized: true,
+      reasons: ['Mere ownership, investment or commercial proximity without a material financing-demand nexus earns zero circularity haircut.'] };
+  }
+  const total = values.reduce((s,[,v]) => s + v, 0);
+  const odq = Math.max(0, 100 - total);
+  const state: FinancingQualityState = odq >= 90 ? 'PASS_HIGH_QUALITY'
+    : odq >= 75 ? 'PASS_INDEPENDENT_FINANCED'
+      : odq >= 60 ? 'REVIEW_SUPPORTED'
+        : odq >= 40 ? 'HARD_REVIEW_REFLEXIVE'
+          : 'FAIL_CIRCULARITY_CRITICAL';
+  return {
+    state,
+    odq,
+    odqMultiplier: odq / 100,
+    fundamentalScoreAuthorized: odq >= 60,
+    reasons: [
+      'ODQ discounts independence of marginal demand; it does not allege fraud.',
+      'ODQ is applied only where a material economic nexus between financing/support and demand is evidenced.',
+    ],
+  };
+}
+
+export interface QualityAdjustedBacklogInput {
+  reportedBacklog: number;
+  odq: number | null;
+  contractQuality: number;
+  fundingProbability: number;
+}
+
+export interface QualityAdjustedBacklogResult {
+  state: 'AVAILABLE' | 'EVIDENCE_PENDING';
+  qualityAdjustedBacklog: number | null;
+}
+
+export function qualityAdjustedBacklog(x: QualityAdjustedBacklogInput): QualityAdjustedBacklogResult {
+  const valid = Number.isFinite(x.reportedBacklog) && x.reportedBacklog >= 0 && x.odq != null && x.odq >= 0 && x.odq <= 100
+    && Number.isFinite(x.contractQuality) && x.contractQuality >= 0 && x.contractQuality <= 1
+    && Number.isFinite(x.fundingProbability) && x.fundingProbability >= 0 && x.fundingProbability <= 1;
+  if (!valid) return { state: 'EVIDENCE_PENDING', qualityAdjustedBacklog: null };
+  return { state: 'AVAILABLE', qualityAdjustedBacklog: x.reportedBacklog * (x.odq / 100) * x.contractQuality * x.fundingProbability };
+}
+
+export interface RatioDiagnostic { state: 'AVAILABLE' | 'NO_CALCULABLE'; value: number | null; }
+function ratio(n: number, d: number): RatioDiagnostic {
+  if (!Number.isFinite(n) || !Number.isFinite(d) || d <= 0) return { state: 'NO_CALCULABLE', value: null };
+  return { state: 'AVAILABLE', value: n / d };
+}
+
+export function capitalRiskTransferAdvantage(fcfCaptured: number, ownCapitalAtRisk: number): RatioDiagnostic {
+  return ratio(fcfCaptured, ownCapitalAtRisk);
+}
+export function aiOrderCashQuality(cashCollected: number, aiRevenue: number): RatioDiagnostic {
+  return ratio(cashCollected, aiRevenue);
+}
+export function workingCapitalIntensity(deltaAR: number, deltaInventory: number, deltaAP: number, deltaRevenue: number): RatioDiagnostic {
+  return ratio(deltaAR + deltaInventory - deltaAP, deltaRevenue);
+}
+
+export const AI_CAPEX_PAYBACK_MONEY_BACKWARDS_RULE =
+  'Follow the money backwards. El backlog sólo vale tanto como el flujo de caja independiente que existe al final de la cadena para pagarlo.' as const;

--- a/src/atlas/algorithm/atlas-kernel-contract-registry-omega.ts
+++ b/src/atlas/algorithm/atlas-kernel-contract-registry-omega.ts
@@ -1,0 +1,33 @@
+export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION = '2026-09-05-v2.0.0' as const;
+
+export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA = {
+  governanceStatus: 'ACTIVE_CANONICAL_PENDING_PR_MERGE',
+  contracts: {
+    delta: { id: 'DELTA_DIVERGENCE_OMEGA_V1_1', runtimeAuthority: 'SHADOW_ONLY' },
+    kappa: { id: 'KAPPA_CALIBRATION_OMEGA_V1_1', runtimeAuthority: 'CALIBRATION_ONLY' },
+    gamma: { id: 'GAMMA_VIGENCIA_OMEGA_V1_2', runtimeAuthority: 'VIGENCIA_ONLY' },
+    upsilon: { id: 'UPSILON_ALLOCATION_OMEGA_V1', runtimeAuthority: 'ALLOCATION_ONLY' },
+    rho: { id: 'RHO_COUNTERPARTY_EXPOSURE_OMEGA_V1', runtimeAuthority: 'EXPOSURE_AGGREGATION_ONLY' },
+  },
+  boundaries: {
+    deltaCannotConclude: true,
+    deltaCannotModulateCoreConfidenceWhileShadow: true,
+    kappaCannotChangeMethodology: true,
+    gammaCannotBuySell: true,
+    upsilonCannotAdmitExclude: true,
+    rhoCannotBuySell: true,
+    rhoCannotSetWeight: true,
+    rhoCannotAdmitExclude: true,
+    falsifierVetoIndependent: true,
+    decisionSafetyIndependent: true,
+  },
+  aiCapexPreScoreSequence: [
+    'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1_1',
+    'T1_FUNDAMENTAL_HARD_GATES',
+    'T2_FINANCING_QUALITY_GATE_OMEGA_V1',
+    'T3_CIRCULAR_DEMAND_GATE_OMEGA_V1',
+    'T4_QUALITY_ADJUSTED_BACKLOG_OMEGA_V1',
+    'T5_CAPITAL_RISK_TRANSFER_ADVANTAGE_OMEGA_V1',
+    'ATLAS_FUNDAMENTAL_SCORE',
+  ],
+} as const;

--- a/src/atlas/algorithm/counterparty-exposure-omega.ts
+++ b/src/atlas/algorithm/counterparty-exposure-omega.ts
@@ -1,0 +1,91 @@
+export const RHO_COUNTERPARTY_EXPOSURE_OMEGA_VERSION = '2026-09-05-v1.0.0' as const;
+
+export type RhoExposureKind =
+  | 'RECOGNIZED'
+  | 'DRAWN'
+  | 'MAXIMUM_FACILITY'
+  | 'CONTINGENT'
+  | 'NO_CUANTIFICADA';
+
+export interface RhoExposureRecord {
+  position: string;
+  counterparty: string | 'COUNTERPARTY_UNDISCLOSED';
+  economicBeneficiary?: string | null;
+  exposureType: string;
+  kind: RhoExposureKind;
+  amount?: number | null;
+  currency?: string | null;
+  asOf: string;
+  sourceId: string;
+  ordinarySales: boolean;
+  material: boolean;
+}
+
+export interface RhoCounterpartyAggregate {
+  counterparty: string;
+  positions: string[];
+  records: number;
+  quantifiedByKind: Partial<Record<Exclude<RhoExposureKind, 'NO_CUANTIFICADA'>, Record<string, number>>>;
+  unquantifiedRecords: number;
+}
+
+export interface RhoResult {
+  state: 'MEASURABLE' | 'EVIDENCE_PENDING';
+  aggregates: RhoCounterpartyAggregate[];
+  rejectedOrdinarySales: number;
+  directAtlasScoreDelta: 0;
+  canBuySell: false;
+  canSetWeight: false;
+  canAdmitExclude: false;
+  reasons: string[];
+}
+
+function finitePositive(value: number | null | undefined): value is number {
+  return value != null && Number.isFinite(value) && value >= 0;
+}
+
+export function evaluateRhoCounterpartyExposure(records: readonly RhoExposureRecord[]): RhoResult {
+  const usable = records.filter((r) => r.material && !r.ordinarySales && r.position.trim() && r.counterparty.trim() && r.sourceId.trim());
+  const invalidQuantified = usable.some((r) => r.kind !== 'NO_CUANTIFICADA' && (!finitePositive(r.amount) || !r.currency?.trim()));
+  const invalidUnquantified = usable.some((r) => r.kind === 'NO_CUANTIFICADA' && r.amount != null);
+  if (invalidQuantified || invalidUnquantified) {
+    return {
+      state: 'EVIDENCE_PENDING', aggregates: [], rejectedOrdinarySales: records.filter((r) => r.ordinarySales).length,
+      directAtlasScoreDelta: 0, canBuySell: false, canSetWeight: false, canAdmitExclude: false,
+      reasons: ['Quantified exposures require non-negative amount and currency; NO_CUANTIFICADA must not carry a fabricated amount.'],
+    };
+  }
+
+  const map = new Map<string, RhoCounterpartyAggregate>();
+  for (const r of usable) {
+    const current = map.get(r.counterparty) ?? {
+      counterparty: r.counterparty, positions: [], records: 0, quantifiedByKind: {}, unquantifiedRecords: 0,
+    };
+    if (!current.positions.includes(r.position)) current.positions.push(r.position);
+    current.records += 1;
+    if (r.kind === 'NO_CUANTIFICADA') {
+      current.unquantifiedRecords += 1;
+    } else {
+      const byCurrency = current.quantifiedByKind[r.kind] ?? {};
+      byCurrency[r.currency as string] = (byCurrency[r.currency as string] ?? 0) + (r.amount as number);
+      current.quantifiedByKind[r.kind] = byCurrency;
+    }
+    map.set(r.counterparty, current);
+  }
+
+  const aggregates = [...map.values()].sort((a, b) => b.positions.length - a.positions.length || a.counterparty.localeCompare(b.counterparty));
+  return {
+    state: usable.length ? 'MEASURABLE' : 'EVIDENCE_PENDING',
+    aggregates,
+    rejectedOrdinarySales: records.filter((r) => r.ordinarySales).length,
+    directAtlasScoreDelta: 0,
+    canBuySell: false,
+    canSetWeight: false,
+    canAdmitExclude: false,
+    reasons: [
+      'Ρ aggregates only declared non-ordinary-sales third-party exposure; it never estimates undisclosed exposure.',
+      'Recognized, drawn, maximum-facility and contingent amounts remain separate because they are economically non-additive.',
+      'NO_CUANTIFICADA contributes to position/record counts only and never to notional totals.',
+    ],
+  };
+}

--- a/src/atlas/algorithm/rho-ai-demand-provenance-omega.test.ts
+++ b/src/atlas/algorithm/rho-ai-demand-provenance-omega.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateRhoCounterpartyExposure } from './counterparty-exposure-omega';
+import {
+  aiOrderCashQuality,
+  capitalRiskTransferAdvantage,
+  evaluateCircularDemand,
+  evaluateFinancingQualityGate,
+  qualityAdjustedBacklog,
+  workingCapitalIntensity,
+} from './ai-demand-provenance-omega';
+
+describe('Ρ — Counterparty Exposure Ω', () => {
+  it('keeps unlike economic exposure kinds separate and counts unquantified records without fake notional', () => {
+    const out = evaluateRhoCounterpartyExposure([
+      { position:'NVDA', counterparty:'OpenAI', exposureType:'credit support', kind:'MAXIMUM_FACILITY', amount:105, currency:'USD_bn', asOf:'2026-09-05', sourceId:'filing-a', ordinarySales:false, material:true },
+      { position:'AVGO', counterparty:'OpenAI', exposureType:'residual guarantee', kind:'NO_CUANTIFICADA', asOf:'2026-09-05', sourceId:'filing-b', ordinarySales:false, material:true },
+      { position:'META', counterparty:'COUNTERPARTY_UNDISCLOSED', exposureType:'residual-value guarantee', kind:'CONTINGENT', amount:70, currency:'USD_bn', asOf:'2026-09-05', sourceId:'filing-c', ordinarySales:false, material:true },
+    ]);
+    expect(out.state).toBe('MEASURABLE');
+    const openai = out.aggregates.find((x) => x.counterparty === 'OpenAI')!;
+    expect(openai.positions.sort()).toEqual(['AVGO','NVDA']);
+    expect(openai.quantifiedByKind.MAXIMUM_FACILITY?.USD_bn).toBe(105);
+    expect(openai.quantifiedByKind.CONTINGENT).toBeUndefined();
+    expect(openai.unquantifiedRecords).toBe(1);
+    expect(out.canBuySell).toBe(false);
+    expect(out.canSetWeight).toBe(false);
+  });
+
+  it('rejects fabricated amount on NO_CUANTIFICADA', () => {
+    const out = evaluateRhoCounterpartyExposure([
+      { position:'X', counterparty:'Y', exposureType:'unknown', kind:'NO_CUANTIFICADA', amount:10, asOf:'2026-09-05', sourceId:'s', ordinarySales:false, material:true },
+    ]);
+    expect(out.state).toBe('EVIDENCE_PENDING');
+  });
+});
+
+describe('AI demand provenance hard gates', () => {
+  it('does not haircut mere equity ownership absent material economic nexus', () => {
+    const out = evaluateCircularDemand({
+      materialEconomicNexus:false, evidenceComplete:true,
+      haircuts:{ circularCapital:25, vendorFinancing:20, guaranteesBackstops:20, leaseDependency:15, reflexiveRevenueFunding:20 },
+    });
+    expect(out.odq).toBe(100);
+    expect(out.state).toBe('PASS_HIGH_QUALITY');
+  });
+
+  it('implements ODQ category boundaries exactly', () => {
+    const mk = (haircut:number) => evaluateCircularDemand({ materialEconomicNexus:true, evidenceComplete:true,
+      haircuts:{ circularCapital:Math.min(haircut,25), vendorFinancing:Math.min(Math.max(haircut-25,0),20), guaranteesBackstops:Math.min(Math.max(haircut-45,0),20), leaseDependency:Math.min(Math.max(haircut-65,0),15), reflexiveRevenueFunding:Math.min(Math.max(haircut-80,0),20) } });
+    expect(mk(10).odq).toBe(90); expect(mk(10).state).toBe('PASS_HIGH_QUALITY');
+    expect(mk(25).odq).toBe(75); expect(mk(25).state).toBe('PASS_INDEPENDENT_FINANCED');
+    expect(mk(40).odq).toBe(60); expect(mk(40).state).toBe('REVIEW_SUPPORTED');
+    expect(mk(60).odq).toBe(40); expect(mk(60).state).toBe('HARD_REVIEW_REFLEXIVE');
+    expect(mk(61).odq).toBe(39); expect(mk(61).state).toBe('FAIL_CIRCULARITY_CRITICAL');
+  });
+
+  it('fails closed when funding evidence is incomplete', () => {
+    const fq = evaluateFinancingQualityGate({
+      fundingSourceIdentified:true, buyerIndependentFromVendor:true, repaymentFromExternalBusinessCashFlow:true,
+      buyerBalanceSheetSupport:null, debtTermsSustainable:true, leaseDependencyMaterial:false, vendorFundingMaterial:false,
+      guaranteesBackstopsMaterial:false, customerConcentrationMaterial:false, terminationPrepaymentProtectionAdequate:true,
+      residualRiskRetainedByVendor:false,
+    });
+    expect(fq.state).toBe('EVIDENCE_PENDING');
+    expect(fq.downstreamFundamentalScoreAuthorized).toBe(false);
+  });
+
+  it('computes quality-adjusted backlog instead of capitalizing reported backlog at face value', () => {
+    const out = qualityAdjustedBacklog({ reportedBacklog:100, odq:65, contractQuality:0.8, fundingProbability:0.9 });
+    expect(out.state).toBe('AVAILABLE');
+    expect(out.qualityAdjustedBacklog).toBeCloseTo(46.8, 8);
+  });
+
+  it('returns NO_CALCULABLE on invalid ratio denominators', () => {
+    expect(capitalRiskTransferAdvantage(10,0).state).toBe('NO_CALCULABLE');
+    expect(aiOrderCashQuality(10,0).state).toBe('NO_CALCULABLE');
+    expect(workingCapitalIntensity(1,2,1,0).state).toBe('NO_CALCULABLE');
+  });
+});


### PR DESCRIPTION
Closes #116.

Ratifies Ρ Counterparty Exposure Ω under the user's explicit instruction to finish all outstanding ATLAS tasks and implements the AI-CAPEX demand-provenance architecture:

- Ρ aggregates filings-backed non-ordinary-sales counterparty exposure while keeping recognized/drawn/max-facility/contingent/unquantified quantities separate.
- Ρ has zero BUY/SELL, weight, admission or structural-score authority.
- T2 Financing Quality Gate Ω asks where the money creating the order originated.
- T3 Circular Demand Gate Ω implements ODQ = 100-(C+V+G+L+R), canonical maxima 25/20/20/15/20, and requires a material economic nexus before any haircut.
- T4 Quality-Adjusted Backlog Ω implements reported_backlog × ODQ × CQ × FP.
- T5 Capital Risk Transfer Advantage Ω plus OCQ/WCI diagnostics fail closed on invalid denominators.
- Business Quality and Marginal Demand Quality remain orthogonal.
- Unknown funding provenance is EVIDENCE_PENDING, never presumed organic.
- Canon includes the 'Follow the money backwards' rule.

A superseding Kernel registry v2 records Δ as SHADOW_ONLY and the five-contract Δ/Κ/Γ/Υ/Ρ composition without silently rewriting the historical Greek v1 file.