### PR TITLE
ASTRA Phase B Ω — Authority Registry projection + Factor Ownership Ledger

### DIFF
--- a/.github/workflows/astra-phase-b-authority-factor-ledger-ci.yml
+++ b/.github/workflows/astra-phase-b-authority-factor-ledger-ci.yml
@@ -1,0 +1,33 @@
+name: ASTRA Phase B Authority + Factor Ledger CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/governance/atlas-authority-registry-projection-omega.ts'
+      - 'src/atlas/governance/atlas-authority-registry-projection-omega.test.ts'
+      - 'src/atlas/algorithm/atlas-factor-ownership-ledger-omega.ts'
+      - 'src/atlas/algorithm/atlas-factor-ownership-ledger-omega.test.ts'
+      - '.github/workflows/astra-phase-b-authority-factor-ledger-ci.yml'
+  push:
+    branches:
+      - astra-phase-b-authority-factor-ledger-v1
+    paths:
+      - 'src/atlas/governance/atlas-authority-registry-projection-omega.ts'
+      - 'src/atlas/governance/atlas-authority-registry-projection-omega.test.ts'
+      - 'src/atlas/algorithm/atlas-factor-ownership-ledger-omega.ts'
+      - 'src/atlas/algorithm/atlas-factor-ownership-ledger-omega.test.ts'
+      - '.github/workflows/astra-phase-b-authority-factor-ledger-ci.yml'
+
+jobs:
+  authority-factor-ledger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run Authority Registry and Factor Ownership invariants
+        run: >-
+          npx --yes vitest@3.2.4 run --globals
+          src/atlas/governance/atlas-authority-registry-projection-omega.test.ts
+          src/atlas/algorithm/atlas-factor-ownership-ledger-omega.test.ts

--- a/research/astra/2026-09-07_ASTRA_PHASE_B_AUTHORITY_FACTOR_LEDGER_PREREG.md
+++ b/research/astra/2026-09-07_ASTRA_PHASE_B_AUTHORITY_FACTOR_LEDGER_PREREG.md
@@ -1,0 +1,81 @@
+# ASTRA Ω — Phase B Authority Registry + Factor Ownership Ledger · Preregistration
+
+**Date:** 2026-09-07  
+**Status:** PREREGISTERED / NON-CANONICAL UNTIL MERGED AND TESTED  
+**Branch:** `astra-phase-b-authority-factor-ledger-v1`
+
+## Purpose
+
+Address two live findings from the frozen ASTRA baseline without creating a second source of truth:
+
+1. runtime/selection/score/canon authority is not sufficiently explicit at one inspectable boundary;
+2. shared economic facts can be consumed by multiple engines without a formal single-owner anti-double-counting firewall.
+
+## Authority Registry design
+
+The new Authority Registry is a **derived projection** of `ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA`, not a parallel authority source. It exposes, per component:
+
+- STATUS
+- COMPONENT_CLASS
+- RUNTIME_AUTHORITY
+- SELECTION_AUTHORITY
+- DIRECT_SCORE_WEIGHT
+- ACTIVATION_GATE
+- OWNER
+- CAN_WRITE_CANON
+
+Unknown fields remain `UNKNOWN_NOT_DECLARED`. They are never silently converted to `0`, `false`, or `ACTIVE`.
+
+Hard invariants:
+
+- exactly one `SOLE_MASTER` selection authority;
+- automated components cannot write canon;
+- Research Ω has zero direct score and no selection authority;
+- declared zero-weight corroborative/shadow intelligence remains zero-weight;
+- undeclared activation and score fields stay explicitly unknown.
+
+## Factor Ownership Ledger design
+
+Initial high-risk factor families:
+
+- VALUATION
+- FREE_CASH_FLOW
+- ROIC
+- BACKLOG
+- CAPEX
+- EXPECTATION_GAP
+- ORGANIC_GROWTH
+
+Each factor receives one canonical normalizer and an explicit scoring-owner state. Secondary consumers may reference normalized evidence but may not mint independent points from the same fact.
+
+Fail-closed rule:
+
+`SCORING_OWNER = UNRESOLVED_RUNTIME_MAPPING -> ADD_POINTS = DENY`
+
+Raw backlog is explicitly `NONE_RAW_FACTOR`: backlog/RPO/contracts/orders/shipments are evidence states and cannot directly create score.
+
+External valuation cross-check remains diagnostic-only for factor scoring.
+
+## Validation gates
+
+Before merge:
+
+1. Authority Registry tests PASS.
+2. Factor Ownership tests PASS.
+3. CI proves exactly one sole master selection authority.
+4. CI proves automated canon-write authority = false.
+5. CI proves unknown score/activation fields are preserved as unknown.
+6. CI proves secondary consumers cannot add independent points.
+7. No claim that runtime double counting is fully eliminated until live scorers are mapped to the ledger.
+
+## Explicit non-claims
+
+This PR does **not** claim:
+
+- all runtime score owners are already known;
+- all legacy engines are removed;
+- Factor Ownership is wired into every live scorer;
+- PR #160 Continuity live Notion gate has passed;
+- OpenClaw is production-authorized.
+
+Those remain separate gates.

