### PR TITLE
feat: promote Durable Revision Gap Ω into ATLAS main engine

### DIFF
--- a/CURRENT_CANON/2026-09-06_DURABLE_REVISION_GAP_MAIN_ENGINE_OMEGA_V1.md
+++ b/CURRENT_CANON/2026-09-06_DURABLE_REVISION_GAP_MAIN_ENGINE_OMEGA_V1.md
@@ -1,0 +1,113 @@
+# ATLAS Ω — DURABLE REVISION GAP Ω v1.0
+
+**Status:** CANONICAL MAIN-ENGINE INPUT — pending PR merge  
+**Date:** 2026-09-06  
+**Module:** `src/atlas/algorithm/durable-revision-gap-omega.ts`
+
+## Decision
+
+The research that began as ELITE CAPITAL SIGNAL Ω / Progeny reverse engineering is split into two layers.
+
+1. **DURABLE REVISION GAP Ω** is promoted into the ATLAS main selection path because its economic variables are company-intrinsic and independently auditable.
+2. **REVEALED CAPITAL INTELLIGENCE Ω** remains corroborative evidence with **0 direct score weight**. Allocator ownership, family-office identity, 13F/13G, PIPE participation, board proximity or access cannot create ATLAS points or override valuation, fundamentals, survivability or falsifiers.
+
+This prevents the system from becoming a guru-copying engine while preserving the useful economic extraction from the research.
+
+## Main-engine thesis
+
+ATLAS should prefer companies where **durable future owner economics are improving faster than market-implied expectations**, subject to survivability and evidence quality.
+
+The main variables are:
+
+- Forward Fundamental Inflection
+- Expectation Gap
+- Inflection Durability
+- Cash Conversion
+- Revision Torque
+- Structural Repeatability
+- Incremental Capital Efficiency
+
+Penalties are:
+
+- Valuation Saturation
+- Balance Fragility
+- Integration Distance
+- Driver Concentration
+
+## Hard laws
+
+- `ACCESS != ALPHA`.
+- `13F/13G != CURRENT FLOW`.
+- `PIPE != EXPECTED RETURN BONUS`.
+- `BOARD PROXIMITY != RIGHT TO TRADE ON MNPI`.
+- `ELITE CAPITAL DIRECT SCORE CONTRIBUTION = 0`.
+- `SURVIVABILITY` is a hard gate and cannot be averaged away.
+- Market cap, brand familiarity and index membership remain zero-point discovery variables under T0.
+- A high-quality company with saturated expectations can score below a lower-quality company with a durable revision gap.
+- Company quality, opportunity, and portfolio sizing remain separate questions.
+
+## Canonical role
+
+`DURABLE_REVISION_GAP_OMEGA_V1` is a **CORE_SELECTION_INPUT** in the main engine and feeds structural selection / Expected Return refinement.
+
+It does **not** replace:
+
+- PRINCIPAL Ω
+- Valuation Ω
+- Expected Return 3–6Y
+- Risk Ω
+- Falsifier Veto Ω
+- Competition for Capital Ω
+- Endogenous Portfolio Engine Ω
+
+It provides the missing bridge between trailing company quality and forward expectation asymmetry.
+
+## Revealed Capital Intelligence boundary
+
+The optional revealed-capital packet can contain:
+
+- source allocator
+- public signal date
+- concentration
+- persistence
+- marginal direction: NEW / ACCELERATING / ADDING / HOLDING / HARVESTING / EXITING
+- information proximity: P0–P4
+- copyability
+
+This packet may increase **research confidence / priority**, but its direct score contribution is always exactly zero.
+
+## Evidence gate
+
+Canonical use requires at least six traceable evidence records and company identity/date alignment. Missing or insufficient evidence returns `EVIDENCE_PENDING`.
+
+## State machine
+
+- `CORE_REVISION_OPPORTUNITY`
+- `POSITIVE_REVISION_GAP`
+- `WATCH`
+- `SATURATED`
+- `FAIL_SURVIVABILITY`
+- `EVIDENCE_PENDING`
+
+## Falsifiers
+
+- forward EPS/FCF trajectory fails to outgrow consensus trajectory
+- margin/cash conversion reverses before the gap closes
+- inflection proves one-off or peak-cycle rather than durable
+- valuation reprices faster than fundamentals
+- refinancing/balance stress breaks survivability
+- integration/dilution consumes owner economics
+- driver concentration creates portfolio-level tail risk
+- revealed-capital signal is stale/reversed and lacks independent confirmation
+
+## Governance
+
+The reverse-engineered Progeny formula is **not** claimed to be Progeny 3's actual internal formula. It is an ATLAS economic model inferred from public behavior and then stripped of allocator identity before entering core scoring.
+
+The model must continue through point-in-time, walk-forward and out-of-sample validation. Any future coefficient recalibration requires Model Learning Governance Ω and Statistical Backtest Firewall Ω.
+
+## Registry
+
+Kernel registry version: `2026-09-06-v2.1.0`.
+
+Main selection sequence now explicitly contains `DURABLE_REVISION_GAP_OMEGA_V1` between Owner Economics Normalization and Valuation / Expected Return.

