### PR TITLE
ATLAS Ω — block non-deterministic / out-of-universe portfolio publication

### DIFF
--- a/.github/workflows/endogenous-portfolio-engine-v2-ci.yml
+++ b/.github/workflows/endogenous-portfolio-engine-v2-ci.yml
@@ -6,6 +6,8 @@ on:
       - 'src/atlas/algorithm/endogenous-portfolio-engine-v2.ts'
       - 'src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts'
       - 'src/atlas/algorithm/endogenous-portfolio-engine-v2-canon.ts'
+      - 'src/atlas/algorithm/structural-portfolio-publication-gate-omega.ts'
+      - 'src/atlas/algorithm/structural-portfolio-publication-gate-omega.test.ts'
       - 'CURRENT_CANON/2026-09-05_ENDOGENOUS_PORTFOLIO_ENGINE_V2.md'
       - '.github/workflows/endogenous-portfolio-engine-v2-ci.yml'
   push:
@@ -14,6 +16,8 @@ on:
       - 'src/atlas/algorithm/endogenous-portfolio-engine-v2.ts'
       - 'src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts'
       - 'src/atlas/algorithm/endogenous-portfolio-engine-v2-canon.ts'
+      - 'src/atlas/algorithm/structural-portfolio-publication-gate-omega.ts'
+      - 'src/atlas/algorithm/structural-portfolio-publication-gate-omega.test.ts'
 
 jobs:
   test:
@@ -23,5 +27,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Run Endogenous Portfolio Engine v2 tests
-        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
+      - name: Run Endogenous Portfolio Engine v2 + publication-gate tests
+        run: npx --yes vitest@3.2.4 run --globals src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts src/atlas/algorithm/structural-portfolio-publication-gate-omega.test.ts

