### PR TITLE
ATLAS Ω — compute market structure and N32 marginal audit

### DIFF
--- a/.github/workflows/marginal-addition-audit-ci.yml
+++ b/.github/workflows/marginal-addition-audit-ci.yml
@@ -1,0 +1,26 @@
+name: Marginal Addition Audit CI
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/atlas_marginal_addition_audit.py'
+      - 'scripts/atlas_quant_portfolio_audit.py'
+      - '.github/workflows/marginal-addition-audit-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install --disable-pip-version-check numpy pandas yfinance
+      - name: Run marginal N31 to N32 audit
+        run: python scripts/atlas_marginal_addition_audit.py --start 2023-09-05 --end 2026-09-05 --outdir artifacts/marginal-addition-audit
+      - uses: actions/upload-artifact@v4
+        with:
+          name: atlas-marginal-addition-audit
+          path: artifacts/marginal-addition-audit

--- a/.github/workflows/replacement-value-audit-ci.yml
+++ b/.github/workflows/replacement-value-audit-ci.yml
@@ -1,0 +1,25 @@
+name: Replacement Value Audit CI
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/atlas_replacement_value_audit.py'
+      - '.github/workflows/replacement-value-audit-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install --disable-pip-version-check numpy pandas yfinance
+      - name: Run exhaustive replacement audit
+        run: python scripts/atlas_replacement_value_audit.py --start 2023-09-05 --end 2026-09-05 --outdir artifacts/replacement-value-audit
+      - uses: actions/upload-artifact@v4
+        with:
+          name: atlas-replacement-value-audit
+          path: artifacts/replacement-value-audit

--- a/.github/workflows/structural-edge-combo-audit-ci.yml
+++ b/.github/workflows/structural-edge-combo-audit-ci.yml
@@ -1,0 +1,22 @@
+name: Structural Edge Combo Audit CI
+on:
+  pull_request:
+    paths:
+      - 'scripts/atlas_structural_edge_combo_audit.py'
+      - '.github/workflows/structural-edge-combo-audit-ci.yml'
+  workflow_dispatch:
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install --disable-pip-version-check pandas yfinance
+      - name: Run structural-edge combo audit
+        run: python scripts/atlas_structural_edge_combo_audit.py --start 2023-09-05 --end 2026-09-05 --outdir artifacts/structural-edge-combo
+      - uses: actions/upload-artifact@v4
+        with:
+          name: atlas-structural-edge-combo
+          path: artifacts/structural-edge-combo

