### PR TITLE
Consolidate Earnings Learning Ω v2.2 and remove duplicate scoring

### DIFF
--- a/.github/workflows/earnings-learning-v2-2-ci.yml
+++ b/.github/workflows/earnings-learning-v2-2-ci.yml
@@ -1,0 +1,25 @@
+name: Earnings Learning Omega v2.2 CI
+
+on:
+  pull_request:
+    paths:
+      - 'runtime/agentic_omega/earnings_learning_v2_2.py'
+      - 'runtime/agentic_omega/test_earnings_learning_v2_2.py'
+      - 'CURRENT_CANON/2026-09-06_EARNINGS_LEARNING_OMEGA_V2_2.md'
+      - '.github/workflows/earnings-learning-v2-2-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'runtime/agentic_omega/earnings_learning_v2_2.py'
+      - 'runtime/agentic_omega/test_earnings_learning_v2_2.py'
+
+jobs:
+  focused-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pytest
+      - run: pytest -q runtime/agentic_omega/test_earnings_learning_v2_2.py

--- a/CURRENT_CANON/2026-09-06_EARNINGS_LEARNING_OMEGA_V2_2.md
+++ b/CURRENT_CANON/2026-09-06_EARNINGS_LEARNING_OMEGA_V2_2.md
@@ -1,0 +1,36 @@
+# ATLAS Ω — Earnings Learning Ω v2.2
+
+**State:** CANDIDATE · DIAGNOSTIC_ONLY  
+**Issue:** #93
+
+## Purpose
+One event-learning surface replaces duplicate scoring across Earnings Flow Confirmation, Expectations Gap / Market Fragility and overlapping event-reaction logic.
+
+## Four independent layers
+1. `PRE_EVENT_EXPECTATION_BURDEN`
+2. `FUNDAMENTAL_SURPRISE`
+3. `POST_EVENT_PRICE_TRUTH`
+4. `SECOND_ORDER_READ_THROUGH`
+
+The implementation exposes the layers but deliberately provides **no official aggregate score**. This prevents the same earnings observation from being counted once as a fundamental beat and again as an allegedly independent event/flow signal.
+
+## Price contract
+- anchor: last verified trade immediately before release;
+- retain AH, D1 open/close, D3, D5, D20;
+- benchmark subtraction occurs once per scored horizon;
+- AH/open are path diagnostics, not extra additive return observations;
+- stale/contradictory tape fails closed.
+
+## Fundamental contract
+EPS is secondary. If EPS basis/quality is not verified it cannot inflate the fundamental layer. Revenue, guidance, margin and FCF/share carry the core economic information.
+
+## Legacy status
+`earnings_flow_confirmation.py` and the earnings-related portion of `market_fragility.py` remain callable for compatibility, but are `SUPERSEDED_FOR_EARNINGS_SCORING`. Their non-earnings responsibilities remain intact. A caller must not add their earnings-derived values to Earnings Learning v2.2.
+
+## Authority
+- learning / diagnosis: YES;
+- BUY/SELL: NO;
+- portfolio mutation: NO;
+- broker execution: NO.
+
+Promotion from CANDIDATE requires focused CI green. Until then the existing runtime remains authoritative.