--- a/CURRENT_CANON/2026-09-06_STRUCTURAL_PORTFOLIO_PUBLICATION_GATE_OMEGA.md
+++ b/CURRENT_CANON/2026-09-06_STRUCTURAL_PORTFOLIO_PUBLICATION_GATE_OMEGA.md
@@ -1,0 +1,63 @@
+# ATLAS Ω — STRUCTURAL PORTFOLIO PUBLICATION GATE
+
+Date: 2026-09-06
+Status: CANONICAL CANDIDATE
+Purpose: prevent narrative/incumbency contamination and prevent experimental equal-weight baskets from being published as the structural MAX RETURN / LOW VOL portfolio.
+
+## Failure discovered
+
+Repeated same-day answers produced incompatible 25/29/31-name portfolios, and an out-of-universe security was admitted despite a newly frozen universe. This proves that a valid company list is not enough: publication needs a mechanical provenance and determinism gate.
+
+A second implementation defect was confirmed: Endogenous Portfolio Engine v2.2 evaluates candidate sets with neutral equal test weights and explicitly emits no target weights. Therefore selection output alone MUST NOT be described as a fully optimized structural MAX RETURN / LOW VOL portfolio.
+
+## Required pipeline
+
+`CANONICAL RAW UNIVERSE -> NORMALIZED WHITELIST -> COMPLETE PIT ENTITY MATRIX -> HARD GATES / FALSIFIER VETO -> DETERMINISTIC SELECTION -> MARGINAL LEDGER -> COVARIANCE-AWARE SIZING -> PUBLICATION GATE`
+
+## Mandatory publication invariants
+
+1. Every candidate ticker must belong to the canonical universe whitelist before the selector runs.
+2. Every canonical economic entity must have one complete PIT evidence row; incomplete-universe runs fail closed.
+3. Duplicate share classes mapped to one canonical entity must carry identical normalized evidence or the run fails closed.
+4. Caller input order has zero authority. The publication gate canonicalizes entity/ticker ordering before every run.
+5. Default reproducibility certification is 100 reruns. Same evidence must produce identical selected tickers and N.
+6. Any different composition/N hash returns `FAIL_NON_DETERMINISTIC_PORTFOLIO_SELECTION`.
+7. The run persists a full marginal ledger with `DeltaU_add` and best `DeltaU_swap` for every eligible canonical entity.
+8. Structural publication requires explicit covariance-aware sizing evidence, a portfolio-volatility-model hash and weights summing to one over exactly the selected names.
+9. Until such sizing exists, the state is `BLOCKED_SIZING_NOT_IMPLEMENTED`; a selection may be inspected but cannot be called the canonical structural portfolio.
+10. `globalOptimalityProven=false` remains mandatory while the search is deterministic local search rather than a proof of combinatorial global optimum.
+
+## Four-session firewall
+
+`EXPERIMENT_4D_EQUAL_WEIGHT` is a separate API and always emits authority `EXPERIMENT_ONLY`.
+
+It cannot overwrite, certify or masquerade as the structural portfolio. Equal weighting is legitimate for a short selection experiment but is not structural position sizing.
+
+## Canonical universe
+
+Raw source: `data/t0-universe-user-seed-2026-09-05.txt`.
+Manifest: `CURRENT_CANON/2026-09-06_ATLAS_CANONICAL_UNIVERSE.md`.
+
+External challengers remain possible only through the canonical discovery/challenger process. They cannot silently enter a run whose whitelist is frozen to the base universe.
+
+## Code
+
+- `src/atlas/algorithm/structural-portfolio-publication-gate-omega.ts`
+- `src/atlas/algorithm/structural-portfolio-publication-gate-omega.test.ts`
+- `.github/workflows/endogenous-portfolio-engine-v2-ci.yml`
+
+## Publication semantics
+
+Allowed terminal publication states include:
+
+- `CANONICAL_READY`
+- `BLOCKED_METADATA_MISSING`
+- `BLOCKED_UNIVERSE_MISMATCH`
+- `BLOCKED_INCOMPLETE_UNIVERSE_EVIDENCE`
+- `BLOCKED_CONFLICTING_ENTITY_ROWS`
+- `BLOCKED_ENGINE_PENDING`
+- `FAIL_NON_DETERMINISTIC_PORTFOLIO_SELECTION`
+- `BLOCKED_SIZING_NOT_IMPLEMENTED`
+- `BLOCKED_INVALID_SIZING`
+
+The safe outcome is to block. ATLAS must never fill missing evidence, missing weights or an out-of-universe ticker with narrative judgment.