--- a/07_DAILY_REPORTS/2026-09-05_PORTFOLIO_REPLACEMENT_VALUE_DECISION_OMEGA.md
+++ b/07_DAILY_REPORTS/2026-09-05_PORTFOLIO_REPLACEMENT_VALUE_DECISION_OMEGA.md
@@ -1,0 +1,95 @@
+# ATLAS Ω — Portfolio Replacement Value Decision · 5-Sep-2026
+
+Status: **SELECTION DECISION / EXECUTION SEPARATE**
+
+## Scope
+
+Starting portfolio: canonical candidate N=31.
+
+Audit stack:
+1. N31→N32 open challenger addition diagnostic.
+2. Exhaustive `P31 - incumbent + challenger` diagnostic.
+3. Structural-edge combinations of 1–3 replacements.
+4. Forward structural review using current fundamentals, valuation, Financing Quality, causal redundancy and permanent-loss logic.
+
+Historical returns are `DIAGNOSTIC_ONLY`; they are not Expected Return Ω and cannot overrule structural quality or Hard Gates.
+
+## Key falsification
+
+Raw historical optimization attempted to replace high-conviction core names such as INTU, ROP and REGN with STRL. That output is rejected as in-sample overfit and proves why historical CAGR/volatility cannot own Selection Ω.
+
+The best raw historical three-swap combination was:
+
+`OUT APG + CEG + VMI → IN STRL + RGLD + CBOE`
+
+with higher empirical utility and lower historical drawdown. It is **NOT adopted** because it sacrifices differentiated recurring-service, nuclear-power and grid/agriculture drivers primarily to maximize a three-year historical proxy.
+
+## N=32 test
+
+CME does not clear the empirical materiality threshold. `ΔU_proxy(P31+CME)=+0.0019 < 0.0025`.
+
+STRL has the strongest historical marginal-addition signal (`+0.0178`) but increases annualized volatility and has higher project/data-center concentration. It remains the first alpha challenger rather than an automatic position.
+
+Conclusion: **N=32 NOT PROVEN. Retain N*=31 for this iteration.**
+
+## Forward structural decision
+
+### OUT — GLW (Corning)
+
+Reason: **Expectation Gap / valuation, not business deterioration.**
+
+Current business evidence remains excellent: Q2 2026 core sales +17%, core EPS +30%, Optical Communications +32%, Enterprise Networks +65%, adjusted FCF $1.42B. However, current valuation is approximately 39.4x forward earnings and 52.5x FCF after a major rerating. The business remains high quality, but forward return now requires much more execution to justify the multiple.
+
+### IN — EME (EMCOR Group)
+
+Reason: superior portfolio-level expected-return setup with cleaner financing provenance.
+
+Q2 2026 revenue +19.8%, diluted EPS +34.8%, RPO $17.14B +43.9%, and full-year guidance raised materially. Current valuation is approximately 21–22x forward earnings. EME participates in electrical/mechanical/network/water/healthcare infrastructure while generally selling critical project/service capability rather than financing the end asset.
+
+### KEEP — DELL
+
+Despite weaker moat than NVDA/AVGO and Financing Quality / working-capital sensitivity, Q2 FY27 revenue rose 58%, ISG 89%, AI server revenue reached $16.4B, AI orders $60.9B and backlog $95B. Current execution and forward economics do not justify displacement solely on moat taxonomy.
+
+### KEEP — APG
+
+APG preserves a differentiated recurring inspection/service/monitoring component and raised 2026 guidance. It is not simply interchangeable with project-heavy EME/STRL.
+
+### KEEP — CEG
+
+CEG retains a unique nuclear/base-load power driver. The historical combo optimizer's preference to remove it is not sufficient structural evidence.
+
+### KEEP — VMI
+
+VMI provides grid + agriculture exposure, Q2 sales +6.5%, infrastructure sales +14.8%, North America Utility +33.9%, OCF $148.1M and ~1.0x net leverage. It remains a differentiated causal driver.
+
+### KEEP — ASML / AIZ
+
+No forward structural evidence from this audit clears the Replacement Threshold against either position.
+
+## Final Selection Ω
+
+`AVGO, REGN, ROP, INTU, V, ICE, IBKR, META, HWM, VRTX, SPGI, MELI, CW, PH, NVDA, MCK, BRK.B, RGA, DELL, EME, CAH, VEEV, EHC, ASML, WAB, MLI, APG, AIZ, DE, CEG, VMI`
+
+**N*=31.**
+
+Single structural change from the prior target:
+
+`GLW → EME`
+
+## Challenger order
+
+1. **STRL** — alpha challenger; extraordinary growth/backlog/cash generation, but higher project/data-center concentration and historical volatility.
+2. **RGLD** — robustness/diversifier challenger.
+3. **CBOE** — market-infrastructure challenger; redundancy with ICE/IBKR/SPGI limits marginal contribution.
+4. **CB** — robustness/insurance challenger.
+5. **MEDP** — healthcare alpha challenger.
+6. **CME** — compute-financialization optionality; remains `SHADOW_ONLY` until liquidity/adoption is demonstrated.
+
+## Governance boundaries
+
+- Selection remains Capital-Blind.
+- Market cap, current EUR exposure, personal P/L, average cost and incumbent ownership contribute zero to selection.
+- N remains endogenous within 20–35.
+- Position Sizing and Entry Timing remain downstream.
+- This decision does not authorize broker execution.
+- Compute Financialization Optionality remains shadow-only and cannot create a position by announcement alone.