--- a/runtime/agentic_omega/earnings_learning_v2_2.py
+++ b/runtime/agentic_omega/earnings_learning_v2_2.py
@@ -1,0 +1,187 @@
+"""ATLAS Ω — Earnings Learning Ω v2.2.
+
+One diagnostic surface for event learning. It deliberately does not emit a BUY/SELL,
+portfolio weight, or broker instruction.
+
+Epistemic layers are disjoint:
+- PRE_EVENT_EXPECTATION_BURDEN: what the market required before the release.
+- FUNDAMENTAL_SURPRISE: what the business actually reported vs that bar.
+- POST_EVENT_PRICE_TRUTH: what price did after the release, benchmark-relative.
+- SECOND_ORDER_READ_THROUGH: later peer/estimate/chain transmission.
+
+Legacy Earnings Flow Confirmation and Expectations Gap remain callable for backward
+compatibility, but duplicated event evidence must not be added to this result again.
+"""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class LearningState(str, Enum):
+    INCOMPLETE = "INCOMPLETE"
+    CONTRADICTORY = "CONTRADICTORY"
+    CONFIRMED = "CONFIRMED"
+    SATURATED = "SATURATED"
+    REBOUND = "REBOUND"
+    REVERSAL = "REVERSAL"
+    MIXED = "MIXED"
+
+
+@dataclass(frozen=True)
+class PreEventExpectationBurden:
+    pre_run: float
+    valuation_premium: float
+    revision_momentum: float
+    narrative_heat: float
+    deceleration_risk: float
+    peer_bar: float
+    implied_move: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class FundamentalSurprise:
+    revenue: float
+    guidance: float
+    margin: float
+    fcf_per_share: float
+    eps: Optional[float] = None
+    eps_quality_ok: bool = False
+
+
+@dataclass(frozen=True)
+class PostEventPriceTruth:
+    # Returns are percentages from the last verified pre-release trade.
+    ah: Optional[float]
+    d1_open: Optional[float]
+    d1_close: Optional[float]
+    d3: Optional[float]
+    d5: Optional[float]
+    d20: Optional[float]
+    benchmark_d1_close: Optional[float] = None
+    benchmark_d3: Optional[float] = None
+    benchmark_d5: Optional[float] = None
+    benchmark_d20: Optional[float] = None
+    pre_release_anchor_verified: bool = True
+    tape_stale: bool = False
+    tape_contradictory: bool = False
+
+
+@dataclass(frozen=True)
+class SecondOrderReadThrough:
+    estimate_revision: Optional[float] = None
+    peer_transmission: Optional[float] = None
+    chain_breadth: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class EarningsLearningInput:
+    expectations: PreEventExpectationBurden
+    fundamentals: FundamentalSurprise
+    price: PostEventPriceTruth
+    read_through: SecondOrderReadThrough = SecondOrderReadThrough()
+    calibration_sample_n: int = 0
+    minimum_calibration_n: int = 8
+
+
+@dataclass(frozen=True)
+class EarningsLearningResult:
+    state: LearningState
+    expectation_burden: float
+    fundamental_surprise: float
+    price_truth: Optional[float]
+    read_through: Optional[float]
+    missing_fields: tuple[str, ...]
+    diagnostic_only: bool = True
+    scoring_authority: str = "DIAGNOSTIC_ONLY"
+
+
+def _mean(values):
+    xs = [float(v) for v in values if v is not None]
+    return None if not xs else sum(xs) / len(xs)
+
+
+def _expectation_burden(x: PreEventExpectationBurden) -> float:
+    values = [x.pre_run, x.valuation_premium, x.revision_momentum,
+              x.narrative_heat, x.deceleration_risk, x.peer_bar]
+    if x.implied_move is not None:
+        values.append(x.implied_move)
+    return float(_mean(values))
+
+
+def _fundamental_surprise(x: FundamentalSurprise) -> float:
+    # EPS is deliberately low-weight and is ignored when its basis/quality is not sound.
+    core = [x.revenue, x.guidance, x.margin, x.fcf_per_share]
+    core_mean = float(_mean(core))
+    if x.eps is None or not x.eps_quality_ok:
+        return core_mean
+    return 0.9 * core_mean + 0.1 * float(x.eps)
+
+
+def _price_truth(x: PostEventPriceTruth) -> Optional[float]:
+    # Each horizon is benchmark-adjusted once. AH/open are retained for path/reversal
+    # classification, not added again to the multi-day return score.
+    adjusted = []
+    for observed, benchmark in (
+        (x.d1_close, x.benchmark_d1_close),
+        (x.d3, x.benchmark_d3),
+        (x.d5, x.benchmark_d5),
+        (x.d20, x.benchmark_d20),
+    ):
+        if observed is not None:
+            adjusted.append(float(observed) - float(benchmark or 0.0))
+    return _mean(adjusted)
+
+
+def _read_through(x: SecondOrderReadThrough) -> Optional[float]:
+    return _mean([x.estimate_revision, x.peer_transmission, x.chain_breadth])
+
+
+def _missing(x: EarningsLearningInput) -> tuple[str, ...]:
+    missing = []
+    if x.price.d1_close is None:
+        missing.append("price.d1_close")
+    if not x.price.pre_release_anchor_verified:
+        missing.append("price.pre_release_anchor_verified")
+    if x.calibration_sample_n < x.minimum_calibration_n:
+        missing.append("calibration_sample")
+    return tuple(missing)
+
+
+def evaluate_earnings_learning(x: EarningsLearningInput) -> EarningsLearningResult:
+    burden = _expectation_burden(x.expectations)
+    fundamental = _fundamental_surprise(x.fundamentals)
+    price = _price_truth(x.price)
+    read = _read_through(x.read_through)
+    missing = _missing(x)
+
+    if x.price.tape_stale or x.price.tape_contradictory:
+        return EarningsLearningResult(LearningState.CONTRADICTORY, burden, fundamental,
+                                      None, read, missing)
+    if missing:
+        return EarningsLearningResult(LearningState.INCOMPLETE, burden, fundamental,
+                                      price, read, missing)
+
+    # Path classifications are deterministic diagnostics, not a tradable score.
+    if x.price.ah is not None and x.price.d1_close is not None and x.price.ah * x.price.d1_close < 0:
+        state = LearningState.REVERSAL
+    elif x.price.d1_open is not None and x.price.d1_close is not None and x.price.d1_open < 0 < x.price.d1_close:
+        state = LearningState.REBOUND
+    elif fundamental > 0 and price is not None and price > 0 and burden < fundamental:
+        state = LearningState.CONFIRMED
+    elif fundamental > 0 and price is not None and price <= 0 and burden >= fundamental:
+        state = LearningState.SATURATED
+    else:
+        state = LearningState.MIXED
+
+    return EarningsLearningResult(state, burden, fundamental, price, read, missing)
+
+
+def combine_independent_layers(result: EarningsLearningResult) -> tuple[Optional[float], ...]:
+    """Expose independent components; intentionally no aggregate score.
+
+    This is the anti-double-counting contract: callers receive each epistemic layer once
+    and cannot obtain an official sum by passing the same observation through legacy EFC
+    or Expectations Gap as a second 'signal'.
+    """
+    return (result.expectation_burden, result.fundamental_surprise,
+            result.price_truth, result.read_through)

