### PR TITLE
ATLAS AI Ω — Live Continuity Binding v1

### DIFF
--- a/.github/workflows/atlas-ai-continuity-mvp-ci.yml
+++ b/.github/workflows/atlas-ai-continuity-mvp-ci.yml
@@ -21,9 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Run ATLAS AI continuity, live-binding and epistemic-safety tests
+      - name: Run ATLAS AI continuity, live-binding, runtime and epistemic-safety tests
         run: >-
           npx --yes vitest@3.2.4 run --globals
           src/atlas/personal-cognitive-os/engine.test.ts
           src/atlas/personal-cognitive-os/continuity-registry.test.ts
           src/atlas/personal-cognitive-os/live-continuity-binding.test.ts
+          src/atlas/personal-cognitive-os/continuity-runtime.test.ts

--- a/.github/workflows/atlas-ai-continuity-mvp-ci.yml
+++ b/.github/workflows/atlas-ai-continuity-mvp-ci.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - atlas-ai-memory-foundation-v1
+      - atlas-ai-live-continuity-binding-v1
     paths:
       - 'src/atlas/personal-cognitive-os/**'
       - '.github/workflows/atlas-ai-continuity-mvp-ci.yml'
@@ -20,8 +21,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Run ATLAS AI continuity and epistemic-safety tests
+      - name: Run ATLAS AI continuity, live-binding and epistemic-safety tests
         run: >-
           npx --yes vitest@3.2.4 run --globals
           src/atlas/personal-cognitive-os/engine.test.ts
           src/atlas/personal-cognitive-os/continuity-registry.test.ts
+          src/atlas/personal-cognitive-os/live-continuity-binding.test.ts

--- a/.github/workflows/atlas-ai-continuity-mvp-ci.yml
+++ b/.github/workflows/atlas-ai-continuity-mvp-ci.yml
@@ -28,3 +28,29 @@ jobs:
           src/atlas/personal-cognitive-os/continuity-registry.test.ts
           src/atlas/personal-cognitive-os/live-continuity-binding.test.ts
           src/atlas/personal-cognitive-os/continuity-runtime.test.ts
+
+  real-notion-continuity:
+    # The workflow file already exists on main, so a same-repository PR can run
+    # this pre-merge gate against the PR code. This avoids the workflow_dispatch
+    # bootstrap deadlock of a brand-new workflow that is not yet on main.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      ATLAS_CONTINUITY_DATA_SOURCE_ID: 20a48cee-6fe0-46ce-b750-5ac78177fcb6
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Require authorized Notion integration secret
+        shell: bash
+        run: |
+          if [ -z "$NOTION_API_KEY" ]; then
+            echo "NOTION_API_KEY repository secret is required for the pre-merge real continuity gate."
+            exit 1
+          fi
+      - name: Run locked 10-case test through real Notion-backed runtime
+        run: >-
+          npx --yes vitest@3.2.4 run --globals
+          src/atlas/personal-cognitive-os/continuity-runtime.notion.integration.test.ts

--- a/.github/workflows/atlas-ai-continuity-notion-smoke.yml
+++ b/.github/workflows/atlas-ai-continuity-notion-smoke.yml
@@ -1,0 +1,27 @@
+name: ATLAS AI Real Notion Continuity Smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  real-notion-continuity:
+    runs-on: ubuntu-latest
+    env:
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      ATLAS_CONTINUITY_DATA_SOURCE_ID: 20a48cee-6fe0-46ce-b750-5ac78177fcb6
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Require Notion integration secret
+        shell: bash
+        run: |
+          if [ -z "$NOTION_API_KEY" ]; then
+            echo "NOTION_API_KEY repository secret is required for the real continuity gate."
+            exit 1
+          fi
+      - name: Run locked 10-case test through real Notion-backed runtime
+        run: >-
+          npx --yes vitest@3.2.4 run --globals
+          src/atlas/personal-cognitive-os/continuity-runtime.notion.integration.test.ts