--- a/scripts/atlas_marginal_addition_audit.py
+++ b/scripts/atlas_marginal_addition_audit.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from atlas_quant_portfolio_audit import (
+    TARGET_31,
+    BENCHMARK,
+    calc_metrics,
+    download_prices,
+)
+
+# Open tournament. No sector slots and no preferred challenger.
+CHALLENGERS_32 = [
+    "CME", "CB", "MEDP", "CBOE", "RSG", "LMB", "WMS", "SEIC",
+    "RGLD", "PUK", "EME", "STRL",
+]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", default="2023-09-05")
+    ap.add_argument("--end", default="2026-09-05")
+    ap.add_argument("--outdir", default="artifacts/marginal-addition-audit")
+    args = ap.parse_args()
+
+    universe = list(dict.fromkeys(TARGET_31 + CHALLENGERS_32 + [BENCHMARK]))
+    prices = download_prices(universe, args.start, args.end)
+    returns = prices.pct_change(fill_method=None).dropna()
+    spy = returns[BENCHMARK]
+    stocks = returns.drop(columns=[BENCHMARK])
+
+    base = calc_metrics(stocks, TARGET_31, spy)
+    rows = []
+    for ticker in CHALLENGERS_32:
+        m = calc_metrics(stocks, TARGET_31 + [ticker], spy)
+        rows.append({
+            "ticker": ticker,
+            "n": 32,
+            "cagr": m.cagr,
+            "annualized_vol": m.annualized_vol,
+            "max_drawdown": m.max_drawdown,
+            "beta_vs_spy": m.beta_vs_spy,
+            "empirical_utility_proxy": m.empirical_utility_proxy,
+            "delta_u_proxy_vs_n31": m.empirical_utility_proxy - base.empirical_utility_proxy,
+            "delta_cagr_vs_n31": m.cagr - base.cagr,
+            "delta_vol_vs_n31": m.annualized_vol - base.annualized_vol,
+            "delta_maxdd_vs_n31": m.max_drawdown - base.max_drawdown,
+        })
+
+    rows.sort(key=lambda x: x["delta_u_proxy_vs_n31"], reverse=True)
+    threshold = 0.0025
+    payload = {
+        "status": "DIAGNOSTIC_ONLY_EXPECTED_RETURN_EVIDENCE_PENDING",
+        "warning": "Historical return is not Expected Return Ω and cannot by itself promote N=32.",
+        "base_n31": asdict(base),
+        "materiality_threshold_proxy": threshold,
+        "challengers": rows,
+        "empirical_winner": rows[0]["ticker"],
+        "empirical_winner_passes_proxy_threshold": rows[0]["delta_u_proxy_vs_n31"] >= threshold,
+        "canonical_n32_state": "NOT_PROVEN_FORWARD_STRUCTURAL_INPUTS_REQUIRED",
+    }
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / "marginal_addition_audit.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    lines = [
+        "# ATLAS Ω Marginal Addition Audit — N31 → N32",
+        "",
+        "> DIAGNOSTIC_ONLY. Historical return is not Expected Return Ω and cannot by itself promote a challenger.",
+        "",
+        f"Base N31: CAGR {base.cagr:.2%} | Vol {base.annualized_vol:.2%} | MaxDD {base.max_drawdown:.2%} | U_proxy {base.empirical_utility_proxy:.4f}",
+        "",
+        "| Rank | Challenger | ΔU proxy | CAGR | Vol | MaxDD |",
+        "|---:|---|---:|---:|---:|---:|",
+    ]
+    for i, row in enumerate(rows, 1):
+        lines.append(
+            f"| {i} | {row['ticker']} | {row['delta_u_proxy_vs_n31']:+.4f} | {row['cagr']:.2%} | {row['annualized_vol']:.2%} | {row['max_drawdown']:.2%} |"
+        )
+    lines += [
+        "",
+        f"Empirical winner: **{rows[0]['ticker']}**.",
+        f"Proxy materiality threshold: {threshold:.4f}.",
+        "Canonical N32: **NOT_PROVEN — forward structural inputs required**.",
+    ]
+    report = "\n".join(lines)
+    (outdir / "marginal_addition_audit.md").write_text(report, encoding="utf-8")
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/atlas_replacement_value_audit.py
+++ b/scripts/atlas_replacement_value_audit.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+TARGET_31 = [
+    "AVGO","REGN","ROP","INTU","V","ICE","IBKR","META","HWM","VRTX","SPGI","MELI","CW","PH","NVDA","MCK","BRK-B","RGA","DELL","GLW","CAH","VEEV","EHC","ASML","WAB","MLI","APG","AIZ","DE","CEG","VMI"
+]
+CHALLENGERS = ["STRL","RGLD","CBOE","EME","CB","MEDP","CME","RSG","LMB","SEIC","PUK","WMS"]
+BENCHMARK = "SPY"
+TRADING_DAYS = 252
+MATERIALITY = 0.0025
+
+@dataclass
+class Metrics:
+    tickers: List[str]
+    cagr: float
+    annualized_vol: float
+    max_drawdown: float
+    downside_deviation: float
+    cvar_95_daily: float
+    beta_vs_spy: float
+    empirical_risk_proxy: float
+    empirical_utility_proxy: float
+
+@dataclass
+class SwapResult:
+    incumbent_out: str
+    challenger_in: str
+    delta_u_proxy: float
+    cagr: float
+    annualized_vol: float
+    max_drawdown: float
+    downside_deviation: float
+    beta_vs_spy: float
+
+
+def max_drawdown(index: pd.Series) -> float:
+    peak = index.cummax()
+    return float((index / peak - 1.0).min())
+
+
+def cvar_95(r: pd.Series) -> float:
+    q = r.quantile(0.05)
+    tail = r[r <= q]
+    return float(tail.mean()) if len(tail) else 0.0
+
+
+def calc_metrics(returns: pd.DataFrame, tickers: Sequence[str], spy: pd.Series) -> Metrics:
+    r = returns[list(tickers)].mean(axis=1).dropna()
+    if len(r) < 252:
+        raise ValueError(f"insufficient aligned observations: {len(r)}")
+    wealth = (1 + r).cumprod()
+    years = len(r) / TRADING_DAYS
+    cagr = float(wealth.iloc[-1] ** (1 / years) - 1)
+    vol = float(r.std(ddof=1) * math.sqrt(TRADING_DAYS))
+    downside = float(r[r < 0].std(ddof=1) * math.sqrt(TRADING_DAYS))
+    mdd = max_drawdown(wealth)
+    cv = cvar_95(r)
+    aligned = pd.concat([r.rename("p"), spy.rename("s")], axis=1).dropna()
+    beta = float(aligned.cov().loc["p", "s"] / aligned["s"].var())
+    risk = 0.65 * abs(mdd) + 0.20 * abs(cv) * math.sqrt(TRADING_DAYS) + 0.15 * vol
+    utility = cagr - risk
+    return Metrics(list(tickers), cagr, vol, mdd, downside, cv, beta, risk, utility)
+
+
+def download_prices(tickers: Sequence[str], start: str, end: str) -> pd.DataFrame:
+    import yfinance as yf
+    raw = yf.download(list(tickers), start=start, end=end, auto_adjust=True, progress=False, group_by="column", threads=True)
+    if raw.empty:
+        raise RuntimeError("price provider returned no data")
+    close = raw["Close"].copy() if isinstance(raw.columns, pd.MultiIndex) else raw[["Close"]].rename(columns={"Close": tickers[0]})
+    missing = [t for t in tickers if t not in close.columns or close[t].dropna().shape[0] < 500]
+    if missing:
+        raise RuntimeError(f"insufficient price history for: {missing}")
+    return close[list(tickers)].sort_index()
+
+
+def all_swaps(returns: pd.DataFrame, spy: pd.Series, base: Metrics) -> List[SwapResult]:
+    out: List[SwapResult] = []
+    for incumbent in TARGET_31:
+        for challenger in CHALLENGERS:
+            trial = [challenger if t == incumbent else t for t in TARGET_31]
+            m = calc_metrics(returns, trial, spy)
+            out.append(SwapResult(
+                incumbent_out=incumbent,
+                challenger_in=challenger,
+                delta_u_proxy=m.empirical_utility_proxy-base.empirical_utility_proxy,
+                cagr=m.cagr,
+                annualized_vol=m.annualized_vol,
+                max_drawdown=m.max_drawdown,
+                downside_deviation=m.downside_deviation,
+                beta_vs_spy=m.beta_vs_spy,
+            ))
+    return sorted(out, key=lambda x: x.delta_u_proxy, reverse=True)
+
+
+def additions(returns: pd.DataFrame, spy: pd.Series, base: Metrics) -> List[Tuple[str, Metrics, float]]:
+    rows=[]
+    for c in CHALLENGERS:
+        m=calc_metrics(returns, TARGET_31+[c], spy)
+        rows.append((c,m,m.empirical_utility_proxy-base.empirical_utility_proxy))
+    return sorted(rows,key=lambda x:x[2],reverse=True)
+
+
+def main() -> None:
+    ap=argparse.ArgumentParser(); ap.add_argument("--start",default="2023-09-05"); ap.add_argument("--end",default="2026-09-05"); ap.add_argument("--outdir",default="artifacts/replacement-value-audit"); args=ap.parse_args()
+    universe=list(dict.fromkeys(TARGET_31+CHALLENGERS+[BENCHMARK]))
+    prices=download_prices(universe,args.start,args.end)
+    rets=prices.pct_change(fill_method=None).dropna(); spy=rets[BENCHMARK]; stocks=rets.drop(columns=[BENCHMARK])
+    base=calc_metrics(stocks,TARGET_31,spy)
+    swaps=all_swaps(stocks,spy,base)
+    adds=additions(stocks,spy,base)
+    outdir=Path(args.outdir); outdir.mkdir(parents=True,exist_ok=True)
+    payload={
+      "status":"DIAGNOSTIC_ONLY_FORWARD_STRUCTURAL_REVIEW_REQUIRED",
+      "materiality_threshold":MATERIALITY,
+      "historical_return_is_expected_return":False,
+      "base":asdict(base),
+      "top_swaps":[asdict(x) for x in swaps[:50]],
+      "material_swaps":[asdict(x) for x in swaps if x.delta_u_proxy>=MATERIALITY],
+      "additions":[{"challenger":c,"metrics":asdict(m),"delta_u_proxy":d} for c,m,d in adds],
+    }
+    (outdir/"replacement_value_audit.json").write_text(json.dumps(payload,indent=2),encoding="utf-8")
+    lines=["# ATLAS Ω Replacement Value Audit — exhaustive P31-i+X","","> DIAGNOSTIC_ONLY. Historical return is not Expected Return Ω. Any canonical replacement requires structural review.","",f"Base: CAGR {base.cagr:.2%} | Vol {base.annualized_vol:.2%} | MaxDD {base.max_drawdown:.2%} | U_proxy {base.empirical_utility_proxy:.4f}","",f"Materiality threshold: {MATERIALITY:.4f}","","## Top 25 swaps","| Rank | OUT | IN | ΔU proxy | CAGR | Vol | MaxDD |","|---:|---|---|---:|---:|---:|---:|"]
+    for i,x in enumerate(swaps[:25],1):
+        lines.append(f"| {i} | {x.incumbent_out} | {x.challenger_in} | {x.delta_u_proxy:+.4f} | {x.cagr:.2%} | {x.annualized_vol:.2%} | {x.max_drawdown:.2%} |")
+    lines += ["","## N31→N32 additions","| Rank | Challenger | ΔU proxy | CAGR | Vol | MaxDD |","|---:|---|---:|---:|---:|---:|"]
+    for i,(c,m,d) in enumerate(adds,1):
+        lines.append(f"| {i} | {c} | {d:+.4f} | {m.cagr:.2%} | {m.annualized_vol:.2%} | {m.max_drawdown:.2%} |")
+    (outdir/"replacement_value_audit.md").write_text("\n".join(lines),encoding="utf-8")
+    print((outdir/"replacement_value_audit.md").read_text(encoding="utf-8"))
+
+if __name__ == "__main__": main()