--- a/src/atlas/algorithm/structural-portfolio-publication-gate-omega.test.ts
+++ b/src/atlas/algorithm/structural-portfolio-publication-gate-omega.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFourSessionEqualWeightExperiment,
+  runStructuralPortfolioPublicationGate,
+} from './structural-portfolio-publication-gate-omega';
+import { CANONICAL_SCENARIOS, type PortfolioCandidateV2 } from './endogenous-portfolio-engine-v2';
+
+function c(ticker: string, entity: string, er = 12): PortfolioCandidateV2 {
+  const scenarios = Object.fromEntries(CANONICAL_SCENARIOS.map(s => [s, -0.5])) as PortfolioCandidateV2['scenarios'];
+  return {
+    ticker, canonicalEntityId: entity, hardGatesPassed: true, falsifierVetoPassed: true,
+    expectedReturn: { fundamentalGrowthPct: er - 4, cashYieldPct: 2, capitalReturnsPct: 1, multipleNormalizationPct: 1 },
+    permanentLossRisk: 2, tailRisk: 1, volatilityRisk: 2, fragility: 1, convexity: 1,
+    confidence: 0.9, individualScore: 90, causalDrivers: { core: 1 }, fundingSources: [], scenarios,
+  };
+}
+
+function req(candidates: PortfolioCandidateV2[]) {
+  return {
+    rawUniverseSource: 'data/t0-universe-user-seed-2026-09-05.txt',
+    normalizedUniverseHash: 'universe-hash', snapshotHash: 'pit-2026-09-06', policyHash: 'policy-v1',
+    allowedTickers: candidates.map(x => x.ticker), expectedCanonicalEntityCount: new Set(candidates.map(x => x.canonicalEntityId)).size,
+    candidates, reproducibilityRuns: 12,
+  };
+}
+
+describe('Structural Portfolio Publication Gate Ω', () => {
+  it('blocks any ticker outside the canonical universe before selection', () => {
+    const xs = [c('AVGO','AVGO'), c('NVDA','NVDA'), c('KEYENCE','KEYENCE')];
+    const r = runStructuralPortfolioPublicationGate({ ...req(xs), allowedTickers: ['AVGO','NVDA'] });
+    expect(r.publicationState).toBe('BLOCKED_UNIVERSE_MISMATCH');
+    expect(r.selectedTickers).toEqual([]);
+  });
+
+  it('blocks publication when full canonical entity evidence is not present', () => {
+    const xs = [c('AVGO','AVGO'), c('NVDA','NVDA')];
+    const r = runStructuralPortfolioPublicationGate({ ...req(xs), expectedCanonicalEntityCount: 3 });
+    expect(r.publicationState).toBe('BLOCKED_INCOMPLETE_UNIVERSE_EVIDENCE');
+  });
+
+  it('is invariant to caller order and emits the same portfolio hash', () => {
+    const xs = [c('AVGO','AVGO',16), c('NVDA','NVDA',15), c('ASML','ASML',14), c('ICE','ICE',10), c('REGN','REGN',11)];
+    const a = runStructuralPortfolioPublicationGate(req(xs));
+    const b = runStructuralPortfolioPublicationGate(req([...xs].reverse()));
+    expect(a.selectedTickers).toEqual(b.selectedTickers);
+    expect(a.optimalN).toBe(b.optimalN);
+    expect(a.portfolioHash).toBe(b.portfolioHash);
+  });
+
+  it('chooses a deterministic representative for duplicate share-class/entity rows', () => {
+    const a = c('GOOGL','ALPHABET',13);
+    const b = { ...a, ticker: 'GOOG' };
+    const other = c('MSFT','MSFT',12);
+    const x = runStructuralPortfolioPublicationGate(req([a,b,other]));
+    const y = runStructuralPortfolioPublicationGate(req([b,a,other]));
+    expect(x.portfolioHash).toBe(y.portfolioHash);
+    expect(x.selectedTickers).toEqual(y.selectedTickers);
+  });
+
+  it('refuses to call reproducible selection a structural portfolio before sizing exists', () => {
+    const xs = [c('AVGO','AVGO',16), c('NVDA','NVDA',15), c('ICE','ICE',10)];
+    const r = runStructuralPortfolioPublicationGate(req(xs));
+    expect(r.selectedTickers.length).toBeGreaterThan(0);
+    expect(r.publicationState).toBe('BLOCKED_SIZING_NOT_IMPLEMENTED');
+    expect(r.weights).toBeNull();
+    expect(r.marginalRanking.length).toBe(3);
+  });
+
+  it('requires covariance-aware sizing evidence and exact normalized weights', () => {
+    const xs = [c('AVGO','AVGO',16), c('NVDA','NVDA',15), c('ICE','ICE',10)];
+    const first = runStructuralPortfolioPublicationGate(req(xs));
+    const selected = first.selectedTickers;
+    const weights = Object.fromEntries(selected.map(t => [t, 1 / selected.length]));
+    const r = runStructuralPortfolioPublicationGate({
+      ...req(xs),
+      sizing: { method: 'COVARIANCE_AWARE', portfolioVolatilityModelHash: 'cov-pit-hash', weights },
+    });
+    expect(r.publicationState).toBe('CANONICAL_READY');
+    expect(Object.values(r.weights ?? {}).reduce((a,b)=>a+b,0)).toBeCloseTo(1,10);
+  });
+
+  it('keeps the four-session equal-weight basket explicitly experimental', () => {
+    const x = buildFourSessionEqualWeightExperiment(['NVDA','AVGO'], 500, ['AVGO','NVDA','ASML']);
+    expect(x.mode).toBe('EXPERIMENT_4D_EQUAL_WEIGHT');
+    expect(x.authority).toBe('EXPERIMENT_ONLY');
+    expect(x.equalWeight).toBeCloseTo(0.5,12);
+    expect(x.amountPerPosition).toBeCloseTo(250,12);
+  });
+});