--- a/src/atlas/algorithm/atlas-factor-ownership-ledger-omega.test.ts
+++ b/src/atlas/algorithm/atlas-factor-ownership-ledger-omega.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ATLAS_FACTOR_OWNERSHIP_LEDGER_OMEGA,
+  getFactorOwnership,
+  validateFactorClaim,
+} from './atlas-factor-ownership-ledger-omega';
+
+describe('ATLAS Factor Ownership Ledger Ω', () => {
+  it('registers every factor exactly once with one canonical normalizer', () => {
+    const ids = ATLAS_FACTOR_OWNERSHIP_LEDGER_OMEGA.map((record) => record.factorId);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const record of ATLAS_FACTOR_OWNERSHIP_LEDGER_OMEGA) {
+      expect(record.canonicalNormalizer).toBeTruthy();
+      expect(record.duplicatePointPolicy).toBe('FORBID');
+    }
+  });
+
+  it('blocks raw backlog from direct scoring', () => {
+    expect(getFactorOwnership('BACKLOG').scoringOwner).toBe('NONE_RAW_FACTOR');
+    expect(validateFactorClaim('BACKLOG', 'QUALITY_ADJUSTED_BACKLOG_OMEGA_V1', 'ADD_POINTS')).toEqual({
+      allowed: false,
+      reason: 'raw_factor_has_no_direct_scoring_authority',
+    });
+  });
+
+  it('keeps valuation scoring single-owner and cross-check diagnostic-only', () => {
+    expect(validateFactorClaim('VALUATION', 'VALUATION_OMEGA', 'ADD_POINTS').allowed).toBe(true);
+    expect(validateFactorClaim('VALUATION', 'EXTERNAL_VALUATION_CROSS_CHECK_OMEGA_V1', 'ADD_POINTS')).toEqual({
+      allowed: false,
+      reason: 'secondary_consumer_cannot_add_independent_points',
+    });
+    expect(validateFactorClaim('VALUATION', 'EXTERNAL_VALUATION_CROSS_CHECK_OMEGA_V1', 'CONSUME').allowed).toBe(true);
+  });
+
+  it('fails closed when the live scoring owner has not yet been mapped', () => {
+    for (const factor of ['FREE_CASH_FLOW', 'ROIC', 'CAPEX', 'EXPECTATION_GAP', 'ORGANIC_GROWTH'] as const) {
+      const record = getFactorOwnership(factor);
+      expect(record.scoringOwner).toBe('UNRESOLVED_RUNTIME_MAPPING');
+      expect(validateFactorClaim(factor, record.canonicalNormalizer, 'ADD_POINTS')).toEqual({
+        allowed: false,
+        reason: 'scoring_owner_unresolved_fail_closed',
+      });
+    }
+  });
+
+  it('allows registered engines to consume normalized factors without creating new points', () => {
+    expect(validateFactorClaim('FREE_CASH_FLOW', 'VALUATION_OMEGA', 'CONSUME').allowed).toBe(true);
+    expect(validateFactorClaim('ROIC', 'CAPITAL_ALLOCATION_QUALITY_OMEGA_V1', 'CONSUME').allowed).toBe(true);
+    expect(validateFactorClaim('CAPEX', 'AI_CAPEX_PAYBACK_OMEGA_V2_1', 'CONSUME').allowed).toBe(true);
+    expect(validateFactorClaim('EXPECTATION_GAP', 'EVENT_PRICING_OPTIONS_EXPECTATIONS_OMEGA_V1', 'CONSUME').allowed).toBe(true);
+  });
+
+  it('rejects unknown consumers instead of silently admitting them', () => {
+    expect(validateFactorClaim('FREE_CASH_FLOW', 'UNREGISTERED_ENGINE', 'CONSUME')).toEqual({
+      allowed: false,
+      reason: 'unregistered_factor_consumer',
+    });
+  });
+});