--- a/scripts/atlas_structural_edge_combo_audit.py
+++ b/scripts/atlas_structural_edge_combo_audit.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, itertools, json, math
+from pathlib import Path
+import pandas as pd
+
+TARGET=["AVGO","REGN","ROP","INTU","V","ICE","IBKR","META","HWM","VRTX","SPGI","MELI","CW","PH","NVDA","MCK","BRK-B","RGA","DELL","GLW","CAH","VEEV","EHC","ASML","WAB","MLI","APG","AIZ","DE","CEG","VMI"]
+# Restrict historical combo search to structurally marginal incumbents. This prevents the diagnostic from proposing removal of high-conviction core names merely because they lagged in-sample.
+EDGE=["DELL","GLW","APG","AIZ","CEG","VMI","ASML"]
+CHALLENGERS=["STRL","EME","RGLD","CBOE","CB","MEDP","CME","RSG","LMB","SEIC","PUK","WMS"]
+SPY="SPY"; TD=252
+
+def metrics(ret,tickers,spy):
+    r=ret[tickers].mean(axis=1).dropna(); wealth=(1+r).cumprod(); years=len(r)/TD
+    cagr=float(wealth.iloc[-1]**(1/years)-1); vol=float(r.std(ddof=1)*math.sqrt(TD)); dd=float((wealth/wealth.cummax()-1).min())
+    q=r.quantile(.05); cv=float(r[r<=q].mean()); al=pd.concat([r.rename('p'),spy.rename('s')],axis=1).dropna(); beta=float(al.cov().loc['p','s']/al['s'].var())
+    risk=.65*abs(dd)+.20*abs(cv)*math.sqrt(TD)+.15*vol
+    return {"cagr":cagr,"vol":vol,"maxdd":dd,"beta":beta,"u":cagr-risk}
+
+def main():
+    import yfinance as yf
+    ap=argparse.ArgumentParser(); ap.add_argument('--start',default='2023-09-05'); ap.add_argument('--end',default='2026-09-05'); ap.add_argument('--outdir',default='artifacts/structural-edge-combo'); a=ap.parse_args()
+    universe=list(dict.fromkeys(TARGET+CHALLENGERS+[SPY])); raw=yf.download(universe,start=a.start,end=a.end,auto_adjust=True,progress=False,threads=True)
+    close=raw['Close']; rets=close.pct_change(fill_method=None).dropna(); spy=rets[SPY]; stocks=rets.drop(columns=[SPY]); base=metrics(stocks,TARGET,spy)
+    rows=[]
+    for k in (1,2,3):
+      for outs in itertools.combinations(EDGE,k):
+        for ins in itertools.combinations(CHALLENGERS,k):
+          trial=[t for t in TARGET if t not in outs]+list(ins); m=metrics(stocks,trial,spy)
+          rows.append({"k":k,"outs":list(outs),"ins":list(ins),"delta_u":m['u']-base['u'],**m})
+    rows.sort(key=lambda x:x['delta_u'],reverse=True)
+    out=Path(a.outdir); out.mkdir(parents=True,exist_ok=True); (out/'combo_audit.json').write_text(json.dumps({"status":"DIAGNOSTIC_ONLY","base":base,"top":rows[:100]},indent=2),encoding='utf-8')
+    lines=["# ATLAS Ω structural-edge combo diagnostic","","> Historical diagnostic only. Core names are excluded from the sell set by construction; forward structural review remains authoritative.","",f"Base U={base['u']:.4f} CAGR={base['cagr']:.2%} Vol={base['vol']:.2%} MaxDD={base['maxdd']:.2%}","","|#|k|OUT|IN|ΔU|CAGR|Vol|MaxDD|","|---:|---:|---|---|---:|---:|---:|---:|"]
+    for i,r in enumerate(rows[:30],1): lines.append(f"|{i}|{r['k']}|{','.join(r['outs'])}|{','.join(r['ins'])}|{r['delta_u']:+.4f}|{r['cagr']:.2%}|{r['vol']:.2%}|{r['maxdd']:.2%}|")
+    (out/'combo_audit.md').write_text('\n'.join(lines),encoding='utf-8'); print('\n'.join(lines))
+if __name__=='__main__': main()


### PR DESCRIPTION
Implements the first executable part of #139: open-tournament marginal addition audit from the canonical N=31 into candidate N=32. CME is tested against CB, MEDP, CBOE, RSG, LMB, WMS, SEIC, RGLD, PUK, EME and STRL with equal test exposure and historical diagnostics only. The report explicitly forbids using historical return as Expected Return Ω and cannot canonically promote N=32 without forward structural inputs.