--- a/runtime/agentic_omega/test_earnings_learning_v2_2.py
+++ b/runtime/agentic_omega/test_earnings_learning_v2_2.py
@@ -1,0 +1,67 @@
+from runtime.agentic_omega.earnings_learning_v2_2 import (
+    EarningsLearningInput, FundamentalSurprise, LearningState,
+    PostEventPriceTruth, PreEventExpectationBurden, SecondOrderReadThrough,
+    combine_independent_layers, evaluate_earnings_learning,
+)
+
+
+def base(**price_overrides):
+    p = dict(ah=2.0, d1_open=2.0, d1_close=3.0, d3=4.0, d5=5.0, d20=6.0,
+             benchmark_d1_close=1.0, benchmark_d3=1.0, benchmark_d5=1.0,
+             benchmark_d20=1.0)
+    p.update(price_overrides)
+    return EarningsLearningInput(
+        expectations=PreEventExpectationBurden(20, 20, 20, 20, 20, 20, 20),
+        fundamentals=FundamentalSurprise(40, 40, 40, 40, eps=100, eps_quality_ok=False),
+        price=PostEventPriceTruth(**p),
+        read_through=SecondOrderReadThrough(10, 10, 10),
+        calibration_sample_n=20,
+    )
+
+
+def test_confirmation_and_eps_quality_gate():
+    r = evaluate_earnings_learning(base())
+    assert r.state == LearningState.CONFIRMED
+    assert r.fundamental_surprise == 40.0  # bad-basis EPS cannot inflate the layer
+    assert r.price_truth == 3.5  # each horizon benchmark-adjusted exactly once
+
+
+def test_saturation():
+    x = base(d1_close=-2, d3=-2, d5=-2, d20=-2, ah=-1, d1_open=-1)
+    x = EarningsLearningInput(
+        expectations=PreEventExpectationBurden(80,80,80,80,80,80,80),
+        fundamentals=x.fundamentals, price=x.price,
+        read_through=x.read_through, calibration_sample_n=20)
+    assert evaluate_earnings_learning(x).state == LearningState.SATURATED
+
+
+def test_pre_event_style_selloff_then_post_event_rebound_path():
+    r = evaluate_earnings_learning(base(ah=None, d1_open=-4, d1_close=2))
+    assert r.state == LearningState.REBOUND
+
+
+def test_after_hours_reversal():
+    r = evaluate_earnings_learning(base(ah=5, d1_close=-1))
+    assert r.state == LearningState.REVERSAL
+
+
+def test_missing_calibration_fails_closed():
+    x = base()
+    x = EarningsLearningInput(x.expectations, x.fundamentals, x.price,
+                              x.read_through, calibration_sample_n=3)
+    r = evaluate_earnings_learning(x)
+    assert r.state == LearningState.INCOMPLETE
+    assert "calibration_sample" in r.missing_fields
+
+
+def test_stale_or_contradictory_tape_fails_closed():
+    assert evaluate_earnings_learning(base(tape_stale=True)).state == LearningState.CONTRADICTORY
+    assert evaluate_earnings_learning(base(tape_contradictory=True)).state == LearningState.CONTRADICTORY
+
+
+def test_duplicate_evidence_has_no_official_aggregate_score():
+    r = evaluate_earnings_learning(base())
+    layers = combine_independent_layers(r)
+    assert len(layers) == 4
+    assert r.scoring_authority == "DIAGNOSTIC_ONLY"
+    assert not hasattr(r, "aggregate_score")


### PR DESCRIPTION
Closes the implementation debt in #93 without adding investment authority. Introduces one diagnostic event-learning surface with four disjoint epistemic layers, fail-closed tape/calibration behavior, EPS quality gate, single benchmark adjustment, deterministic confirmation/saturation/rebound/reversal states, and no official aggregate score. Legacy EFC/Expectations Gap remain compatibility surfaces but are superseded for earnings scoring. Merge only after focused CI is green.