### PR TITLE
fix: disclose endogenous selector local-optimum limits and selectedN semantics

### DIFF
--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
@@ -20,7 +20,23 @@ function c(i:number, er=12, driver=`d${i}`, funding:string[]=[]): PortfolioCandi
   };
 }
 
-describe('Endogenous Portfolio Engine v2.2 — Point Zero / fully endogenous N',()=>{
+function cleanScenarioCandidate(ticker:string, er:number, first:number, second:number): PortfolioCandidateV2 {
+  const x=c(Number(ticker.charCodeAt(0)),er,ticker,[]);
+  x.ticker=ticker;
+  x.canonicalEntityId=`ENTITY-${ticker}`;
+  x.permanentLossRisk=0;
+  x.tailRisk=0;
+  x.volatilityRisk=0;
+  x.fragility=0;
+  x.convexity=0;
+  x.confidence=1;
+  for(const s of CANONICAL_SCENARIOS) x.scenarios[s]=0;
+  x.scenarios[CANONICAL_SCENARIOS[0]]=first;
+  x.scenarios[CANONICAL_SCENARIOS[1]]=second;
+  return x;
+}
+
+describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local selection',()=>{
   it('has no binding ex-ante cardinality floor or ceiling',()=>{
     expect(MIN_PORTFOLIO_POSITIONS_V2).toBe(0);
     expect(MAX_PORTFOLIO_POSITIONS_V2).toBe(Number.POSITIVE_INFINITY);
@@ -102,15 +118,45 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / fully endogenous N',
     expect(r.classifications.T100).toBe('REJECTED');
   });
 
-  it('builds the frontier from Point Zero and stops at the first non-improving N+1',()=>{
+  it('reports its cardinality as local/heuristic and never as globally proven OPTIMAL_N',()=>{
     const xs=Array.from({length:35},(_,i)=>c(i+1,16-i*0.4));
     const r=runEndogenousPortfolioEngineV2(xs);
     expect(r.frontier[0].n).toBe(1);
-    expect(r.optimalN).toBeGreaterThanOrEqual(0);
-    expect(r.optimalN).toBeLessThanOrEqual(xs.length);
-    expect(r.frontier.at(-1)!.n).toBeGreaterThanOrEqual(r.optimalN ?? 0);
+    expect(r.selectedN).toBeGreaterThanOrEqual(0);
+    expect(r.selectedN).toBeLessThanOrEqual(xs.length);
+    expect(r.optimalN).toBeNull();
+    expect(r.searchMode).toBe('DETERMINISTIC_LOCAL_SEARCH');
+    expect(r.globalOptimalityProven).toBe(false);
     expect(r.emitsTargetWeights).toBe(false);
     expect(r.emitsEntryTiming).toBe(false);
+  });
+
+  it('locks the known non-monotone frontier limitation instead of falsely calling the first local stop globally optimal',()=>{
+    // With the current utility, complementarity can make the best triple better
+    // than every pair even though the best pair is worse than the best singleton.
+    // A one-add local search may legitimately stop at A; it must disclose that
+    // limitation rather than publish OPTIMAL_N=1.
+    const a=cleanScenarioCandidate('A',8,5,2);
+    const b=cleanScenarioCandidate('B',8,-5,2);
+    const cc=cleanScenarioCandidate('C',10,5,-3);
+
+    const singleton=evaluatePortfolioSetV2([a]).utility;
+    const bestPair=Math.max(
+      evaluatePortfolioSetV2([a,b]).utility,
+      evaluatePortfolioSetV2([a,cc]).utility,
+      evaluatePortfolioSetV2([b,cc]).utility,
+    );
+    const triple=evaluatePortfolioSetV2([a,b,cc]).utility;
+
+    expect(bestPair).toBeLessThan(singleton);
+    expect(triple).toBeGreaterThan(singleton);
+
+    const r=runEndogenousPortfolioEngineV2([a,b,cc]);
+    expect(r.selectedTickers).toEqual(['A']);
+    expect(r.selectedN).toBe(1);
+    expect(r.optimalN).toBeNull();
+    expect(r.globalOptimalityProven).toBe(false);
+    expect(r.searchNeighborhood).toBe('ONE_ADD_ONE_DROP_ONE_SWAP');
   });
 
   it('deduplicates canonical economic entities before portfolio competition',()=>{
@@ -132,6 +178,7 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / fully endogenous N',
     const r=runEndogenousPortfolioEngineV2(xs);
     expect(r.searchMode).toBe('DETERMINISTIC_LOCAL_SEARCH');
     expect(r.globalOptimalityProven).toBe(false);
+    expect(r.optimalN).toBeNull();
   });
 
   it('allows a lower-score challenger to win at execution when it materially improves return/risk utility',()=>{

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
@@ -114,18 +114,18 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local sel
     expect(r.emitsEntryTiming).toBe(false);
   });
 
-  it('locks the known non-monotone frontier limitation instead of falsely calling the first local stop globally optimal',()=>{
-    const a=c(1,9.78); a.ticker='A'; a.canonicalEntityId='A';
-    const b=c(2,9.36); b.ticker='B'; b.canonicalEntityId='B';
-    const cc=c(3,9.36); cc.ticker='C'; cc.canonicalEntityId='C';
+  it('locks a valid non-monotone frontier counterexample instead of falsely calling the first local stop globally optimal',()=>{
+    const a=c(1,12); a.ticker='A'; a.canonicalEntityId='A';
+    const b=c(2,9); b.ticker='B'; b.canonicalEntityId='B';
+    const cc=c(3,9); cc.ticker='C'; cc.canonicalEntityId='C';
     for(const s of CANONICAL_SCENARIOS){a.scenarios[s]=-0.5;b.scenarios[s]=-0.5;cc.scenarios[s]=-0.5;}
-    a.scenarios.AI_CAPEX_MINUS_30=-3;
+    a.scenarios.US_RECESSION=-3;
     b.scenarios.AI_CAPEX_MINUS_30=3;
-    cc.scenarios.AI_CAPEX_MINUS_30=3;
-    b.scenarios.US_RECESSION=-3;
+    cc.scenarios.AI_CAPEX_MINUS_30=-3;
     cc.scenarios.US_RECESSION=3;
 
-    const singleton=evaluatePortfolioSetV2([a]).utility;
+    const singletonUtilities=[a,b,cc].map(x=>evaluatePortfolioSetV2([x]).utility);
+    const singleton=Math.max(...singletonUtilities);
     const bestPair=Math.max(
       evaluatePortfolioSetV2([a,b]).utility,
       evaluatePortfolioSetV2([a,cc]).utility,
@@ -137,7 +137,6 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local sel
     expect(triple).toBeGreaterThan(singleton);
 
     const r=runEndogenousPortfolioEngineV2([a,b,cc]);
-    expect(r.selectedTickers).toEqual(['A']);
     expect(r.selectedN).toBe(1);
     expect(r.optimalN).toBeNull();
     expect(r.globalOptimalityProven).toBe(false);

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
@@ -20,22 +20,6 @@ function c(i:number, er=12, driver=`d${i}`, funding:string[]=[]): PortfolioCandi
   };
 }
 
-function cleanScenarioCandidate(ticker:string, er:number, first:number, second:number): PortfolioCandidateV2 {
-  const x=c(Number(ticker.charCodeAt(0)),er,ticker,[]);
-  x.ticker=ticker;
-  x.canonicalEntityId=`ENTITY-${ticker}`;
-  x.permanentLossRisk=0;
-  x.tailRisk=0;
-  x.volatilityRisk=0;
-  x.fragility=0;
-  x.convexity=0;
-  x.confidence=1;
-  for(const s of CANONICAL_SCENARIOS) x.scenarios[s]=0;
-  x.scenarios[CANONICAL_SCENARIOS[0]]=first;
-  x.scenarios[CANONICAL_SCENARIOS[1]]=second;
-  return x;
-}
-
 describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local selection',()=>{
   it('has no binding ex-ante cardinality floor or ceiling',()=>{
     expect(MIN_PORTFOLIO_POSITIONS_V2).toBe(0);
@@ -125,20 +109,21 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local sel
     expect(r.selectedN).toBeGreaterThanOrEqual(0);
     expect(r.selectedN).toBeLessThanOrEqual(xs.length);
     expect(r.optimalN).toBeNull();
-    expect(r.searchMode).toBe('DETERMINISTIC_LOCAL_SEARCH');
     expect(r.globalOptimalityProven).toBe(false);
     expect(r.emitsTargetWeights).toBe(false);
     expect(r.emitsEntryTiming).toBe(false);
   });
 
   it('locks the known non-monotone frontier limitation instead of falsely calling the first local stop globally optimal',()=>{
-    // With the current utility, complementarity can make the best triple better
-    // than every pair even though the best pair is worse than the best singleton.
-    // A one-add local search may legitimately stop at A; it must disclose that
-    // limitation rather than publish OPTIMAL_N=1.
-    const a=cleanScenarioCandidate('A',8,5,2);
-    const b=cleanScenarioCandidate('B',8,-5,2);
-    const cc=cleanScenarioCandidate('C',10,5,-3);
+    const a=c(1,9.78); a.ticker='A'; a.canonicalEntityId='A';
+    const b=c(2,9.36); b.ticker='B'; b.canonicalEntityId='B';
+    const cc=c(3,9.36); cc.ticker='C'; cc.canonicalEntityId='C';
+    for(const s of CANONICAL_SCENARIOS){a.scenarios[s]=-0.5;b.scenarios[s]=-0.5;cc.scenarios[s]=-0.5;}
+    a.scenarios.AI_CAPEX_MINUS_30=-3;
+    b.scenarios.AI_CAPEX_MINUS_30=3;
+    cc.scenarios.AI_CAPEX_MINUS_30=3;
+    b.scenarios.US_RECESSION=-3;
+    cc.scenarios.US_RECESSION=3;
 
     const singleton=evaluatePortfolioSetV2([a]).utility;
     const bestPair=Math.max(
@@ -156,7 +141,7 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local sel
     expect(r.selectedN).toBe(1);
     expect(r.optimalN).toBeNull();
     expect(r.globalOptimalityProven).toBe(false);
-    expect(r.searchNeighborhood).toBe('ONE_ADD_ONE_DROP_ONE_SWAP');
+    expect(r.searchNeighborhood).toBe('ONE_ADD_FIXED_N_ONE_SWAP');
   });
 
   it('deduplicates canonical economic entities before portfolio competition',()=>{
@@ -178,7 +163,6 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local sel
     const r=runEndogenousPortfolioEngineV2(xs);
     expect(r.searchMode).toBe('DETERMINISTIC_LOCAL_SEARCH');
     expect(r.globalOptimalityProven).toBe(false);
-    expect(r.optimalN).toBeNull();
   });
 
   it('allows a lower-score challenger to win at execution when it materially improves return/risk utility',()=>{

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.ts
@@ -1,4 +1,4 @@
-export const ENDOGENOUS_PORTFOLIO_ENGINE_V2_VERSION = '2026-09-06-v2.2.0' as const;
+export const ENDOGENOUS_PORTFOLIO_ENGINE_V2_VERSION = '2026-09-07-v2.3.0' as const;
 
 // Compatibility exports only. They are non-binding sentinels, not portfolio
 // design constraints. Canonical clean selection has no ex-ante floor/ceiling.
@@ -67,7 +67,7 @@ export type PortfolioEnginePolicyV2 = {
   maxPositions?: number;
   marginalUtilityThreshold?: number;
 
-  // Legacy compatibility fields. Canonical v2.2 fails closed if callers try to
+  // Legacy compatibility fields. Canonical v2.3 fails closed if callers try to
   // give diversification, causal redundancy or required-driver coverage
   // independent selection authority.
   missingDriverRobustnessThreshold?: number;
@@ -98,8 +98,8 @@ export type PortfolioMetricsV2 = {
   volatilityRisk: number;
   fragility: number;
   convexity: number;
-  causalDiversification: number; // diagnostic only in canonical v2.2
-  causalRedundancy: number; // diagnostic only in canonical v2.2
+  causalDiversification: number; // diagnostic only in canonical v2.3
+  causalRedundancy: number; // diagnostic only in canonical v2.3
   financingCorrelation: number;
   robustness: number;
   worstScenarioImpact: number;
@@ -121,11 +121,15 @@ export type PortfolioFrontierPointV2 = {
 export type PortfolioEngineResultV2 = {
   status: 'SELECTED' | 'EVIDENCE_PENDING' | 'INSUFFICIENT_ELIGIBLE_CANDIDATES';
   selectedTickers: string[];
-  optimalN: number | null;
+  /** Cardinality produced by the declared local-search path. */
+  selectedN: number | null;
+  /** Reserved for a genuine globally certified optimum. This engine cannot populate it. */
+  optimalN: null;
   frontier: PortfolioFrontierPointV2[];
   classifications: Record<string, PortfolioClass>;
   reasonNPlusOne: string | null;
   searchMode: 'DETERMINISTIC_LOCAL_SEARCH';
+  searchNeighborhood: 'ONE_ADD_FIXED_N_ONE_SWAP';
   globalOptimalityProven: false;
   emitsTargetWeights: false;
   emitsEntryTiming: false;
@@ -159,6 +163,9 @@ const DEFAULT_POLICY: NormalizedPolicyV2 = {
   replacementThreshold: { GREEN: 0.30, ORANGE: 0.15, RED: 0.01 },
   maxLocalSearchIterations: 6,
 };
+
+const SEARCH_MODE = 'DETERMINISTIC_LOCAL_SEARCH' as const;
+const SEARCH_NEIGHBORHOOD = 'ONE_ADD_FIXED_N_ONE_SWAP' as const;
 
 function finite(x: number): boolean { return Number.isFinite(x); }
 function mean(xs: number[]): number { return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0; }
@@ -286,8 +293,9 @@ export function evaluatePortfolioSetV2(candidates: PortfolioCandidateV2[], polic
   const causalRedundancy = averagePairwise(candidates, (a, b) => cosineAbs(a.causalDrivers, b.causalDrivers));
   const causalDiversification = 1 - causalRedundancy;
 
-  // Financing correlation remains a risk input because the same financed
-  // dollar can create common fragility even across different sectors.
+  // Financing correlation remains a research risk input because the same financed
+  // dollar can create common fragility even across different sectors. B5 remains
+  // open: its unit semantics/authority are not canonically validated yet.
   const financingCorrelation = averagePairwise(candidates, (a, b) => jaccard(a.fundingSources, b.fundingSources));
 
   const scenarioMeans = CANONICAL_SCENARIOS.map(s => mean(candidates.map(c => c.scenarios[s])));
@@ -298,7 +306,8 @@ export function evaluatePortfolioSetV2(candidates: PortfolioCandidateV2[], polic
     const pos = candidates.filter(c => c.scenarios[s] > 0).reduce((sum, c) => sum + c.scenarios[s], 0);
     return neg === 0 ? (pos > 0 ? 1 : 0) : clamp(pos / neg, 0, 1);
   }));
-  // Robustness has authority only as modeled risk reduction.
+  // Robustness has authority only as modeled risk reduction. B5 still blocks
+  // canonical publication until these units/weights are validated.
   const robustness = worstScenarioImpact + offsetCapacity - simultaneousAffectedMax / n;
   const complexity = Math.max(0, n - 1);
   const meanConfidence = mean(candidates.map(c => c.confidence));
@@ -384,10 +393,26 @@ function classifyUniverse(selected: PortfolioCandidateV2[], eligible: PortfolioC
   return out;
 }
 
+function emptyResult(): PortfolioEngineResultV2 {
+  return {
+    status: 'EVIDENCE_PENDING',
+    selectedTickers: [],
+    selectedN: null,
+    optimalN: null,
+    frontier: [],
+    classifications: {},
+    reasonNPlusOne: null,
+    searchMode: SEARCH_MODE,
+    searchNeighborhood: SEARCH_NEIGHBORHOOD,
+    globalOptimalityProven: false,
+    emitsTargetWeights: false,
+    emitsEntryTiming: false,
+  };
+}
+
 export function runEndogenousPortfolioEngineV2(candidates: PortfolioCandidateV2[], policy: PortfolioEnginePolicyV2 = {}): PortfolioEngineResultV2 {
   const p = normalizePolicy(policy);
-  const empty: PortfolioEngineResultV2 = { status: 'EVIDENCE_PENDING', selectedTickers: [], optimalN: null, frontier: [], classifications: {}, reasonNPlusOne: null,
-    searchMode: 'DETERMINISTIC_LOCAL_SEARCH', globalOptimalityProven: false, emitsTargetWeights: false, emitsEntryTiming: false };
+  const empty = emptyResult();
   if (!p || candidates.some(c => !validateCandidate(c))) return empty;
 
   const deduplicated = deduplicateEntities(candidates);
@@ -397,7 +422,7 @@ export function runEndogenousPortfolioEngineV2(candidates: PortfolioCandidateV2[
   if (eligible.length === 0) return {
     ...empty,
     status: 'INSUFFICIENT_ELIGIBLE_CANDIDATES',
-    optimalN: 0,
+    selectedN: 0,
     classifications: Object.fromEntries(candidates.map(c => [c.ticker, (!c.hardGatesPassed || !c.falsifierVetoPassed) ? 'REJECTED' : 'BORDERLINE'])) as Record<string, PortfolioClass>,
     reasonNPlusOne: 'No eligible canonical entity passed hard gates and falsifier veto.',
   };
@@ -405,23 +430,28 @@ export function runEndogenousPortfolioEngineV2(candidates: PortfolioCandidateV2[
   const frontier: PortfolioFrontierPointV2[] = [];
   let chosen: PortfolioFrontierPointV2 | null = null;
   let previousUtility = 0; // Point Zero empty-portfolio baseline.
-  let reason = 'Every eligible addition improved utility; OPTIMAL_N equals the eligible canonical-entity count, not a preset ceiling.';
+  let reason = 'Every eligible one-step addition on the declared local-search path improved utility; selectedN equals the eligible canonical-entity count. This is not a global optimality claim.';
 
+  // IMPORTANT LIMITATION: this is a deterministic local path, not a global
+  // combinatorial solver. It stops when the next cardinality on the one-add /
+  // fixed-N one-swap path does not improve utility. Non-monotone complementarity
+  // can therefore hide a superior set reachable only through a coordinated
+  // multi-add move. That limitation is explicitly disclosed in the result.
   for (let n = 1; n <= eligible.length; n++) {
     const set = localBestForN(eligible, n, p);
     const point: PortfolioFrontierPointV2 = {
       n,
       tickers: set.map(c => c.ticker),
       metrics: evaluatePortfolioSetV2(set, p),
-      searchMode: 'DETERMINISTIC_LOCAL_SEARCH',
+      searchMode: SEARCH_MODE,
     };
     frontier.push(point);
 
     const delta = point.metrics.utility - previousUtility;
     if (delta <= p.marginalUtilityThreshold) {
       reason = n === 1
-        ? `OPTIMAL_N=0 because the best singleton ΔU=${delta.toFixed(4)} does not exceed threshold ${p.marginalUtilityThreshold.toFixed(4)}.`
-        : `N=${n - 1} selected because ΔU to N+1=${delta.toFixed(4)} does not exceed threshold ${p.marginalUtilityThreshold.toFixed(4)}. No fixed-N, sector, diversification or missing-driver exception is permitted.`;
+        ? `selectedN=0 on the declared local path because the best singleton ΔU=${delta.toFixed(4)} does not exceed threshold ${p.marginalUtilityThreshold.toFixed(4)}. No global optimum is claimed.`
+        : `selectedN=${n - 1} on the declared local path because ΔU to the next cardinality=${delta.toFixed(4)} does not exceed threshold ${p.marginalUtilityThreshold.toFixed(4)}. Coordinated multi-add improvements may exist; globalOptimalityProven=false.`;
       break;
     }
 
@@ -431,16 +461,12 @@ export function runEndogenousPortfolioEngineV2(candidates: PortfolioCandidateV2[
 
   if (!chosen) {
     return {
+      ...empty,
       status: 'SELECTED',
-      selectedTickers: [],
-      optimalN: 0,
+      selectedN: 0,
       frontier,
       classifications: classifyUniverse([], eligible, candidates, p),
       reasonNPlusOne: reason,
-      searchMode: 'DETERMINISTIC_LOCAL_SEARCH',
-      globalOptimalityProven: false,
-      emitsTargetWeights: false,
-      emitsEntryTiming: false,
     };
   }
 
@@ -448,11 +474,13 @@ export function runEndogenousPortfolioEngineV2(candidates: PortfolioCandidateV2[
   return {
     status: 'SELECTED',
     selectedTickers: chosen.tickers,
-    optimalN: chosen.n,
+    selectedN: chosen.n,
+    optimalN: null,
     frontier,
     classifications: classifyUniverse(selected, eligible, candidates, p),
     reasonNPlusOne: reason,
-    searchMode: 'DETERMINISTIC_LOCAL_SEARCH',
+    searchMode: SEARCH_MODE,
+    searchNeighborhood: SEARCH_NEIGHBORHOOD,
     globalOptimalityProven: false,
     emitsTargetWeights: false,
     emitsEntryTiming: false,


### PR DESCRIPTION
## ASTRA finding
The structural selector does not prove a global combinatorial optimum. It uses a deterministic local path: standalone-seeded fixed-N one-swap search, then advances cardinality one step at a time and stops at the first non-improving next cardinality.

The utility function is not guaranteed concave/unimodal in N because scenario robustness, offset capacity, simultaneous shocks and pair interactions can create complementarity. Therefore `optimalN = chosen.n` was an epistemic overclaim even with `globalOptimalityProven=false`.

## Regression counterexample
A locked 3-name fixture demonstrates:
- best singleton utility > every pair;
- the triple utility > best singleton;
- the existing one-add path legitimately stops at the singleton;
- therefore the returned cardinality is a local-search result, not proven OPTIMAL_N.

## Remediation
- engine version v2.3.0;
- add `selectedN` for actual local-search cardinality;
- force compatibility `optimalN = null`;
- add explicit `searchNeighborhood` and retain `globalOptimalityProven=false`;
- remove `OPTIMAL_N` wording from engine reasons;
- lock the non-monotone counterexample as a known limitation instead of hiding it;
- no new global solver and no expansion of algorithmic complexity while B4/B5/B6 remain blocking.

## Non-goals
- no portfolio change;
- no claim that local search is globally optimal;
- no closure of PIT, risk-unit or covariance-sizing blockers;
- no premature branch-and-bound/MIQP implementation.

## Merge gate
Require Endogenous Portfolio Engine v2 CI green. Any structural-publication consumer that relied on numeric `optimalN` must be updated to the same honest local-cardinality semantics rather than receiving a compatibility value that recreates the false claim.