--- a/src/atlas/algorithm/structural-portfolio-publication-gate-omega.ts
+++ b/src/atlas/algorithm/structural-portfolio-publication-gate-omega.ts
@@ -1,0 +1,276 @@
+import {
+  evaluatePortfolioSetV2,
+  runEndogenousPortfolioEngineV2,
+  type PortfolioCandidateV2,
+  type PortfolioEnginePolicyV2,
+} from './endogenous-portfolio-engine-v2';
+
+export const STRUCTURAL_PORTFOLIO_PUBLICATION_GATE_VERSION = '2026-09-06-v1.0.0' as const;
+
+export type StructuralPublicationState =
+  | 'CANONICAL_READY'
+  | 'BLOCKED_METADATA_MISSING'
+  | 'BLOCKED_UNIVERSE_MISMATCH'
+  | 'BLOCKED_INCOMPLETE_UNIVERSE_EVIDENCE'
+  | 'BLOCKED_CONFLICTING_ENTITY_ROWS'
+  | 'BLOCKED_ENGINE_PENDING'
+  | 'FAIL_NON_DETERMINISTIC_PORTFOLIO_SELECTION'
+  | 'BLOCKED_SIZING_NOT_IMPLEMENTED'
+  | 'BLOCKED_INVALID_SIZING';
+
+export type MarginalRow = {
+  ticker: string;
+  canonicalEntityId: string;
+  selected: boolean;
+  deltaUAdd: number;
+  bestDeltaUSwap: number | null;
+  bestSwapAgainst: string | null;
+};
+
+export type StructuralSizingEvidence = {
+  method: 'COVARIANCE_AWARE';
+  portfolioVolatilityModelHash: string;
+  weights: Record<string, number>;
+};
+
+export type StructuralPortfolioRunRequest = {
+  rawUniverseSource: string;
+  normalizedUniverseHash: string;
+  snapshotHash: string;
+  policyHash: string;
+  allowedTickers: string[];
+  expectedCanonicalEntityCount: number;
+  candidates: PortfolioCandidateV2[];
+  policy?: PortfolioEnginePolicyV2;
+  reproducibilityRuns?: number;
+  sizing?: StructuralSizingEvidence;
+};
+
+export type StructuralPortfolioRun = {
+  publicationState: StructuralPublicationState;
+  reason: string;
+  selectedTickers: string[];
+  optimalN: number | null;
+  portfolioHash: string | null;
+  reproducibilityRuns: number;
+  marginalRanking: MarginalRow[];
+  weights: Record<string, number> | null;
+  globalOptimalityProven: false;
+  searchMode: 'DETERMINISTIC_LOCAL_SEARCH';
+};
+
+export type FourSessionExperiment = {
+  mode: 'EXPERIMENT_4D_EQUAL_WEIGHT';
+  authority: 'EXPERIMENT_ONLY';
+  tickers: string[];
+  equalWeight: number;
+  amountPerPosition: number;
+  totalCapital: number;
+};
+
+function finite(x: number): boolean { return Number.isFinite(x); }
+function upper(x: string): string { return x.trim().toUpperCase(); }
+
+function stableFingerprint(value: unknown): string {
+  const s = JSON.stringify(value);
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+function evidenceFingerprint(c: PortfolioCandidateV2): string {
+  return JSON.stringify({
+    hardGatesPassed: c.hardGatesPassed,
+    falsifierVetoPassed: c.falsifierVetoPassed,
+    expectedReturn: c.expectedReturn,
+    permanentLossRisk: c.permanentLossRisk,
+    tailRisk: c.tailRisk,
+    volatilityRisk: c.volatilityRisk,
+    fragility: c.fragility,
+    convexity: c.convexity,
+    confidence: c.confidence,
+    individualScore: c.individualScore,
+    causalDrivers: Object.entries(c.causalDrivers ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+    fundingSources: [...(c.fundingSources ?? [])].map(upper).sort(),
+    scenarios: Object.entries(c.scenarios ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+  });
+}
+
+function canonicalizeEntities(candidates: PortfolioCandidateV2[]): PortfolioCandidateV2[] | null {
+  const sorted = [...candidates].sort((a, b) => {
+    const ea = upper(a.canonicalEntityId ?? '');
+    const eb = upper(b.canonicalEntityId ?? '');
+    return ea.localeCompare(eb) || upper(a.ticker).localeCompare(upper(b.ticker));
+  });
+  const out = new Map<string, PortfolioCandidateV2>();
+  const fp = new Map<string, string>();
+  for (const c of sorted) {
+    const entity = upper(c.canonicalEntityId ?? '');
+    if (!entity) return null;
+    const current = fp.get(entity);
+    const next = evidenceFingerprint(c);
+    if (current !== undefined && current !== next) return null;
+    if (!out.has(entity)) out.set(entity, { ...c, ticker: upper(c.ticker), canonicalEntityId: entity });
+    fp.set(entity, next);
+  }
+  return [...out.values()];
+}
+
+function portfolioFingerprint(selectedTickers: string[], optimalN: number | null): string {
+  return stableFingerprint({ optimalN, selectedTickers: [...selectedTickers].map(upper).sort() });
+}
+
+function validateSizing(selected: string[], sizing?: StructuralSizingEvidence): StructuralPublicationState | null {
+  if (!sizing) return 'BLOCKED_SIZING_NOT_IMPLEMENTED';
+  if (sizing.method !== 'COVARIANCE_AWARE' || !sizing.portfolioVolatilityModelHash.trim()) return 'BLOCKED_INVALID_SIZING';
+  const selectedSet = new Set(selected.map(upper));
+  const entries = Object.entries(sizing.weights).map(([t, w]) => [upper(t), w] as const);
+  if (entries.length !== selectedSet.size) return 'BLOCKED_INVALID_SIZING';
+  if (entries.some(([t, w]) => !selectedSet.has(t) || !finite(w) || w < 0)) return 'BLOCKED_INVALID_SIZING';
+  const sum = entries.reduce((a, [, w]) => a + w, 0);
+  if (Math.abs(sum - 1) > 1e-8) return 'BLOCKED_INVALID_SIZING';
+  return null;
+}
+
+function marginalRanking(
+  canonical: PortfolioCandidateV2[],
+  selectedTickers: string[],
+  policy: PortfolioEnginePolicyV2,
+): MarginalRow[] {
+  const byTicker = new Map(canonical.map(c => [upper(c.ticker), c]));
+  const selected = selectedTickers.map(t => byTicker.get(upper(t))).filter(Boolean) as PortfolioCandidateV2[];
+  const selectedSet = new Set(selected.map(c => upper(c.ticker)));
+  const eligible = canonical.filter(c => c.hardGatesPassed && c.falsifierVetoPassed);
+  const baseUtility = selected.length ? evaluatePortfolioSetV2(selected, policy).utility : 0;
+  const outsiders = eligible.filter(c => !selectedSet.has(upper(c.ticker)));
+
+  const rows = eligible.map(c => {
+    const ticker = upper(c.ticker);
+    const isSelected = selectedSet.has(ticker);
+    let deltaUAdd: number;
+    if (isSelected) {
+      const without = selected.filter(x => upper(x.ticker) !== ticker);
+      const withoutUtility = without.length ? evaluatePortfolioSetV2(without, policy).utility : 0;
+      deltaUAdd = baseUtility - withoutUtility;
+    } else {
+      const withCandidate = [...selected, c];
+      deltaUAdd = evaluatePortfolioSetV2(withCandidate, policy).utility - baseUtility;
+    }
+
+    let bestDeltaUSwap: number | null = null;
+    let bestSwapAgainst: string | null = null;
+    if (!isSelected && selected.length) {
+      for (let i = 0; i < selected.length; i++) {
+        const trial = [...selected];
+        const incumbent = upper(trial[i].ticker);
+        trial[i] = c;
+        const delta = evaluatePortfolioSetV2(trial, policy).utility - baseUtility;
+        if (bestDeltaUSwap === null || delta > bestDeltaUSwap + 1e-12 ||
+          (Math.abs(delta - bestDeltaUSwap) <= 1e-12 && incumbent.localeCompare(bestSwapAgainst ?? '') < 0)) {
+          bestDeltaUSwap = delta;
+          bestSwapAgainst = incumbent;
+        }
+      }
+    } else if (isSelected && outsiders.length) {
+      const idx = selected.findIndex(x => upper(x.ticker) === ticker);
+      for (const challenger of outsiders) {
+        const trial = [...selected];
+        trial[idx] = challenger;
+        const delta = evaluatePortfolioSetV2(trial, policy).utility - baseUtility;
+        const challengerTicker = upper(challenger.ticker);
+        if (bestDeltaUSwap === null || delta > bestDeltaUSwap + 1e-12 ||
+          (Math.abs(delta - bestDeltaUSwap) <= 1e-12 && challengerTicker.localeCompare(bestSwapAgainst ?? '') < 0)) {
+          bestDeltaUSwap = delta;
+          bestSwapAgainst = challengerTicker;
+        }
+      }
+    }
+
+    return { ticker, canonicalEntityId: upper(c.canonicalEntityId!), selected: isSelected, deltaUAdd, bestDeltaUSwap, bestSwapAgainst };
+  });
+
+  return rows.sort((a, b) => b.deltaUAdd - a.deltaUAdd || a.ticker.localeCompare(b.ticker));
+}
+
+export function runStructuralPortfolioPublicationGate(req: StructuralPortfolioRunRequest): StructuralPortfolioRun {
+  const repeats = Math.max(2, Math.floor(req.reproducibilityRuns ?? 100));
+  const base = (state: StructuralPublicationState, reason: string): StructuralPortfolioRun => ({
+    publicationState: state, reason, selectedTickers: [], optimalN: null, portfolioHash: null,
+    reproducibilityRuns: repeats, marginalRanking: [], weights: null,
+    globalOptimalityProven: false, searchMode: 'DETERMINISTIC_LOCAL_SEARCH',
+  });
+
+  if (!req.rawUniverseSource.trim() || !req.normalizedUniverseHash.trim() || !req.snapshotHash.trim() || !req.policyHash.trim())
+    return base('BLOCKED_METADATA_MISSING', 'Universe/snapshot/policy provenance is incomplete.');
+
+  const allowed = new Set(req.allowedTickers.map(upper));
+  if (!allowed.size || req.candidates.some(c => !allowed.has(upper(c.ticker))))
+    return base('BLOCKED_UNIVERSE_MISMATCH', 'At least one candidate is outside the canonical universe whitelist.');
+
+  const canonical = canonicalizeEntities(req.candidates);
+  if (!canonical) return base('BLOCKED_CONFLICTING_ENTITY_ROWS', 'Canonical entity IDs are missing or duplicate entity rows disagree on evidence.');
+  if (canonical.length !== req.expectedCanonicalEntityCount)
+    return base('BLOCKED_INCOMPLETE_UNIVERSE_EVIDENCE', `Expected ${req.expectedCanonicalEntityCount} canonical entities but received ${canonical.length}.`);
+
+  const policy = req.policy ?? {};
+  let firstHash: string | null = null;
+  let firstResult: ReturnType<typeof runEndogenousPortfolioEngineV2> | null = null;
+  for (let i = 0; i < repeats; i++) {
+    // Deliberately perturb caller order, then canonicalize again. Same evidence must be order-invariant.
+    const rotated = canonical.slice(i % canonical.length).concat(canonical.slice(0, i % canonical.length));
+    const supplied = i % 2 ? [...rotated].reverse() : rotated;
+    const rerunInput = canonicalizeEntities(supplied)!;
+    const result = runEndogenousPortfolioEngineV2(rerunInput, policy);
+    if (result.status !== 'SELECTED') return base('BLOCKED_ENGINE_PENDING', `Selector returned ${result.status}.`);
+    const hash = portfolioFingerprint(result.selectedTickers, result.optimalN);
+    if (firstHash === null) { firstHash = hash; firstResult = result; }
+    else if (hash !== firstHash) return base('FAIL_NON_DETERMINISTIC_PORTFOLIO_SELECTION', 'Identical evidence produced different portfolio composition/N across order-perturbed reruns.');
+  }
+
+  const result = firstResult!;
+  const sizingState = validateSizing(result.selectedTickers, req.sizing);
+  const ranking = marginalRanking(canonical, result.selectedTickers, policy);
+  if (sizingState) return {
+    publicationState: sizingState,
+    reason: sizingState === 'BLOCKED_SIZING_NOT_IMPLEMENTED'
+      ? 'Selection is reproducible, but structural MAX RETURN / LOW VOL publication is blocked until covariance-aware sizing exists.'
+      : 'Sizing evidence is incomplete or invalid.',
+    selectedTickers: result.selectedTickers,
+    optimalN: result.optimalN,
+    portfolioHash: firstHash,
+    reproducibilityRuns: repeats,
+    marginalRanking: ranking,
+    weights: null,
+    globalOptimalityProven: false,
+    searchMode: 'DETERMINISTIC_LOCAL_SEARCH',
+  };
+
+  return {
+    publicationState: 'CANONICAL_READY',
+    reason: 'Universe, PIT snapshot, deterministic selection, marginal ledger and covariance-aware sizing gates passed.',
+    selectedTickers: result.selectedTickers,
+    optimalN: result.optimalN,
+    portfolioHash: firstHash,
+    reproducibilityRuns: repeats,
+    marginalRanking: ranking,
+    weights: Object.fromEntries(Object.entries(req.sizing!.weights).map(([t, w]) => [upper(t), w])),
+    globalOptimalityProven: false,
+    searchMode: 'DETERMINISTIC_LOCAL_SEARCH',
+  };
+}
+
+export function buildFourSessionEqualWeightExperiment(
+  tickers: string[], totalCapital: number, allowedTickers: string[],
+): FourSessionExperiment {
+  const allowed = new Set(allowedTickers.map(upper));
+  const canonical = [...new Set(tickers.map(upper))].sort();
+  if (!canonical.length || !finite(totalCapital) || totalCapital <= 0 || canonical.some(t => !allowed.has(t)))
+    throw new Error('INVALID_4D_EXPERIMENT_INPUT');
+  return {
+    mode: 'EXPERIMENT_4D_EQUAL_WEIGHT', authority: 'EXPERIMENT_ONLY', tickers: canonical,
+    equalWeight: 1 / canonical.length, amountPerPosition: totalCapital / canonical.length, totalCapital,
+  };
+}


### PR DESCRIPTION
Fixes the same-day portfolio inconsistency bug at the publication boundary.

Key changes:
- hard whitelist gate before selection;
- requires complete canonical-entity PIT matrix;
- deterministic canonicalization independent of caller order;
- default 100-run reproducibility certification;
- emits full marginal DeltaU_add / best DeltaU_swap ledger;
- blocks structural publication while covariance-aware sizing is absent;
- separates EXPERIMENT_4D_EQUAL_WEIGHT as EXPERIMENT_ONLY;
- adds focused CI tests.

This intentionally fails closed rather than inventing a fourth portfolio. globalOptimalityProven remains false.