--- a/src/atlas/personal-cognitive-os/continuity-registry.ts
+++ b/src/atlas/personal-cognitive-os/continuity-registry.ts
@@ -5,6 +5,7 @@ export type ContinuityRegistryState = 'ACTIVE' | 'WAITING' | 'BLOCKED' | 'CLOSED
 export type ContinuityRegistryRecord = {
   projectId: string;
   name: string;
+  aliases?: string[];
   state: ContinuityRegistryState;
   active: boolean;
   established: string[];
@@ -48,6 +49,7 @@ function lexicalScore(query: string, record: ContinuityRegistryRecord): number {
   const corpus = new Set(tokenize([
     record.projectId,
     record.name,
+    ...(record.aliases ?? []),
     record.openLoop ?? '',
     record.nextBestAction ?? '',
     ...record.established,
@@ -99,7 +101,9 @@ export function retrieveContinuityFromRegistry(
   if (explicitHint) {
     const normalizedHint = normalize(explicitHint);
     const exact = available.filter((record) =>
-      normalize(record.projectId) === normalizedHint || normalize(record.name) === normalizedHint,
+      normalize(record.projectId) === normalizedHint ||
+      normalize(record.name) === normalizedHint ||
+      (record.aliases ?? []).some((alias) => normalize(alias) === normalizedHint),
     );
     if (exact.length === 1) {
       return {
@@ -116,7 +120,9 @@ export function retrieveContinuityFromRegistry(
     if (input.activeProjectHint) {
       const normalizedHint = normalize(input.activeProjectHint);
       const active = available.filter((record) =>
-        normalize(record.projectId) === normalizedHint || normalize(record.name) === normalizedHint,
+        normalize(record.projectId) === normalizedHint ||
+        normalize(record.name) === normalizedHint ||
+        (record.aliases ?? []).some((alias) => normalize(alias) === normalizedHint),
       );
       if (active.length === 1) {
         return {

--- a/src/atlas/personal-cognitive-os/continuity-runtime.notion.integration.test.ts
+++ b/src/atlas/personal-cognitive-os/continuity-runtime.notion.integration.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { handleContinuityRequest } from './continuity-runtime';
+
+const token = process.env.NOTION_API_KEY ?? '';
+const dataSourceId = process.env.ATLAS_CONTINUITY_DATA_SOURCE_ID ?? '';
+
+if (!token || !dataSourceId) {
+  throw new Error('real_continuity_integration_requires_NOTION_API_KEY_and_ATLAS_CONTINUITY_DATA_SOURCE_ID');
+}
+
+const cases = [
+  ['DINASTIA_ARTSRUNI', 'Reconstruir Casa Artsruni', 'Toumanoff no basta: el puente Artsruni a Mesopotamia sigue sin prueba independiente.'],
+  ['ELITE_CAPITAL_SIGNAL', 'Actualizar snapshots Exor verificados', 'Lingotto: skill/alpha post-filing sigue sin demostrarse; falta ejecutar el backtest completo.'],
+  ['STRATEGY_FACTORY', 'Strategy Factory', 'La factoría no se amplía: falta correr el brazo nulo completo.'],
+  ['EUROPE_RECOGNITION_BASE', 'Comparar patrones europeos', 'Hay sesgo por seleccionar inquiry; falta cohorte censurada y survival analysis.'],
+  ['ATLAS_AI', 'Atlas AI', 'La continuidad live falla por contaminación entre proyectos; el registry debe leerse antes de Sigue.'],
+  ['CEUTA_RABAT', 'Auditar Ceuta Ω', 'Separar detonantes documentados de coordinación inferida y buscar falsificadores.'],
+  ['ATLAS_PORTFOLIO_37', 'Cartera de 37', 'El corte 37 debe observarse contra benchmarks sin reinterpretación post hoc.'],
+  ['HOBBIECODE_STRATEGYQUANT', 'HobbieCode StrategyQuant', 'Reconstruir reglas del robot Nasdaq y comprobar robustez out-of-sample.'],
+  ['ACCIDENT_MEDICO_LEGAL', 'Análisis penal médico', 'La lesión de mano necesita fecha y cadena causal documental antes de integrarla.'],
+  ['PROPICKS_REVERSE_ENGINEERING', 'ProPicks ingeniería inversa', 'No atribuir pesos al algoritmo sin features y controles negativos definidos ex ante.'],
+] as const;
+
+describe('ATLAS AI Ω — REAL Notion-backed continuity runtime', () => {
+  it.each(cases)('recovers %s from the live Notion registry without epistemic promotion', async (expectedProject, title, context) => {
+    const result = await handleContinuityRequest({
+      utterance: 'Sigue',
+      conversationTitle: title,
+      recentTurns: [
+        { role: 'user', content: context },
+        { role: 'assistant', content: `Último estado local: ${context}` },
+      ],
+    }, {
+      notionToken: token,
+      notionDataSourceId: dataSourceId,
+    });
+
+    expect(result.runtime).toBe('ATLAS_CONTINUITY_RUNTIME_V1');
+    expect(result.registryRead).toBe(true);
+    expect(result.status).toBe('RESOLVED');
+    expect(result.matchedProjectId).toBe(expectedProject);
+    expect(result.state?.activeProject).toBe(expectedProject);
+    expect(result.state?.established.length).toBeGreaterThan(0);
+    expect(result.state?.hypotheses.length).toBeGreaterThan(0);
+    expect(result.state?.openLoops.length).toBeGreaterThan(0);
+    expect(result.state?.nextBestAction).toBeTruthy();
+
+    for (const hypothesis of result.state?.hypotheses ?? []) {
+      expect(result.state?.established).not.toContain(hypothesis);
+    }
+  });
+});

--- a/src/atlas/personal-cognitive-os/continuity-runtime.test.ts
+++ b/src/atlas/personal-cognitive-os/continuity-runtime.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import type { ContinuityRegistryRecord } from './continuity-registry';
+import { handleContinuityRequest } from './continuity-runtime';
+import type { ContinuityRegistryProvider } from './live-continuity-binding';
+
+function record(
+  projectId: string,
+  name: string,
+  aliases: string[],
+  established: string,
+  hypothesis: string,
+  openLoop: string,
+  nextBestAction: string,
+): ContinuityRegistryRecord {
+  return {
+    projectId,
+    name,
+    aliases,
+    state: projectId === 'ATLAS_AI' || projectId === 'ACCIDENT_MEDICO_LEGAL' ? 'BLOCKED' : 'ACTIVE',
+    active: true,
+    established: [established],
+    hypotheses: [hypothesis],
+    openLoop,
+    nextBestAction,
+    evidenceStandard: 'LOCKED_TEST',
+    provenance: [`runtime-test:${projectId}`],
+    updatedAt: '2026-09-06',
+  };
+}
+
+const registry: ContinuityRegistryRecord[] = [
+  record('DINASTIA_ARTSRUNI', 'DINASTÍA Ω / Artsruni', ['artsruni', 'reconstruir casa artsruni'], 'Homonym Firewall and documentary-hiatus discipline remain valid.', 'Artsruni → Mesopotamia remains unproven.', 'Establish strongest defensible Artsruni line.', 'Test the strongest remaining bridge against primary or academic evidence.'),
+  record('ELITE_CAPITAL_SIGNAL', 'Elite Capital Signal Ω', ['lingotto', 'backtest post-filing'], 'Investor prestige does not demonstrate predictive skill.', 'Institutional signal produces post-filing alpha.', 'Run complete post-filing backtest.', 'Execute the complete post-filing backtest under the predefined rule.'),
+  record('STRATEGY_FACTORY', 'Strategy Factory Ω', ['strategy factory', 'brazo nulo'], 'Architecture exists; complete robustness validation is not established.', 'The pipeline discovers genuine edge rather than noise.', 'Run complete null arm.', 'Execute the null arm before expanding architecture.'),
+  record('EUROPE_RECOGNITION_BASE', 'European institutional-recognition base', ['base europea', 'patrones europeos', 'cohorte censurada'], 'Inquiry-only selection conditions on the dependent variable.', 'A particular sensitivity causally explains observed lag.', 'Design no-T4/censored arm and survival analysis.', 'Construct the censored cohort and survival-analysis design.'),
+  record('ATLAS_AI', 'ATLAS AI Ω', ['atlas ai', 'continuity mvp'], 'GitHub + Notion are persistent layers; Memory != Digital Twin.', 'A live runtime binding may solve cross-project contamination.', 'Establish real live runtime binding.', 'Read Notion before resolving Sigue and rerun the locked test.'),
+  record('CEUTA_RABAT', 'Ceuta/Rabat research', ['ceuta', 'rabat', 'auditoría ceuta'], 'Documented triggers must be separated from demonstrated coordination.', 'A central actor coordinated inducement beyond available evidence.', 'Separate documented causes from inferred coordination.', 'Build the claim/evidence/falsifier matrix.'),
+  record('ATLAS_PORTFOLIO_37', 'ATLAS Ω portfolio 37', ['cartera 37', 'atlas 37'], 'Experimental 37-name cut exists; scores do not replace market validation.', 'The selection will outperform benchmarks.', 'Observe predefined benchmark-relative performance.', 'Continue observation without post-hoc reinterpretation.'),
+  record('HOBBIECODE_STRATEGYQUANT', 'HobbieCode / StrategyQuant', ['hobbiecode', 'strategyquant', 'robot nasdaq'], 'The identified approach uses strategy generation and robustness testing.', 'The specific robot has genuine edge.', 'Reconstruct/test process and rules.', 'Run out-of-sample robustness checks.'),
+  record('ACCIDENT_MEDICO_LEGAL', 'Accident / medical-legal', ['accidente', 'lesión mano', 'análisis penal médico'], 'Hand-injury origin/date and causal link remain ambiguous.', 'The hand injury is attributable to the accident.', 'Establish documentary causal chain.', 'Locate the earliest documentary evidence of timing and causation.'),
+  record('PROPICKS_REVERSE_ENGINEERING', 'ProPicks reverse engineering', ['propicks', 'algoritmo propicks'], 'Own scores are not the proprietary algorithm signal.', 'Exact internal weights/rules are known.', 'Design prospective ex-ante tests.', 'Predefine features and negative controls.'),
+];
+
+class Provider implements ContinuityRegistryProvider {
+  reads = 0;
+  async listActive() {
+    this.reads += 1;
+    return registry;
+  }
+}
+
+const lockedCases = [
+  ['DINASTIA_ARTSRUNI', 'Reconstruir Casa Artsruni', 'Toumanoff no basta: el puente Artsruni a Mesopotamia sigue sin prueba independiente.'],
+  ['ELITE_CAPITAL_SIGNAL', 'Actualizar snapshots Exor verificados', 'Lingotto: skill/alpha post-filing sigue sin demostrarse; falta ejecutar el backtest completo.'],
+  ['STRATEGY_FACTORY', 'Strategy Factory', 'La factoría no se amplía: falta correr el brazo nulo completo.'],
+  ['EUROPE_RECOGNITION_BASE', 'Comparar patrones europeos', 'Hay sesgo por seleccionar inquiry; falta cohorte censurada y survival analysis.'],
+  ['ATLAS_AI', 'Atlas AI', 'La continuidad live falla por contaminación entre proyectos; el registry debe leerse antes de Sigue.'],
+  ['CEUTA_RABAT', 'Auditar Ceuta Ω', 'Separar detonantes documentados de coordinación inferida y buscar falsificadores.'],
+  ['ATLAS_PORTFOLIO_37', 'Cartera de 37', 'El corte 37 debe observarse contra benchmarks sin reinterpretación post hoc.'],
+  ['HOBBIECODE_STRATEGYQUANT', 'HobbieCode StrategyQuant', 'Reconstruir reglas del robot Nasdaq y comprobar robustez out-of-sample.'],
+  ['ACCIDENT_MEDICO_LEGAL', 'Análisis penal médico', 'La lesión de mano necesita fecha y cadena causal documental antes de integrarla.'],
+  ['PROPICKS_REVERSE_ENGINEERING', 'ProPicks ingeniería inversa', 'No atribuir pesos al algoritmo sin features y controles negativos definidos ex ante.'],
+] as const;
+
+describe('ATLAS AI Ω — minimal continuity runtime acceptance', () => {
+  it.each(lockedCases)('routes %s through runtime and preserves epistemic separation', async (projectId, title, localContext) => {
+    const provider = new Provider();
+    const response = await handleContinuityRequest({
+      utterance: 'Sigue',
+      conversationTitle: title,
+      recentTurns: [
+        { role: 'user', content: localContext },
+        { role: 'assistant', content: `Último estado local: ${localContext}` },
+      ],
+    }, { provider });
+
+    expect(provider.reads).toBe(1);
+    expect(response.runtime).toBe('ATLAS_CONTINUITY_RUNTIME_V1');
+    expect(response.status).toBe('RESOLVED');
+    expect(response.matchedProjectId).toBe(projectId);
+    expect(response.state?.activeProject).toBe(projectId);
+    expect(response.state?.established.length).toBeGreaterThan(0);
+    expect(response.state?.hypotheses.length).toBeGreaterThan(0);
+    expect(response.state?.openLoops.length).toBeGreaterThan(0);
+    expect(response.state?.nextBestAction).toBeTruthy();
+
+    for (const hypothesis of response.state?.hypotheses ?? []) {
+      expect(response.state?.established).not.toContain(hypothesis);
+    }
+  });
+
+  it('does not construct a Notion provider without runtime credentials', async () => {
+    await expect(handleContinuityRequest({
+      utterance: 'Sigue',
+      conversationTitle: 'Atlas AI',
+      recentTurns: [{ role: 'user', content: 'Seguimos Atlas AI.' }],
+    }, { notionToken: '', notionDataSourceId: '' })).rejects.toThrow(/missing_NOTION_API_KEY/);
+  });
+});

--- a/src/atlas/personal-cognitive-os/continuity-runtime.ts
+++ b/src/atlas/personal-cognitive-os/continuity-runtime.ts
@@ -1,0 +1,54 @@
+import {
+  NotionHttpContinuityRegistryProvider,
+  resolveLiveContinuity,
+  type ContinuityRegistryProvider,
+  type LiveContinuityBindingInput,
+  type LiveContinuityBindingResult,
+} from './live-continuity-binding';
+
+export type ContinuityRuntimeRequest = LiveContinuityBindingInput;
+
+export type ContinuityRuntimeResponse = LiveContinuityBindingResult & {
+  runtime: 'ATLAS_CONTINUITY_RUNTIME_V1';
+};
+
+export type ContinuityRuntimeOptions = {
+  provider?: ContinuityRegistryProvider;
+  notionToken?: string;
+  notionDataSourceId?: string;
+  fetchImpl?: typeof fetch;
+};
+
+function providerFromOptions(options: ContinuityRuntimeOptions): ContinuityRegistryProvider {
+  if (options.provider) return options.provider;
+
+  const token = options.notionToken ?? process.env.NOTION_API_KEY ?? '';
+  const dataSourceId = options.notionDataSourceId ?? process.env.ATLAS_CONTINUITY_DATA_SOURCE_ID ?? '';
+
+  if (!token.trim()) throw new Error('atlas_continuity_runtime_missing_NOTION_API_KEY');
+  if (!dataSourceId.trim()) throw new Error('atlas_continuity_runtime_missing_ATLAS_CONTINUITY_DATA_SOURCE_ID');
+
+  return new NotionHttpContinuityRegistryProvider({
+    token,
+    dataSourceId,
+    fetchImpl: options.fetchImpl,
+  });
+}
+
+/**
+ * Smallest executable boundary for Atlas continuity.
+ *
+ * The caller supplies only LOCAL conversation evidence. The runtime itself
+ * reads the persistent registry before deciding what `Sigue` means.
+ */
+export async function handleContinuityRequest(
+  request: ContinuityRuntimeRequest,
+  options: ContinuityRuntimeOptions = {},
+): Promise<ContinuityRuntimeResponse> {
+  const provider = providerFromOptions(options);
+  const result = await resolveLiveContinuity(request, provider);
+  return {
+    ...result,
+    runtime: 'ATLAS_CONTINUITY_RUNTIME_V1',
+  };
+}

--- a/src/atlas/personal-cognitive-os/live-continuity-binding.test.ts
+++ b/src/atlas/personal-cognitive-os/live-continuity-binding.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ContinuityRegistryRecord } from './continuity-registry';
+import {
+  NotionHttpContinuityRegistryProvider,
+  resolveLiveContinuity,
+  type ContinuityRegistryProvider,
+  type LocalConversationTurn,
+} from './live-continuity-binding';
+
+function r(
+  projectId: string,
+  name: string,
+  established: string,
+  hypothesis: string,
+  openLoop: string,
+  nextBestAction: string,
+): ContinuityRegistryRecord {
+  return {
+    projectId,
+    name,
+    state: 'ACTIVE',
+    active: true,
+    established: [established],
+    hypotheses: [hypothesis],
+    openLoop,
+    nextBestAction,
+    evidenceStandard: 'TEST',
+    provenance: [`registry:${projectId}`],
+    updatedAt: '2026-09-06',
+  };
+}
+
+const registry: ContinuityRegistryRecord[] = [
+  r('DINASTIA_ARTSRUNI', 'DINASTÍA Ω / Artsruni', 'Homonym Firewall remains valid.', 'Artsruni to Mesopotamia remains unproven.', 'Establish strongest defensible Artsruni line.', 'Test the remaining Artsruni bridge against primary or academic evidence.'),
+  r('ELITE_CAPITAL_SIGNAL', 'Elite Capital Signal Ω', 'Prestige does not prove predictive skill.', 'Institutional signal produces post-filing alpha.', 'Run complete post-filing backtest.', 'Execute the complete post-filing backtest under the predefined rule.'),
+  r('STRATEGY_FACTORY', 'Strategy Factory Ω', 'Architecture exists; robustness is not established.', 'Pipeline discovers genuine edge.', 'Run the complete null arm.', 'Execute the null arm before expanding architecture.'),
+  r('EUROPE_RECOGNITION_BASE', 'European institutional-recognition base', 'Inquiry-only selection conditions on the dependent variable.', 'Sensitivity causally explains lag.', 'Design censored/no-inquiry arm.', 'Construct the censored cohort and survival-analysis design.'),
+  r('ATLAS_AI', 'ATLAS AI Ω', 'GitHub and Notion are the persistent layers.', 'Live continuity binding will solve cross-project contamination.', 'Bind live chat to the Continuity Registry.', 'Read Notion before resolving Sigue, then rerun the locked test.'),
+  r('CEUTA_RABAT', 'Ceuta/Rabat research', 'Documented triggers must be separated from demonstrated coordination.', 'A central actor coordinated inducement.', 'Separate causes from inferred coordination.', 'Build the claim/evidence/falsifier matrix.'),
+  r('ATLAS_PORTFOLIO_37', 'ATLAS Ω portfolio 37', 'The experimental 37-name cut exists.', 'The selection will outperform benchmarks.', 'Observe predefined benchmark-relative performance.', 'Continue observation without post-hoc reinterpretation.'),
+  r('HOBBIECODE_STRATEGYQUANT', 'HobbieCode / StrategyQuant', 'The process uses strategy generation and robustness testing.', 'The specific robot has genuine edge.', 'Reconstruct and test the robot process.', 'Run out-of-sample robustness checks.'),
+  r('ACCIDENT_MEDICO_LEGAL', 'Accident / medical-legal', 'Hand-injury causation remains ambiguous.', 'The hand injury is attributable to the accident.', 'Establish documentary causal chain.', 'Locate the earliest hand-injury documentation.'),
+  r('PROPICKS_REVERSE_ENGINEERING', 'ProPicks reverse engineering', 'Own scores are not the proprietary algorithm signal.', 'Exact internal weights are known.', 'Design prospective ex-ante tests.', 'Predefine features and negative controls.'),
+];
+
+class MemoryProvider implements ContinuityRegistryProvider {
+  calls = 0;
+  async listActive(): Promise<ContinuityRegistryRecord[]> {
+    this.calls += 1;
+    return registry;
+  }
+}
+
+const titleCases: Array<[string, string, string]> = [
+  ['DINASTIA_ARTSRUNI', 'Reconstruir Casa Artsruni', 'Toumanoff y el puente Artsruni a Mesopotamia siguen sin prueba independiente.'],
+  ['ELITE_CAPITAL_SIGNAL', 'Actualizar snapshots Exor verificados', 'Seguimos con el backtest post-filing de Lingotto; habilidad predictiva sigue no demostrada.'],
+  ['STRATEGY_FACTORY', 'Strategy Factory', 'Falta correr el brazo nulo antes de diseñar otra versión de la factoría.'],
+  ['EUROPE_RECOGNITION_BASE', 'Comparar patrones europeos', 'Tenemos que construir la cohorte censurada y el análisis de supervivencia.'],
+  ['ATLAS_AI', 'Atlas AI', 'La continuidad live falló por contaminación entre proyectos; hay que leer el Continuity Registry antes de responder.'],
+  ['CEUTA_RABAT', 'Auditar Ceuta Ω', 'Separar detonantes documentados de coordinación inferida y buscar falsificadores.'],
+  ['ATLAS_PORTFOLIO_37', 'Cartera de 37', 'El corte experimental de 37 debe compararse contra benchmarks sin reinterpretación post hoc.'],
+  ['HOBBIECODE_STRATEGYQUANT', 'HobbieCode StrategyQuant', 'Reconstruir las reglas del robot Nasdaq y someterlas a robustez out-of-sample.'],
+  ['ACCIDENT_MEDICO_LEGAL', 'Análisis penal médico', 'La prioridad es documentar fecha y causalidad de la lesión de mano antes de integrarla en la reclamación.'],
+  ['PROPICKS_REVERSE_ENGINEERING', 'ProPicks ingeniería inversa', 'Hay que predefinir features y controles negativos antes de atribuir pesos al algoritmo.'],
+];
+
+describe('ATLAS AI Ω — live continuity binding', () => {
+  it.each(titleCases)('resolves %s from local conversation evidence before answering Sigue', async (expected, title, context) => {
+    const provider = new MemoryProvider();
+    const recentTurns: LocalConversationTurn[] = [
+      { role: 'user', content: context },
+      { role: 'assistant', content: `Estado actual del proyecto: ${context}` },
+    ];
+
+    const result = await resolveLiveContinuity({
+      utterance: 'Sigue',
+      conversationTitle: title,
+      recentTurns,
+    }, provider);
+
+    expect(provider.calls).toBe(1);
+    expect(result.status).toBe('RESOLVED');
+    expect(result.matchedProjectId).toBe(expected);
+    expect(result.state?.activeProject).toBe(expected);
+    expect(result.state?.hypotheses.length).toBeGreaterThan(0);
+    expect(result.state?.nextBestAction).toBeTruthy();
+  });
+
+  it('uses an explicit runtime project id over noisy local transcript text', async () => {
+    const provider = new MemoryProvider();
+    const result = await resolveLiveContinuity({
+      utterance: 'Sigue',
+      explicitProjectId: 'STRATEGY_FACTORY',
+      conversationTitle: 'Mixed notes',
+      recentTurns: [
+        { role: 'assistant', content: 'Ayer también trabajamos Exor, Lingotto, Artsruni y ProPicks.' },
+      ],
+    }, provider);
+
+    expect(result.status).toBe('RESOLVED');
+    expect(result.matchedProjectId).toBe('STRATEGY_FACTORY');
+    expect(result.reason).toBe('explicit_runtime_project');
+  });
+
+  it('fails closed instead of selecting a project when local context is genuinely ambiguous', async () => {
+    const provider = new MemoryProvider();
+    const result = await resolveLiveContinuity({
+      utterance: 'Sigue',
+      conversationTitle: 'Investigaciones',
+      recentTurns: [
+        { role: 'user', content: 'Strategy Factory: falta el brazo nulo. Elite Capital Signal: falta el backtest post-filing.' },
+      ],
+    }, provider);
+
+    expect(result.status).toBe('AMBIGUOUS');
+    expect(result.state).toBeNull();
+    expect(result.matchedProjectId).toBeNull();
+  });
+
+  it('fails closed when the Notion registry cannot be read', async () => {
+    const provider: ContinuityRegistryProvider = {
+      async listActive() {
+        throw new Error('notion_unavailable');
+      },
+    };
+
+    const result = await resolveLiveContinuity({
+      utterance: 'Sigue',
+      conversationTitle: 'Atlas AI',
+      recentTurns: [{ role: 'user', content: 'Seguimos con Atlas AI.' }],
+    }, provider);
+
+    expect(result.status).toBe('REGISTRY_UNAVAILABLE');
+    expect(result.state).toBeNull();
+    expect(result.matchedProjectId).toBeNull();
+  });
+
+  it('queries the real Notion data-source endpoint shape and maps active rows into registry records', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe('https://api.notion.com/v1/data_sources/ds-123/query');
+      expect(init?.method).toBe('POST');
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer secret-token');
+      expect(headers['Notion-Version']).toBe('2026-03-11');
+      const body = JSON.parse(String(init?.body));
+      expect(body.filter).toEqual({ property: 'Active', checkbox: { equals: true } });
+
+      return new Response(JSON.stringify({
+        object: 'list',
+        has_more: false,
+        next_cursor: null,
+        results: [{
+          object: 'page',
+          properties: {
+            'Name': { type: 'title', title: [{ plain_text: 'ATLAS AI Ω' }] },
+            'Project ID': { type: 'rich_text', rich_text: [{ plain_text: 'ATLAS_AI' }] },
+            'State': { type: 'select', select: { name: 'BLOCKED' } },
+            'Active': { type: 'checkbox', checkbox: true },
+            'Established': { type: 'rich_text', rich_text: [{ plain_text: 'GitHub + Notion are persistent layers.' }] },
+            'Hypotheses': { type: 'rich_text', rich_text: [{ plain_text: 'Live binding may solve routing.' }] },
+            'Open Loop': { type: 'rich_text', rich_text: [{ plain_text: 'Bind live runtime.' }] },
+            'Next Best Action': { type: 'rich_text', rich_text: [{ plain_text: 'Read Notion before Sigue.' }] },
+            'Evidence Standard': { type: 'rich_text', rich_text: [{ plain_text: 'PREREGISTERED_CONTINUITY_TEST' }] },
+            'Provenance': { type: 'rich_text', rich_text: [{ plain_text: 'live-retest' }] },
+            'Updated': { type: 'date', date: { start: '2026-09-06' } },
+          },
+        }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+
+    const provider = new NotionHttpContinuityRegistryProvider({
+      token: 'secret-token',
+      dataSourceId: 'ds-123',
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    const rows = await provider.listActive();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].projectId).toBe('ATLAS_AI');
+    expect(rows[0].state).toBe('BLOCKED');
+    expect(rows[0].active).toBe(true);
+    expect(rows[0].hypotheses).toEqual(['Live binding may solve routing.']);
+  });
+});

--- a/src/atlas/personal-cognitive-os/live-continuity-binding.ts
+++ b/src/atlas/personal-cognitive-os/live-continuity-binding.ts
@@ -1,0 +1,422 @@
+import {
+  assertNoEpistemicPromotion,
+  retrieveContinuityFromRegistry,
+  type ContinuityRegistryRecord,
+  type ContinuityRetrievalResult,
+} from './continuity-registry';
+import type { ContinuityState } from './engine';
+
+export type LocalConversationTurn = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+export type LiveContinuityBindingInput = {
+  utterance: string;
+  conversationTitle?: string | null;
+  recentTurns: LocalConversationTurn[];
+  explicitProjectId?: string | null;
+};
+
+export interface ContinuityRegistryProvider {
+  listActive(): Promise<ContinuityRegistryRecord[]>;
+}
+
+export type LiveContinuityStatus =
+  | 'RESOLVED'
+  | 'AMBIGUOUS'
+  | 'NO_PROJECT'
+  | 'REGISTRY_UNAVAILABLE';
+
+export type LiveContinuityBindingResult = {
+  status: LiveContinuityStatus;
+  matchedProjectId: string | null;
+  state: ContinuityState | null;
+  confidence: number;
+  reason: string;
+  registryRead: boolean;
+  diagnostics: {
+    bestProjectId: string | null;
+    bestScore: number;
+    secondScore: number;
+  };
+};
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'into', 'then', 'than',
+  'que', 'para', 'con', 'del', 'las', 'los', 'una', 'uno', 'por', 'como', 'esto',
+  'esta', 'este', 'hay', 'sigue', 'seguir', 'seguimos', 'continue', 'continua',
+]);
+
+function normalize(value: string): string {
+  return value
+    .trim()
+    .toLocaleLowerCase('es')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokens(value: string): string[] {
+  return normalize(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !STOPWORDS.has(token));
+}
+
+function stem(token: string): string {
+  if (token.length <= 5) return token;
+  return token.slice(0, Math.min(7, token.length));
+}
+
+function tokenMatches(a: string, b: string): boolean {
+  if (a === b) return true;
+  const sa = stem(a);
+  const sb = stem(b);
+  return sa.length >= 5 && sb.length >= 5 && (sa.startsWith(sb) || sb.startsWith(sa));
+}
+
+function identityPhrases(record: ContinuityRegistryRecord): string[] {
+  return [record.projectId, record.name, ...(record.aliases ?? [])].filter(Boolean);
+}
+
+function identityTokens(record: ContinuityRegistryRecord): string[] {
+  return [...new Set(identityPhrases(record).flatMap(tokens))];
+}
+
+function signatureTokens(record: ContinuityRegistryRecord): string[] {
+  return [...new Set([
+    ...identityTokens(record),
+    ...tokens(record.openLoop ?? ''),
+    ...tokens(record.nextBestAction ?? ''),
+    ...record.established.flatMap(tokens),
+    ...record.hypotheses.flatMap(tokens),
+  ])];
+}
+
+function sharedTokenCount(left: string[], right: string[]): number {
+  const matched = new Set<number>();
+  let count = 0;
+  for (const token of left) {
+    const index = right.findIndex((candidate, i) => !matched.has(i) && tokenMatches(token, candidate));
+    if (index >= 0) {
+      matched.add(index);
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function containsIdentityPhrase(text: string, record: ContinuityRegistryRecord): boolean {
+  const n = normalize(text);
+  return identityPhrases(record).some((phrase) => {
+    const p = normalize(phrase);
+    return p.length >= 5 && n.includes(p);
+  });
+}
+
+function scoreConversationEvidence(
+  input: LiveContinuityBindingInput,
+  record: ContinuityRegistryRecord,
+): number {
+  let score = 0;
+  const idTokens = identityTokens(record);
+  const sigTokens = signatureTokens(record);
+
+  if (input.conversationTitle) {
+    if (containsIdentityPhrase(input.conversationTitle, record)) score += 40;
+    score += sharedTokenCount(tokens(input.conversationTitle), idTokens) * 7;
+  }
+
+  const turns = input.recentTurns.slice(-8);
+  turns.forEach((turn, index) => {
+    const recency = 1 + ((index + 1) / Math.max(1, turns.length));
+    if (containsIdentityPhrase(turn.content, record)) score += 20 * recency;
+    const turnTokens = tokens(turn.content);
+    score += sharedTokenCount(turnTokens, idTokens) * 3 * recency;
+    score += Math.min(8, sharedTokenCount(turnTokens, sigTokens)) * recency;
+  });
+
+  return Math.round(score * 100) / 100;
+}
+
+function inferProjectFromLocalConversation(
+  input: LiveContinuityBindingInput,
+  records: ContinuityRegistryRecord[],
+): { projectId: string | null; ambiguous: boolean; bestScore: number; secondScore: number } {
+  const ranked = records
+    .map((record) => ({ record, score: scoreConversationEvidence(input, record) }))
+    .sort((a, b) => b.score - a.score);
+
+  const best = ranked[0];
+  const second = ranked[1];
+  const bestScore = best?.score ?? 0;
+  const secondScore = second?.score ?? 0;
+
+  if (!best || bestScore < 6) {
+    return { projectId: null, ambiguous: false, bestScore, secondScore };
+  }
+
+  const requiredMargin = Math.max(3, bestScore * 0.2);
+  if (second && bestScore - secondScore < requiredMargin) {
+    return { projectId: null, ambiguous: true, bestScore, secondScore };
+  }
+
+  return { projectId: best.record.projectId, ambiguous: false, bestScore, secondScore };
+}
+
+function exactProject(
+  projectId: string,
+  records: ContinuityRegistryRecord[],
+): ContinuityRegistryRecord | null {
+  const wanted = normalize(projectId);
+  return records.find((record) => normalize(record.projectId) === wanted || normalize(record.name) === wanted) ?? null;
+}
+
+function fromRetrieval(
+  retrieval: ContinuityRetrievalResult,
+  reason: string,
+  diagnostics: LiveContinuityBindingResult['diagnostics'],
+): LiveContinuityBindingResult {
+  return {
+    status: retrieval.state ? 'RESOLVED' : retrieval.ambiguous ? 'AMBIGUOUS' : 'NO_PROJECT',
+    matchedProjectId: retrieval.matchedProjectId,
+    state: retrieval.state,
+    confidence: retrieval.confidence,
+    reason,
+    registryRead: true,
+    diagnostics,
+  };
+}
+
+export async function resolveLiveContinuity(
+  input: LiveContinuityBindingInput,
+  provider: ContinuityRegistryProvider,
+): Promise<LiveContinuityBindingResult> {
+  let records: ContinuityRegistryRecord[];
+  try {
+    records = (await provider.listActive()).filter((record) => record.active && record.state !== 'CLOSED');
+  } catch {
+    return {
+      status: 'REGISTRY_UNAVAILABLE',
+      matchedProjectId: null,
+      state: null,
+      confidence: 0,
+      reason: 'registry_read_failed',
+      registryRead: false,
+      diagnostics: { bestProjectId: null, bestScore: 0, secondScore: 0 },
+    };
+  }
+
+  if (input.explicitProjectId) {
+    const exact = exactProject(input.explicitProjectId, records);
+    if (!exact) {
+      return {
+        status: 'NO_PROJECT',
+        matchedProjectId: null,
+        state: null,
+        confidence: 0,
+        reason: 'explicit_runtime_project_not_in_registry',
+        registryRead: true,
+        diagnostics: { bestProjectId: null, bestScore: 0, secondScore: 0 },
+      };
+    }
+    const retrieval = retrieveContinuityFromRegistry(
+      { utterance: input.utterance, activeProjectHint: exact.projectId },
+      records,
+    );
+    if (retrieval.state) assertNoEpistemicPromotion(exact, retrieval.state);
+    return fromRetrieval(retrieval, 'explicit_runtime_project', {
+      bestProjectId: exact.projectId,
+      bestScore: 1,
+      secondScore: 0,
+    });
+  }
+
+  const inferred = inferProjectFromLocalConversation(input, records);
+  if (!inferred.projectId) {
+    return {
+      status: inferred.ambiguous ? 'AMBIGUOUS' : 'NO_PROJECT',
+      matchedProjectId: null,
+      state: null,
+      confidence: 0,
+      reason: inferred.ambiguous ? 'local_conversation_project_ambiguous' : 'insufficient_local_project_evidence',
+      registryRead: true,
+      diagnostics: {
+        bestProjectId: null,
+        bestScore: inferred.bestScore,
+        secondScore: inferred.secondScore,
+      },
+    };
+  }
+
+  const record = records.find((candidate) => candidate.projectId === inferred.projectId);
+  if (!record) {
+    return {
+      status: 'NO_PROJECT',
+      matchedProjectId: null,
+      state: null,
+      confidence: 0,
+      reason: 'inferred_project_missing_from_registry',
+      registryRead: true,
+      diagnostics: {
+        bestProjectId: inferred.projectId,
+        bestScore: inferred.bestScore,
+        secondScore: inferred.secondScore,
+      },
+    };
+  }
+
+  const retrieval = retrieveContinuityFromRegistry(
+    { utterance: input.utterance, activeProjectHint: record.projectId },
+    records,
+  );
+  if (retrieval.state) assertNoEpistemicPromotion(record, retrieval.state);
+
+  return fromRetrieval(retrieval, 'local_conversation_to_registry_binding', {
+    bestProjectId: record.projectId,
+    bestScore: inferred.bestScore,
+    secondScore: inferred.secondScore,
+  });
+}
+
+type NotionRichText = { plain_text?: string };
+type NotionProperty = {
+  type?: string;
+  title?: NotionRichText[];
+  rich_text?: NotionRichText[];
+  select?: { name?: string } | null;
+  checkbox?: boolean;
+  date?: { start?: string } | null;
+};
+type NotionPage = { properties?: Record<string, NotionProperty> };
+type NotionQueryResponse = {
+  results?: NotionPage[];
+  has_more?: boolean;
+  next_cursor?: string | null;
+};
+
+function textProperty(properties: Record<string, NotionProperty>, name: string): string {
+  const property = properties[name];
+  const values = property?.type === 'title' ? property.title : property?.rich_text;
+  return (values ?? []).map((item) => item.plain_text ?? '').join('').trim();
+}
+
+function selectProperty(properties: Record<string, NotionProperty>, name: string): string {
+  return properties[name]?.select?.name?.trim() ?? '';
+}
+
+function checkboxProperty(properties: Record<string, NotionProperty>, name: string): boolean {
+  return properties[name]?.checkbox === true;
+}
+
+function dateProperty(properties: Record<string, NotionProperty>, name: string): string {
+  return properties[name]?.date?.start?.trim() ?? '';
+}
+
+function optionalText(value: string): string | null {
+  return value.trim() ? value.trim() : null;
+}
+
+function splitAliases(value: string): string[] {
+  return value
+    .split(/\n|\|/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function validState(value: string): ContinuityRegistryRecord['state'] {
+  if (value === 'ACTIVE' || value === 'WAITING' || value === 'BLOCKED' || value === 'CLOSED') return value;
+  throw new Error(`invalid_notion_continuity_state:${value || 'EMPTY'}`);
+}
+
+export function mapNotionPageToContinuityRecord(page: NotionPage): ContinuityRegistryRecord {
+  const properties = page.properties ?? {};
+  const projectId = textProperty(properties, 'Project ID');
+  const name = textProperty(properties, 'Name');
+  if (!projectId || !name) throw new Error('invalid_notion_continuity_row_missing_identity');
+
+  const established = textProperty(properties, 'Established');
+  const hypotheses = textProperty(properties, 'Hypotheses');
+  const provenance = textProperty(properties, 'Provenance');
+  const aliases = textProperty(properties, 'Aliases');
+
+  return {
+    projectId,
+    name,
+    aliases: splitAliases(aliases),
+    state: validState(selectProperty(properties, 'State')),
+    active: checkboxProperty(properties, 'Active'),
+    established: established ? [established] : [],
+    hypotheses: hypotheses ? [hypotheses] : [],
+    openLoop: optionalText(textProperty(properties, 'Open Loop')),
+    nextBestAction: optionalText(textProperty(properties, 'Next Best Action')),
+    evidenceStandard: optionalText(textProperty(properties, 'Evidence Standard')),
+    provenance: provenance ? [provenance] : ['notion:continuity-registry'],
+    updatedAt: dateProperty(properties, 'Updated'),
+  };
+}
+
+export type NotionHttpContinuityRegistryProviderOptions = {
+  token: string;
+  dataSourceId: string;
+  fetchImpl?: typeof fetch;
+  notionVersion?: string;
+};
+
+export class NotionHttpContinuityRegistryProvider implements ContinuityRegistryProvider {
+  private readonly token: string;
+  private readonly dataSourceId: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly notionVersion: string;
+
+  constructor(options: NotionHttpContinuityRegistryProviderOptions) {
+    if (!options.token.trim()) throw new Error('notion_token_required');
+    if (!options.dataSourceId.trim()) throw new Error('notion_data_source_id_required');
+    this.token = options.token;
+    this.dataSourceId = options.dataSourceId.replace(/^collection:\/\//, '');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.notionVersion = options.notionVersion ?? '2026-03-11';
+  }
+
+  async listActive(): Promise<ContinuityRegistryRecord[]> {
+    const records: ContinuityRegistryRecord[] = [];
+    let startCursor: string | null = null;
+
+    do {
+      const body: Record<string, unknown> = {
+        filter: { property: 'Active', checkbox: { equals: true } },
+        page_size: 100,
+      };
+      if (startCursor) body.start_cursor = startCursor;
+
+      const response = await this.fetchImpl(
+        `https://api.notion.com/v1/data_sources/${this.dataSourceId}/query`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            'Notion-Version': this.notionVersion,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`notion_continuity_query_failed:${response.status}`);
+      }
+
+      const payload = await response.json() as NotionQueryResponse;
+      for (const page of payload.results ?? []) {
+        const record = mapNotionPageToContinuityRecord(page);
+        if (record.active && record.state !== 'CLOSED') records.push(record);
+      }
+
+      startCursor = payload.has_more ? (payload.next_cursor ?? null) : null;
+    } while (startCursor);
+
+    return records;
+  }
+}

--- a/src/atlas/personal-cognitive-os/live-continuity-binding.ts
+++ b/src/atlas/personal-cognitive-os/live-continuity-binding.ts
@@ -141,10 +141,45 @@ function scoreConversationEvidence(
   return Math.round(score * 100) / 100;
 }
 
+function explicitProjectIdsInLocalContext(
+  input: LiveContinuityBindingInput,
+  records: ContinuityRegistryRecord[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const turn of input.recentTurns.slice(-8)) {
+    for (const record of records) {
+      if (containsIdentityPhrase(turn.content, record)) ids.add(record.projectId);
+    }
+  }
+  return ids;
+}
+
+function explicitProjectIdsInTitle(
+  input: LiveContinuityBindingInput,
+  records: ContinuityRegistryRecord[],
+): Set<string> {
+  const ids = new Set<string>();
+  if (!input.conversationTitle) return ids;
+  for (const record of records) {
+    if (containsIdentityPhrase(input.conversationTitle, record)) ids.add(record.projectId);
+  }
+  return ids;
+}
+
 function inferProjectFromLocalConversation(
   input: LiveContinuityBindingInput,
   records: ContinuityRegistryRecord[],
 ): { projectId: string | null; ambiguous: boolean; bestScore: number; secondScore: number } {
+  const titleExplicit = explicitProjectIdsInTitle(input, records);
+  const turnExplicit = explicitProjectIdsInLocalContext(input, records);
+
+  // Safety gate: when local turns explicitly name multiple projects, a generic title
+  // must not let the scoring model silently choose one. A single explicit title project
+  // is allowed to disambiguate because it is local conversation metadata.
+  if (turnExplicit.size > 1 && titleExplicit.size !== 1) {
+    return { projectId: null, ambiguous: true, bestScore: 0, secondScore: 0 };
+  }
+
   const ranked = records
     .map((record) => ({ record, score: scoreConversationEvidence(input, record) }))
     .sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Purpose
Fix the exact failure demonstrated by the preregistered continuity work: cross-project contamination when `Sigue` is answered without a guaranteed read of the persistent Continuity Registry.

## Scope — no new cognitive layers
This PR implements only the missing runtime path:

`LOCAL CHAT CONTEXT → ACTIVE PROJECT IDENTIFICATION → NOTION CONTINUITY REGISTRY READ → ContinuityRegistryRecord → deterministic continuity retrieval → response state`

## Implemented
- `live-continuity-binding.ts`
  - registry is read **before** resolution
  - strict local-conversation project inference
  - explicit runtime project ID takes precedence
  - multi-project explicit context fails closed unless local title metadata unambiguously selects one project
  - insufficient evidence / ambiguity / registry outage fail closed
  - epistemic-promotion assertion before returning state
  - native Node 20 Notion HTTP provider
  - official Data Source endpoint `POST /v1/data_sources/{id}/query`
  - Notion API version `2026-03-11`
- `continuity-runtime.ts`
  - smallest executable Atlas continuity handler
  - reads `NOTION_API_KEY` + `ATLAS_CONTINUITY_DATA_SOURCE_ID` when no provider is injected
  - returns explicit runtime/status/diagnostics
- `continuity-registry.ts`
  - project aliases
- Tests
  - engine tests
  - registry tests
  - 10-case live-binding routing suite
  - ambiguity / registry-outage safety tests
  - Notion HTTP request/mapping test
  - 10-case runtime acceptance suite through `handleContinuityRequest`
- CI
  - standard continuity CI runs all pure/runtime tests
  - the existing default-branch continuity workflow now contains a **pre-merge real-Notion job** for same-repository PRs, so PR #160 can validate its own code against the actual registry before merge
  - the separate manual `ATLAS AI Real Notion Continuity Smoke` workflow remains useful after merge for later reruns

## Notion side
`ATLAS Continuity Registry Ω` has `Aliases`; all 10 preregistered rows are populated and re-read from the real data source. Data source ID: `20a48cee-6fe0-46ce-b750-5ac78177fcb6`.

## Validation history
1. First binding CI: **FAIL** — explicit two-project context was incorrectly resolved.
2. Test was preserved; binding was hardened to fail closed.
3. Binding CI: **SUCCESS** — run `34032247180`.
4. Minimal runtime handler + 10-case runtime suite added.
5. Runtime CI: **SUCCESS** — run `34032541696`.
6. ASTRA continuation audit identified a CI bootstrap deadlock: the new `workflow_dispatch` smoke could not serve as a pre-merge gate because GitHub only dispatches workflows already present on the default branch.
7. Fix: real Notion integration test moved into the existing default-branch continuity PR workflow. Commit `113f17f408731a70f40070e7b94ca593e27aa293` triggers the actual pre-merge gate.

## Critical boundary
The old ChatGPT threads cannot validate this code because ChatGPT does not execute `atlas_genesis`. A valid integration test must execute `handleContinuityRequest` with authorized Notion access.

## DO NOT MERGE YET
Remaining sequence:
1. Require the new PR workflow job `real-notion-continuity` to execute.
2. Require the repository secret `NOTION_API_KEY` to be present and authorized to read `ATLAS Continuity Registry Ω`.
3. Require all 10 real-registry runtime cases to PASS with no epistemic promotion.
4. Only then decide merge.

Locked product gates remain:
- Project Recovery >= 9/10
- Open-Loop Recovery >= 8/10
- Established Recovery >= 85%
- Hypothesis Recovery >= 85%
- Epistemic Promotion Rate = 0%

This PR does not unfreeze Decision Prediction or Digital Twin inference.