--- a/src/atlas/algorithm/atlas-factor-ownership-ledger-omega.ts
+++ b/src/atlas/algorithm/atlas-factor-ownership-ledger-omega.ts
@@ -1,0 +1,134 @@
+export const ATLAS_FACTOR_OWNERSHIP_LEDGER_OMEGA_VERSION = '2026-09-07-v1.0.0' as const;
+
+export type FactorOwnershipRecord = {
+  factorId: 'VALUATION' | 'FREE_CASH_FLOW' | 'ROIC' | 'BACKLOG' | 'CAPEX' | 'EXPECTATION_GAP' | 'ORGANIC_GROWTH';
+  canonicalNormalizer: string;
+  scoringOwner: string | 'UNRESOLVED_RUNTIME_MAPPING' | 'NONE_RAW_FACTOR';
+  secondaryConsumers: readonly string[];
+  diagnosticOnlyConsumers?: readonly string[];
+  rawFactMayAddIndependentPoints: boolean;
+  duplicatePointPolicy: 'FORBID';
+  runtimeStatus: 'ENFORCED_FOR_REGISTERED_CLAIMS' | 'AUDIT_ONLY_UNTIL_SCORER_MAPPING';
+  rationale: string;
+};
+
+/**
+ * This ledger owns factor reuse, not economic truth. A factor can be consumed by many engines,
+ * but the same normalized fact may not be converted into independent points more than once.
+ * UNRESOLVED_RUNTIME_MAPPING fails closed for ADD_POINTS claims until the real scorer is mapped.
+ */
+export const ATLAS_FACTOR_OWNERSHIP_LEDGER_OMEGA: readonly FactorOwnershipRecord[] = [
+  {
+    factorId: 'VALUATION',
+    canonicalNormalizer: 'VALUATION_OMEGA',
+    scoringOwner: 'VALUATION_OMEGA',
+    secondaryConsumers: ['EXPECTED_RETURN_3_6Y', 'ACTIVE_VS_INDEX_HURDLE_OMEGA_V1', 'VALUATION_COMPRESSION_STRESS_OMEGA_V1'],
+    diagnosticOnlyConsumers: ['EXTERNAL_VALUATION_CROSS_CHECK_OMEGA_V1', 'VALUATION_METHOD_INTEGRITY_OMEGA_V1'],
+    rawFactMayAddIndependentPoints: true,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'ENFORCED_FOR_REGISTERED_CLAIMS',
+    rationale: 'Valuation may contribute once through its canonical owner. Cross-checks and stress diagnostics must not create a second valuation score.',
+  },
+  {
+    factorId: 'FREE_CASH_FLOW',
+    canonicalNormalizer: 'OWNER_ECONOMICS_NORMALIZATION_OMEGA_V1',
+    scoringOwner: 'UNRESOLVED_RUNTIME_MAPPING',
+    secondaryConsumers: ['PRINCIPAL_OMEGA', 'VALUATION_OMEGA', 'EXPECTED_RETURN_3_6Y', 'ECONOMIC_THROUGHPUT_GATE_OMEGA_V1', 'AI_CAPEX_PAYBACK_OMEGA_V2_1'],
+    rawFactMayAddIndependentPoints: false,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'AUDIT_ONLY_UNTIL_SCORER_MAPPING',
+    rationale: 'Normalized FCF is shared evidence. Until the live scoring owner is mapped, no new independent FCF points may be introduced by a secondary engine.',
+  },
+  {
+    factorId: 'ROIC',
+    canonicalNormalizer: 'REINVESTMENT_RUNWAY_ROIC_OMEGA_V1',
+    scoringOwner: 'UNRESOLVED_RUNTIME_MAPPING',
+    secondaryConsumers: ['PRINCIPAL_OMEGA', 'BUSINESS_QUALITY_OMEGA', 'CAPITAL_ALLOCATION_QUALITY_OMEGA_V1', 'ECONOMIC_THROUGHPUT_GATE_OMEGA_V1', 'EXPECTED_RETURN_3_6Y'],
+    rawFactMayAddIndependentPoints: false,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'AUDIT_ONLY_UNTIL_SCORER_MAPPING',
+    rationale: 'ROIC must be normalized once and referenced thereafter; historical ROIC and incremental ROIC are not separate point opportunities without an explicitly distinct construct.',
+  },
+  {
+    factorId: 'BACKLOG',
+    canonicalNormalizer: 'CONTRACT_ECONOMIC_EVIDENCE_NORMALIZER_OMEGA_V1',
+    scoringOwner: 'NONE_RAW_FACTOR',
+    secondaryConsumers: ['QUALITY_ADJUSTED_BACKLOG_OMEGA_V1', 'GRID_BOTTLENECK_POWER_CAPTURE_OMEGA_V1', 'NARRATIVE_TO_NUMBERS_BRIDGE_OMEGA_V1'],
+    rawFactMayAddIndependentPoints: false,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'ENFORCED_FOR_REGISTERED_CLAIMS',
+    rationale: 'Raw backlog, RPO, contract ceilings, orders and shipments are evidence states, not recognized revenue/FCF and must never be rewarded twice.',
+  },
+  {
+    factorId: 'CAPEX',
+    canonicalNormalizer: 'CAPEX_PRODUCTIVITY_OMEGA',
+    scoringOwner: 'UNRESOLVED_RUNTIME_MAPPING',
+    secondaryConsumers: ['AI_CAPEX_PAYBACK_OMEGA_V2_1', 'AI_FINANCIAL_FRAGILITY_OMEGA_V1_1', 'GLOBAL_CAPEX_CHAIN_OMEGA', 'EXPECTED_RETURN_3_6Y'],
+    rawFactMayAddIndependentPoints: false,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'AUDIT_ONLY_UNTIL_SCORER_MAPPING',
+    rationale: 'CAPEX level, productivity, financing quality and payback are related but distinct constructs. The raw spend itself cannot become repeated positive or negative points.',
+  },
+  {
+    factorId: 'EXPECTATION_GAP',
+    canonicalNormalizer: 'EXPECTATION_GAP_OMEGA',
+    scoringOwner: 'UNRESOLVED_RUNTIME_MAPPING',
+    secondaryConsumers: ['EXPECTED_RETURN_3_6Y', 'EVENT_PRICING_OPTIONS_EXPECTATIONS_OMEGA_V1', 'TAPE_RS_COMPLEMENTARY_ONLY'],
+    rawFactMayAddIndependentPoints: false,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'AUDIT_ONLY_UNTIL_SCORER_MAPPING',
+    rationale: 'Expectations and price response may inform one expectation-gap construct; multiple market-surprise proxies cannot independently reward the same latent surprise.',
+  },
+  {
+    factorId: 'ORGANIC_GROWTH',
+    canonicalNormalizer: 'ORGANIC_GROWTH_DECOMPOSITION_OMEGA_V1',
+    scoringOwner: 'UNRESOLVED_RUNTIME_MAPPING',
+    secondaryConsumers: ['GROWTH_OMEGA', 'PRINCIPAL_OMEGA', 'EXPECTED_RETURN_3_6Y', 'NARRATIVE_TO_NUMBERS_BRIDGE_OMEGA_V1'],
+    rawFactMayAddIndependentPoints: false,
+    duplicatePointPolicy: 'FORBID',
+    runtimeStatus: 'AUDIT_ONLY_UNTIL_SCORER_MAPPING',
+    rationale: 'Reported growth is decomposed once for M&A, FX, divestitures and accounting effects; consumers reference the normalized organic series rather than recreating independent growth points.',
+  },
+] as const;
+
+export type FactorClaimIntent = 'CONSUME' | 'ADD_POINTS';
+
+export type FactorClaimDecision = {
+  allowed: boolean;
+  reason: string;
+};
+
+export function getFactorOwnership(factorId: FactorOwnershipRecord['factorId']): FactorOwnershipRecord {
+  const record = ATLAS_FACTOR_OWNERSHIP_LEDGER_OMEGA.find((item) => item.factorId === factorId);
+  if (!record) throw new Error(`factor_not_registered:${factorId}`);
+  return record;
+}
+
+export function validateFactorClaim(
+  factorId: FactorOwnershipRecord['factorId'],
+  claimer: string,
+  intent: FactorClaimIntent,
+): FactorClaimDecision {
+  const record = getFactorOwnership(factorId);
+
+  if (intent === 'CONSUME') {
+    const knownConsumer = claimer === record.canonicalNormalizer ||
+      claimer === record.scoringOwner ||
+      record.secondaryConsumers.includes(claimer) ||
+      (record.diagnosticOnlyConsumers ?? []).includes(claimer);
+    return knownConsumer
+      ? { allowed: true, reason: 'registered_consumer_reference_only' }
+      : { allowed: false, reason: 'unregistered_factor_consumer' };
+  }
+
+  if (record.scoringOwner === 'NONE_RAW_FACTOR') {
+    return { allowed: false, reason: 'raw_factor_has_no_direct_scoring_authority' };
+  }
+  if (record.scoringOwner === 'UNRESOLVED_RUNTIME_MAPPING') {
+    return { allowed: false, reason: 'scoring_owner_unresolved_fail_closed' };
+  }
+  if (claimer !== record.scoringOwner) {
+    return { allowed: false, reason: 'secondary_consumer_cannot_add_independent_points' };
+  }
+  return { allowed: true, reason: 'single_registered_scoring_owner' };
+}