--- a/src/atlas/algorithm/atlas-kernel-contract-registry-omega.ts
+++ b/src/atlas/algorithm/atlas-kernel-contract-registry-omega.ts
@@ -1,4 +1,4 @@
-export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION = '2026-09-05-v2.0.0' as const;
+export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION = '2026-09-06-v2.1.0' as const;
 
 export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA = {
   governanceStatus: 'ACTIVE_CANONICAL_PENDING_PR_MERGE',
@@ -8,6 +8,16 @@ export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA = {
     gamma: { id: 'GAMMA_VIGENCIA_OMEGA_V1_2', runtimeAuthority: 'VIGENCIA_ONLY' },
     upsilon: { id: 'UPSILON_ALLOCATION_OMEGA_V1', runtimeAuthority: 'ALLOCATION_ONLY' },
     rho: { id: 'RHO_COUNTERPARTY_EXPOSURE_OMEGA_V1', runtimeAuthority: 'EXPOSURE_AGGREGATION_ONLY' },
+    durableRevisionGap: {
+      id: 'DURABLE_REVISION_GAP_OMEGA_V1',
+      runtimeAuthority: 'CORE_SELECTION_INPUT',
+      scoreAuthority: 'MAIN_ENGINE_ECONOMIC_SCORE',
+    },
+    revealedCapitalIntelligence: {
+      id: 'REVEALED_CAPITAL_INTELLIGENCE_OMEGA_V1',
+      runtimeAuthority: 'CORROBORATIVE_EVIDENCE_ONLY',
+      directScoreWeight: 0,
+    },
   },
   boundaries: {
     deltaCannotConclude: true,
@@ -18,9 +28,27 @@ export const ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA = {
     rhoCannotBuySell: true,
     rhoCannotSetWeight: true,
     rhoCannotAdmitExclude: true,
+    revealedCapitalCannotCreateDirectScore: true,
+    revealedCapitalCannotBypassFundamentals: true,
+    revealedCapitalCannotBypassValuation: true,
+    revealedCapitalCannotBypassFalsifierVeto: true,
+    durableRevisionGapRequiresIndependentFundamentalEvidence: true,
     falsifierVetoIndependent: true,
     decisionSafetyIndependent: true,
   },
+  mainSelectionSequence: [
+    'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1_1',
+    'PRINCIPAL_OMEGA',
+    'BUSINESS_QUALITY_OMEGA',
+    'GROWTH_OMEGA',
+    'PER_SHARE_ECONOMICS_OMEGA_V1',
+    'OWNER_ECONOMICS_NORMALIZATION_OMEGA_V1',
+    'DURABLE_REVISION_GAP_OMEGA_V1',
+    'VALUATION_OMEGA',
+    'EXPECTED_RETURN_3_6Y',
+    'RISK_OMEGA',
+    'COMPETITION_FOR_CAPITAL_OMEGA',
+  ],
   aiCapexPreScoreSequence: [
     'T0_ANTI_MEGACAP_DISCOVERY_GATE_OMEGA_V1_1',
     'T1_FUNDAMENTAL_HARD_GATES',

--- a/src/atlas/algorithm/durable-revision-gap-omega.test.ts
+++ b/src/atlas/algorithm/durable-revision-gap-omega.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateDurableRevisionGapOmega } from './durable-revision-gap-omega';
+
+const base = {
+  ticker: 'TEST',
+  family: 'COMPOUNDER_ACCELERATION' as const,
+  evidenceTraceable: true,
+  evidenceIds: ['e1', 'e2', 'e3', 'e4', 'e5', 'e6'],
+  survivabilityScore: 85,
+  structuralRepeatabilityScore: 88,
+  forwardFundamentalInflectionScore: 90,
+  expectationGapScore: 92,
+  inflectionDurabilityScore: 86,
+  cashConversionScore: 90,
+  revisionTorqueScore: 84,
+  incrementalCapitalEfficiencyScore: 82,
+  valuationSaturationScore: 25,
+  balanceFragilityScore: 20,
+  integrationDistanceScore: 15,
+  driverConcentrationScore: 20,
+};
+
+describe('DURABLE_REVISION_GAP_OMEGA_V1', () => {
+  it('promotes a durable revision opportunity when fundamentals outrun expectations', () => {
+    const result = evaluateDurableRevisionGapOmega(base);
+    expect(result.eligible).toBe(true);
+    expect(result.state).toBe('CORE_REVISION_OPPORTUNITY');
+    expect(result.durableRevisionGapScore).toBeGreaterThanOrEqual(78);
+  });
+
+  it('does not allow revealed-capital evidence to create direct score points', () => {
+    const withoutElite = evaluateDurableRevisionGapOmega(base);
+    const withElite = evaluateDurableRevisionGapOmega({
+      ...base,
+      eliteCapitalEvidence: {
+        source: 'Progeny 3',
+        signalDateIso: '2026-05-15',
+        concentrationScore: 95,
+        persistenceScore: 95,
+        marginalDirection: 'ACCELERATING',
+        informationProximity: 'P3_GOVERNANCE',
+        copyabilityScore: 90,
+      },
+    });
+    expect(withElite.durableRevisionGapScore).toBe(withoutElite.durableRevisionGapScore);
+    expect(withElite.eliteCapitalDirectScoreContribution).toBe(0);
+    expect(withElite.revealedCapitalConfidence).toBe('HIGH');
+  });
+
+  it('fails closed when survivability is weak', () => {
+    const result = evaluateDurableRevisionGapOmega({ ...base, survivabilityScore: 25 });
+    expect(result.state).toBe('FAIL_SURVIVABILITY');
+    expect(result.durableRevisionGapScore).toBeLessThanOrEqual(39.9);
+  });
+
+  it('caps a saturated opportunity even with strong operating evidence', () => {
+    const result = evaluateDurableRevisionGapOmega({ ...base, valuationSaturationScore: 92 });
+    expect(result.state).toBe('SATURATED');
+    expect(result.durableRevisionGapScore).toBeLessThanOrEqual(59.9);
+  });
+
+  it('blocks canonical use when evidence is insufficient', () => {
+    const result = evaluateDurableRevisionGapOmega({ ...base, evidenceIds: ['e1', 'e2'] });
+    expect(result.evidenceGate).toBe('PROVISIONAL');
+    expect(result.state).toBe('EVIDENCE_PENDING');
+    expect(result.eligible).toBe(false);
+  });
+});

--- a/src/atlas/algorithm/durable-revision-gap-omega.ts
+++ b/src/atlas/algorithm/durable-revision-gap-omega.ts
@@ -1,0 +1,211 @@
+export const DURABLE_REVISION_GAP_OMEGA_VERSION = '2026-09-06-v1.0.0' as const;
+
+export type RevisionOpportunityFamily =
+  | 'COMPOUNDER_ACCELERATION'
+  | 'NORMALIZATION'
+  | 'SCARCITY_PHYSICAL'
+  | 'TURNAROUND'
+  | 'SPECIAL_SITUATION';
+
+export type DurableRevisionGapInput = {
+  ticker: string;
+  family: RevisionOpportunityFamily;
+  evidenceTraceable: boolean;
+  evidenceIds: readonly string[];
+
+  // 0-100 evidence-normalized company economics.
+  survivabilityScore: number;
+  structuralRepeatabilityScore: number;
+  forwardFundamentalInflectionScore: number;
+  expectationGapScore: number;
+  inflectionDurabilityScore: number;
+  cashConversionScore: number;
+  revisionTorqueScore: number;
+  incrementalCapitalEfficiencyScore: number;
+
+  // 0-100 risk/saturation scores. Higher is worse.
+  valuationSaturationScore: number;
+  balanceFragilityScore: number;
+  integrationDistanceScore: number;
+  driverConcentrationScore: number;
+
+  // Optional external revealed-capital evidence. It never creates score points.
+  eliteCapitalEvidence?: {
+    source: string;
+    signalDateIso: string;
+    concentrationScore: number;
+    persistenceScore: number;
+    marginalDirection: 'NEW' | 'ACCELERATING' | 'ADDING' | 'HOLDING' | 'HARVESTING' | 'EXITING';
+    informationProximity: 'P0_PUBLIC_ONLY' | 'P1_CONCENTRATED_OWNER' | 'P2_NEGOTIATED_CAPITAL' | 'P3_GOVERNANCE' | 'P4_CONTROL_OR_OPERATING';
+    copyabilityScore: number;
+  };
+};
+
+export type DurableRevisionGapState =
+  | 'CORE_REVISION_OPPORTUNITY'
+  | 'POSITIVE_REVISION_GAP'
+  | 'WATCH'
+  | 'SATURATED'
+  | 'FAIL_SURVIVABILITY'
+  | 'EVIDENCE_PENDING';
+
+export type DurableRevisionGapResult = {
+  ticker: string;
+  family: RevisionOpportunityFamily;
+  evidenceGate: 'CONFIRMED' | 'PROVISIONAL' | 'BLOCKED';
+  eligible: boolean;
+  revisionCoreScore: number;
+  penaltyScore: number;
+  durableRevisionGapScore: number;
+  eliteCapitalDirectScoreContribution: 0;
+  revealedCapitalConfidence: 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH';
+  state: DurableRevisionGapState;
+  reasons: string[];
+  falsifiers: string[];
+};
+
+const clamp = (x: number): number => Math.max(0, Math.min(100, x));
+const round1 = (x: number): number => Math.round(x * 10) / 10;
+
+function requireScore(name: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new Error(`${name}_must_be_between_0_and_100`);
+  }
+}
+
+function validate(input: DurableRevisionGapInput): void {
+  const fields: Array<[string, number]> = [
+    ['survivability_score', input.survivabilityScore],
+    ['structural_repeatability_score', input.structuralRepeatabilityScore],
+    ['forward_fundamental_inflection_score', input.forwardFundamentalInflectionScore],
+    ['expectation_gap_score', input.expectationGapScore],
+    ['inflection_durability_score', input.inflectionDurabilityScore],
+    ['cash_conversion_score', input.cashConversionScore],
+    ['revision_torque_score', input.revisionTorqueScore],
+    ['incremental_capital_efficiency_score', input.incrementalCapitalEfficiencyScore],
+    ['valuation_saturation_score', input.valuationSaturationScore],
+    ['balance_fragility_score', input.balanceFragilityScore],
+    ['integration_distance_score', input.integrationDistanceScore],
+    ['driver_concentration_score', input.driverConcentrationScore],
+  ];
+  fields.forEach(([name, value]) => requireScore(name, value));
+
+  if (input.eliteCapitalEvidence) {
+    requireScore('elite_concentration_score', input.eliteCapitalEvidence.concentrationScore);
+    requireScore('elite_persistence_score', input.eliteCapitalEvidence.persistenceScore);
+    requireScore('elite_copyability_score', input.eliteCapitalEvidence.copyabilityScore);
+  }
+}
+
+function revealedCapitalConfidence(input: DurableRevisionGapInput): DurableRevisionGapResult['revealedCapitalConfidence'] {
+  const e = input.eliteCapitalEvidence;
+  if (!e) return 'NONE';
+  const base = (e.concentrationScore + e.persistenceScore + e.copyabilityScore) / 3;
+  const proximityBoost = e.informationProximity === 'P3_GOVERNANCE' || e.informationProximity === 'P4_CONTROL_OR_OPERATING' ? 10 : 0;
+  const directionBoost = e.marginalDirection === 'NEW' || e.marginalDirection === 'ACCELERATING' || e.marginalDirection === 'ADDING' ? 5 : 0;
+  const confidence = clamp(base + proximityBoost + directionBoost);
+  if (confidence >= 80) return 'HIGH';
+  if (confidence >= 55) return 'MEDIUM';
+  return 'LOW';
+}
+
+export function evaluateDurableRevisionGapOmega(input: DurableRevisionGapInput): DurableRevisionGapResult {
+  validate(input);
+
+  const evidenceGate: DurableRevisionGapResult['evidenceGate'] =
+    input.evidenceTraceable && input.evidenceIds.length >= 6
+      ? 'CONFIRMED'
+      : input.evidenceTraceable && input.evidenceIds.length > 0
+        ? 'PROVISIONAL'
+        : 'BLOCKED';
+
+  // Main-engine economics. No allocator/family-office variable appears here.
+  // Expectation gap + forward inflection lead; durability and cash conversion
+  // prevent transient growth or narrative-only acceleration from dominating.
+  const revisionCoreScore = round1(
+    input.forwardFundamentalInflectionScore * 0.24 +
+      input.expectationGapScore * 0.24 +
+      input.inflectionDurabilityScore * 0.16 +
+      input.cashConversionScore * 0.14 +
+      input.revisionTorqueScore * 0.10 +
+      input.structuralRepeatabilityScore * 0.06 +
+      input.incrementalCapitalEfficiencyScore * 0.06,
+  );
+
+  const penaltyScore = round1(
+    input.valuationSaturationScore * 0.12 +
+      input.balanceFragilityScore * 0.12 +
+      input.integrationDistanceScore * 0.08 +
+      input.driverConcentrationScore * 0.08,
+  );
+
+  let durableRevisionGapScore = round1(clamp(revisionCoreScore - penaltyScore));
+
+  // Survivability is a hard gate, not an averageable variable.
+  if (input.survivabilityScore < 40) durableRevisionGapScore = Math.min(durableRevisionGapScore, 39.9);
+  // Structural repeatability can be weaker for special situations, but a fully
+  // non-repeatable thesis cannot be promoted as a core revision opportunity.
+  if (input.structuralRepeatabilityScore < 35 && input.family !== 'SPECIAL_SITUATION') {
+    durableRevisionGapScore = Math.min(durableRevisionGapScore, 54.9);
+  }
+  if (input.valuationSaturationScore >= 85) durableRevisionGapScore = Math.min(durableRevisionGapScore, 59.9);
+  durableRevisionGapScore = round1(durableRevisionGapScore);
+
+  const eligible =
+    evidenceGate === 'CONFIRMED' &&
+    input.survivabilityScore >= 40 &&
+    (input.structuralRepeatabilityScore >= 35 || input.family === 'SPECIAL_SITUATION');
+
+  let state: DurableRevisionGapState;
+  const reasons: string[] = [];
+
+  if (evidenceGate !== 'CONFIRMED') {
+    state = 'EVIDENCE_PENDING';
+    reasons.push('Durable Revision Gap requires at least six traceable evidence records.');
+  } else if (input.survivabilityScore < 40) {
+    state = 'FAIL_SURVIVABILITY';
+    reasons.push('Survivability is a hard gate and cannot be rescued by revision upside.');
+  } else if (input.valuationSaturationScore >= 85) {
+    state = 'SATURATED';
+    reasons.push('Fundamental improvement may be real, but expectations/valuation already imply excessive success.');
+  } else if (durableRevisionGapScore >= 78) {
+    state = 'CORE_REVISION_OPPORTUNITY';
+    reasons.push('Durable forward economics are improving faster than implied expectations with cash-quality support.');
+  } else if (durableRevisionGapScore >= 65) {
+    state = 'POSITIVE_REVISION_GAP';
+    reasons.push('A positive durable revision gap exists but does not clear the strongest core threshold.');
+  } else {
+    state = 'WATCH';
+    reasons.push('Evidence is valid but the remaining revision gap is insufficient after saturation and risk penalties.');
+  }
+
+  if (input.eliteCapitalEvidence) {
+    reasons.push('Revealed-capital evidence is corroborative only and contributes exactly zero direct score points.');
+  }
+
+  const falsifiers = [
+    'forward_eps_or_fcf_trajectory_fails_to_outgrow_consensus_trajectory',
+    'margin_or_cash_conversion_reverses_before_the_revision_gap_closes',
+    'inflection_is_one_off_project_or_peak_cycle_instead_of_durable_economics',
+    'valuation_reprices_faster_than_fundamental_revisions',
+    'balance_sheet_or_refinancing_risk_breaks_survivability',
+    'integration_distance_or_dilution_consumes_the_expected_owner_economics',
+    'driver_concentration_turns_one_theme_into_portfolio_level_tail_risk',
+    'revealed_capital_signal_is_stale_or_reversed_and_had_no_independent_fundamental_confirmation',
+  ];
+
+  return {
+    ticker: input.ticker,
+    family: input.family,
+    evidenceGate,
+    eligible,
+    revisionCoreScore,
+    penaltyScore,
+    durableRevisionGapScore,
+    eliteCapitalDirectScoreContribution: 0,
+    revealedCapitalConfidence: revealedCapitalConfidence(input),
+    state,
+    reasons,
+    falsifiers,
+  };
+}


### PR DESCRIPTION
Promotes the economic core extracted from ELITE CAPITAL SIGNAL / Progeny reverse engineering into the ATLAS main selection path.

Changes:
- adds `DURABLE_REVISION_GAP_OMEGA_V1` as a core selection input
- adds fail-closed tests for survivability, saturation, evidence, and zero elite-capital score authority
- updates the kernel contract registry to include Durable Revision Gap in `mainSelectionSequence`
- keeps `REVEALED_CAPITAL_INTELLIGENCE_OMEGA_V1` corroborative only with direct score weight = 0
- adds canonical governance documentation

Key law: allocator/family-office ownership can raise research confidence, never company score or BUY authority.