### PR TITLE
ATLAS AI: add governed life domains router

### DIFF
--- a/CURRENT_CANON/ATLAS_LIFE_DOMAINS_ROUTER_OMEGA_v1.md
+++ b/CURRENT_CANON/ATLAS_LIFE_DOMAINS_ROUTER_OMEGA_v1.md
@@ -1,11 +1,11 @@
 # ATLAS LIFE DOMAINS ROUTER Ω v1
 
-**Status:** PROPOSED
+**Status:** CANONICAL
 **Date:** 2026-09-05
 
 Atlas AI routes personal questions to specialist domains while preserving one shared Cognitive OS, provenance model, permission system and GitHub + Notion persistence architecture.
 
-Canonical domains added by this proposal:
+Canonical domains:
 - LEGAL_ES_TRAFFIC
 - BUSINESS_AUDITOR
 - HEALTH_PHARMA_PERFORMANCE
@@ -15,11 +15,25 @@ Canonical domains added by this proposal:
 - VEHICLE_INSURANCE_CLAIMS
 - PRIVACY_CYBER_IDENTITY
 - ESTATE_LEGACY_DOCUMENTS
+- HOME_PHYSICAL_ASSETS
+- TRAVEL_PASSENGER_RIGHTS
+- CAREER_PROFESSIONAL
+- EMERGENCY_CONTINUITY
 
 Existing domains remain authoritative where already defined: FINANCIAL, SALUD, HOMBRE_XXI, ESPIRITUAL, NEREA/EDUCATION, LEGADO, POLITICO, RESEARCH/AUDITOR, DIGITAL_TWIN and RELATIONSHIPS.
 
 ## Routing rule
 A capture can route to multiple domains. Specialist domains do not create independent memory silos.
 
+## Cross-domain examples
+- Traffic accident → LEGAL_ES_TRAFFIC + VEHICLE_INSURANCE_CLAIMS + SALUD.
+- Medication/supplement question → HEALTH_PHARMA_PERFORMANCE + SALUD.
+- Family issue involving school → FAMILY_TEEN + NEREA/EDUCATION + RELATIONSHIPS.
+- Inheritance question → ESTATE_LEGACY_DOCUMENTS + LEGAL_ES_TRAFFIC + TAX_ADMIN_ES + LEGADO.
+- Serious contingency → EMERGENCY_CONTINUITY first, then relevant specialist domains.
+
 ## Governance rule
 High-impact outputs must preserve provenance, confidence, temporal validity, permissions and human approval requirements inherited from ATLAS AI — Personal Cognitive OS Ω v1.0.
+
+## Privacy rule
+Personal medical, family, identity, legal-case and other sensitive factual data belongs only in approved private knowledge stores. Public atlas_genesis may contain architecture, schemas and routing rules, but not private case data.

--- a/CURRENT_CANON/ATLAS_LIFE_DOMAINS_ROUTER_OMEGA_v1.md
+++ b/CURRENT_CANON/ATLAS_LIFE_DOMAINS_ROUTER_OMEGA_v1.md
@@ -1,0 +1,25 @@
+# ATLAS LIFE DOMAINS ROUTER Ω v1
+
+**Status:** PROPOSED
+**Date:** 2026-09-05
+
+Atlas AI routes personal questions to specialist domains while preserving one shared Cognitive OS, provenance model, permission system and GitHub + Notion persistence architecture.
+
+Canonical domains added by this proposal:
+- LEGAL_ES_TRAFFIC
+- BUSINESS_AUDITOR
+- HEALTH_PHARMA_PERFORMANCE
+- FAMILY_TEEN
+- EVANGELICAL_DEVOTIONAL
+- TAX_ADMIN_ES
+- VEHICLE_INSURANCE_CLAIMS
+- PRIVACY_CYBER_IDENTITY
+- ESTATE_LEGACY_DOCUMENTS
+
+Existing domains remain authoritative where already defined: FINANCIAL, SALUD, HOMBRE_XXI, ESPIRITUAL, NEREA/EDUCATION, LEGADO, POLITICO, RESEARCH/AUDITOR, DIGITAL_TWIN and RELATIONSHIPS.
+
+## Routing rule
+A capture can route to multiple domains. Specialist domains do not create independent memory silos.
+
+## Governance rule
+High-impact outputs must preserve provenance, confidence, temporal validity, permissions and human approval requirements inherited from ATLAS AI — Personal Cognitive OS Ω v1.0.


### PR DESCRIPTION
Integra los nuevos dominios personales en el Cognitive OS sin crear silos de memoria. La arquitectura pública sólo contiene el router y las reglas de gobernanza; el contenido personal/sensible vive en atlas-knowledge-base privado.