--- a/src/atlas/governance/atlas-authority-registry-projection-omega.test.ts
+++ b/src/atlas/governance/atlas-authority-registry-projection-omega.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA,
+  automatedComponentCanWriteCanon,
+  getAuthorityRecord,
+  getAuthorityRegistryUnknowns,
+} from './atlas-authority-registry-projection-omega';
+
+describe('ATLAS Authority Registry projection Ω', () => {
+  it('has exactly one sole master selection authority', () => {
+    const masters = ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA.filter((record) => record.selectionAuthority === 'SOLE_MASTER');
+    expect(masters).toHaveLength(1);
+    expect(masters[0].id).toBe('ATLAS_OMEGA_MASTER_UNIVERSE_PROMPT_2026_09_06');
+  });
+
+  it('denies automated canon writes for every projected component', () => {
+    for (const record of ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA) {
+      expect(record.canWriteCanon).toBe(false);
+      expect(automatedComponentCanWriteCanon(record.id)).toBe(false);
+    }
+  });
+
+  it('preserves declared zero-weight shadow/corroborative signals', () => {
+    expect(getAuthorityRecord('REVEALED_CAPITAL_INTELLIGENCE_OMEGA_V1')?.directScoreWeight).toBe(0);
+    expect(getAuthorityRecord('TRADER_INTELLIGENCE_OMEGA_V1')?.directScoreWeight).toBe(0);
+  });
+
+  it('does not silently convert undeclared authority fields into zero or false', () => {
+    const unknowns = getAuthorityRegistryUnknowns();
+    expect(unknowns.length).toBeGreaterThan(0);
+    expect(unknowns.some((record) => record.activationGate === 'UNKNOWN_NOT_DECLARED')).toBe(true);
+    expect(unknowns.some((record) => record.directScoreWeight === 'UNKNOWN_NOT_DECLARED')).toBe(true);
+  });
+
+  it('keeps the research substrate outside selection authority and direct scoring', () => {
+    const research = getAuthorityRecord('RESEARCH_OMEGA');
+    expect(research?.selectionAuthority).toBe('NONE');
+    expect(research?.directScoreWeight).toBe(0);
+    expect(research?.canWriteCanon).toBe(false);
+  });
+});

--- a/src/atlas/governance/atlas-authority-registry-projection-omega.ts
+++ b/src/atlas/governance/atlas-authority-registry-projection-omega.ts
@@ -1,0 +1,110 @@
+import { ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA, ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION } from '../algorithm/atlas-kernel-contract-registry-omega';
+
+export const ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA_VERSION = '2026-09-07-v1.0.0' as const;
+
+export type AuthorityRegistryRecord = {
+  id: string;
+  status: 'ACTIVE_CANONICAL' | 'ACTIVE_REGISTERED';
+  componentClass: string;
+  runtimeAuthority: string;
+  selectionAuthority: 'NONE' | 'SOLE_MASTER' | 'SUBORDINATE' | 'UNKNOWN_NOT_DECLARED';
+  directScoreWeight: number | 'NOT_APPLICABLE' | 'UNKNOWN_NOT_DECLARED';
+  activationGate: string | 'UNKNOWN_NOT_DECLARED';
+  owner: 'ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA';
+  canWriteCanon: false;
+  sourceRegistryVersion: string;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value as UnknownRecord;
+}
+
+function contractSelectionAuthority(key: string, contract: UnknownRecord): AuthorityRegistryRecord['selectionAuthority'] {
+  if (contract.cleanSelectionAuthority === false || contract.portfolioMembershipAuthority === false) return 'NONE';
+  if (key === 'capitalBlindSelection' || key === 'endogenousPortfolio') return 'SUBORDINATE';
+  if (typeof contract.runtimeAuthority === 'string' && contract.runtimeAuthority.includes('SUBORDINATE_SELECTION_INPUT')) return 'SUBORDINATE';
+  return 'UNKNOWN_NOT_DECLARED';
+}
+
+function contractDirectScoreWeight(contract: UnknownRecord): AuthorityRegistryRecord['directScoreWeight'] {
+  return typeof contract.directScoreWeight === 'number' ? contract.directScoreWeight : 'UNKNOWN_NOT_DECLARED';
+}
+
+const kernel = ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA;
+
+const architectureRecords: AuthorityRegistryRecord[] = Object.entries(kernel.canonicalArchitecture).map(([slot, raw]) => {
+  const component = asRecord(raw);
+  const id = String(component.id);
+  const isResearch = component.kind === 'RESEARCH_SUBSTRATE';
+  return {
+    id,
+    status: 'ACTIVE_CANONICAL',
+    componentClass: String(component.kind),
+    runtimeAuthority: isResearch ? 'RESEARCH_SUBSTRATE_ONLY' : `CANONICAL_ARCHITECTURE_${slot}`,
+    selectionAuthority: 'NONE',
+    directScoreWeight: isResearch ? 0 : 'UNKNOWN_NOT_DECLARED',
+    activationGate: 'CANONICAL_ARCHITECTURE_ACTIVE',
+    owner: 'ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA',
+    canWriteCanon: false,
+    sourceRegistryVersion: ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION,
+  };
+});
+
+const masterSelectionRecord: AuthorityRegistryRecord = {
+  id: kernel.masterSelectionAuthority.id,
+  status: 'ACTIVE_CANONICAL',
+  componentClass: 'MASTER_SELECTION_AUTHORITY',
+  runtimeAuthority: kernel.masterSelectionAuthority.authority,
+  selectionAuthority: 'SOLE_MASTER',
+  directScoreWeight: 'NOT_APPLICABLE',
+  activationGate: kernel.masterSelectionAuthority.pointZero ? 'POINT_ZERO_REQUIRED' : 'UNKNOWN_NOT_DECLARED',
+  owner: 'ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA',
+  canWriteCanon: false,
+  sourceRegistryVersion: ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION,
+};
+
+const contractRecords: AuthorityRegistryRecord[] = Object.entries(kernel.contracts).map(([key, raw]) => {
+  const contract = asRecord(raw);
+  return {
+    id: String(contract.id ?? key),
+    status: 'ACTIVE_REGISTERED',
+    componentClass: `REGISTERED_CONTRACT:${key}`,
+    runtimeAuthority: typeof contract.runtimeAuthority === 'string' ? contract.runtimeAuthority : 'UNKNOWN_NOT_DECLARED',
+    selectionAuthority: contractSelectionAuthority(key, contract),
+    directScoreWeight: contractDirectScoreWeight(contract),
+    activationGate: typeof contract.activationGate === 'string' ? contract.activationGate : 'UNKNOWN_NOT_DECLARED',
+    owner: 'ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA',
+    canWriteCanon: false,
+    sourceRegistryVersion: ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA_VERSION,
+  };
+});
+
+/**
+ * Derived projection only. It deliberately does not become a second source of truth.
+ * Unknown fields remain UNKNOWN_NOT_DECLARED rather than being silently promoted to zero/false.
+ */
+export const ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA: readonly AuthorityRegistryRecord[] = [
+  ...architectureRecords,
+  masterSelectionRecord,
+  ...contractRecords,
+] as const;
+
+export function getAuthorityRecord(id: string): AuthorityRegistryRecord | undefined {
+  return ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA.find((record) => record.id === id);
+}
+
+export function automatedComponentCanWriteCanon(id: string): boolean {
+  const record = getAuthorityRecord(id);
+  return record?.canWriteCanon === true;
+}
+
+export function getAuthorityRegistryUnknowns(): AuthorityRegistryRecord[] {
+  return ATLAS_AUTHORITY_REGISTRY_PROJECTION_OMEGA.filter((record) =>
+    record.runtimeAuthority === 'UNKNOWN_NOT_DECLARED' ||
+    record.selectionAuthority === 'UNKNOWN_NOT_DECLARED' ||
+    record.directScoreWeight === 'UNKNOWN_NOT_DECLARED' ||
+    record.activationGate === 'UNKNOWN_NOT_DECLARED',
+  );
+}


### PR DESCRIPTION
## Purpose
Open Phase B corrections from the frozen ASTRA baseline without rewriting history or creating a second source of truth.

## Implemented

### 1) Authority Registry projection Ω
Derived directly from `ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA` and exposes:
- STATUS
- COMPONENT_CLASS
- RUNTIME_AUTHORITY
- SELECTION_AUTHORITY
- DIRECT_SCORE_WEIGHT
- ACTIVATION_GATE
- OWNER
- CAN_WRITE_CANON

Key rule: undeclared fields stay `UNKNOWN_NOT_DECLARED`; they are never silently promoted to zero/false/active.

Tests enforce:
- exactly one sole master selection authority;
- automated canon writes = false;
- Research Ω has no selection authority and zero direct score;
- existing declared zero-weight intelligence remains zero-weight.

### 2) Factor Ownership Ledger Ω
Initial high-risk families:
- Valuation
- FCF
- ROIC
- Backlog
- CAPEX
- Expectation Gap
- Organic Growth

Secondary engines may consume canonical normalized evidence but cannot mint independent points from the same factor. `UNRESOLVED_RUNTIME_MAPPING` fails closed for `ADD_POINTS` until the real scoring owner is mapped.

Raw backlog has no direct scoring authority. External valuation cross-check is diagnostic-only.

### 3) CI + preregistration
Adds dedicated Vitest CI and a non-canonical preregistration under `research/astra/`.

## Explicit non-claims
This PR does NOT claim that runtime double counting is fully eliminated yet. It creates the ownership firewall and blocks unmapped scoring claims; live scorers still need to be mapped/wired.

This PR is independent of PR #160. Continuity remains blocked on the missing GitHub Actions `NOTION_API_KEY` secret and must not be merged until its real Notion 10-case gate passes.