### PR TITLE
feat: enforce single-owner factor scoring boundary

### DIFF
--- a/.github/workflows/factor-ownership-ledger-omega-ci.yml
+++ b/.github/workflows/factor-ownership-ledger-omega-ci.yml
@@ -1,0 +1,31 @@
+name: Factor Ownership Ledger Omega CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/atlas/algorithm/factor-ownership-ledger-omega.ts'
+      - 'src/atlas/algorithm/factor-ownership-ledger-omega.test.ts'
+      - 'src/atlas/algorithm/atlas-architecture-consolidation-omega.test.ts'
+      - 'CURRENT_CANON/2026-09-07_FACTOR_OWNERSHIP_LEDGER_OMEGA_V1.md'
+      - '.github/workflows/factor-ownership-ledger-omega-ci.yml'
+  pull_request:
+    paths:
+      - 'src/atlas/algorithm/factor-ownership-ledger-omega.ts'
+      - 'src/atlas/algorithm/factor-ownership-ledger-omega.test.ts'
+      - 'src/atlas/algorithm/atlas-architecture-consolidation-omega.test.ts'
+      - 'CURRENT_CANON/2026-09-07_FACTOR_OWNERSHIP_LEDGER_OMEGA_V1.md'
+      - '.github/workflows/factor-ownership-ledger-omega-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run factor ownership and architecture invariants
+        run: >-
+          npx --yes vitest@3.2.4 run --globals
+          src/atlas/algorithm/factor-ownership-ledger-omega.test.ts
+          src/atlas/algorithm/atlas-architecture-consolidation-omega.test.ts

--- a/CURRENT_CANON/2026-09-07_FACTOR_OWNERSHIP_LEDGER_OMEGA_V1.md
+++ b/CURRENT_CANON/2026-09-07_FACTOR_OWNERSHIP_LEDGER_OMEGA_V1.md
@@ -1,0 +1,79 @@
+# FACTOR OWNERSHIP LEDGER Ω v1.0
+
+**Date:** `2026-09-07`  
+**Status:** `ACTIVE_E2_BOUNDARY / CALLSITE_AUDIT_REQUIRED`  
+**Canonical engine:** `E2 ASSESSMENT Ω`  
+**Creates new engine:** `NO`
+
+## 1. Problem
+
+The ASTRA master audit identified a structural double-counting risk: several specialized modules can observe the same economic fact (for example backlog, FCF, ROIC or valuation) and accidentally turn corroboration into multiple independent points.
+
+The governing rule is:
+
+`MULTIPLE EVIDENCE -> CONFIDENCE`
+
+not:
+
+`MULTIPLE ENGINES -> MULTIPLE POINTS`
+
+## 2. Executable boundary
+
+Source:
+
+`src/atlas/algorithm/factor-ownership-ledger-omega.ts`
+
+Tests:
+
+`src/atlas/algorithm/factor-ownership-ledger-omega.test.ts`
+
+Architecture binding:
+
+`src/atlas/algorithm/atlas-architecture-consolidation-omega.test.ts`
+
+Every registered economic factor has one explicit `E2_SLOT:*` scoring owner. Specialized engines, research programs, external cross-checks and shadow signals are evidence contributors only unless they are routed through that factor's owner slot.
+
+`assertSingleOwnerFactorScoring()` rejects:
+
+- a direct score claim made by a non-owner;
+- a second direct score claim for the same factor;
+- non-finite factor scores.
+
+`uniqueEvidenceIdsForConfidence()` deduplicates corroborating evidence for confidence handling without creating another score.
+
+## 3. Initial mandatory factor coverage
+
+The v1 ledger registers the core score/risk factors surfaced by the current selection pipeline and the master audit, including:
+
+- business quality;
+- growth and earnings revisions;
+- per-share economics;
+- valuation and 3–6y expected return;
+- FCF, margins, ROIC and balance sheet;
+- moat durability and disruption risk;
+- customer concentration;
+- backlog;
+- capex bottleneck;
+- momentum;
+- macro, regulatory, geopolitical, financing and credit risk;
+- AI value capture;
+- AI capital-formation quality.
+
+## 4. Shadow rule
+
+Shadow signals retain `directScoreWeight = 0` until promotion through independent evidence and out-of-sample validation. Being named as an `evidenceContributor` does not confer score authority.
+
+## 5. What this does NOT prove
+
+This change does **not** prove that every historical scoring callsite has already been migrated through the ledger. Therefore the status is not `DOUBLE_COUNTING_ELIMINATED`.
+
+Required next empirical step:
+
+1. enumerate all current score-producing callsites;
+2. map each emitted score to one ledger factor;
+3. fail CI on unmapped factor score emissions;
+4. demonstrate that a repeated fact from two modules changes confidence/evidence density but not aggregate factor score twice.
+
+Until that callsite audit is complete, the honest status remains:
+
+`ACTIVE_E2_BOUNDARY / CALLSITE_AUDIT_REQUIRED`.

--- a/src/atlas/algorithm/atlas-architecture-consolidation-omega.test.ts
+++ b/src/atlas/algorithm/atlas-architecture-consolidation-omega.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA } from './atlas-kernel-contract-registry-omega';
+import { FACTOR_OWNERSHIP_HARD_RULES } from './factor-ownership-ledger-omega';
 
 describe('ATLAS architecture consolidation Ω', () => {
   const r = ATLAS_KERNEL_CONTRACT_REGISTRY_OMEGA;
@@ -8,6 +9,12 @@ describe('ATLAS architecture consolidation Ω', () => {
     const engines = Object.values(r.canonicalArchitecture).filter((x) => x.kind === 'CANONICAL_ENGINE');
     expect(engines).toHaveLength(6);
     expect(r.canonicalArchitecture.R0.kind).toBe('RESEARCH_SUBSTRATE');
+  });
+
+  it('keeps the factor ownership ledger inside E2 rather than creating a seventh engine', () => {
+    expect(FACTOR_OWNERSHIP_HARD_RULES.canonicalEngine).toBe('E2_ASSESSMENT_OMEGA');
+    expect(FACTOR_OWNERSHIP_HARD_RULES.createsNewEngine).toBe(false);
+    expect(FACTOR_OWNERSHIP_HARD_RULES.oneDirectScoreClaimPerFactor).toBe(true);
   });
 
   it('keeps research, signals, score, gates, selection and execution as distinct planes', () => {

--- a/src/atlas/algorithm/factor-ownership-ledger-omega.test.ts
+++ b/src/atlas/algorithm/factor-ownership-ledger-omega.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ATLAS_FACTOR_KEYS,
+  FACTOR_OWNERSHIP_HARD_RULES,
+  FACTOR_OWNERSHIP_LEDGER_OMEGA,
+  assertSingleOwnerFactorScoring,
+  uniqueEvidenceIdsForConfidence,
+} from './factor-ownership-ledger-omega';
+
+describe('Factor Ownership Ledger Ω', () => {
+  it('is an E2 boundary and never a seventh canonical engine', () => {
+    expect(FACTOR_OWNERSHIP_HARD_RULES.canonicalEngine).toBe('E2_ASSESSMENT_OMEGA');
+    expect(FACTOR_OWNERSHIP_HARD_RULES.createsNewEngine).toBe(false);
+    expect(FACTOR_OWNERSHIP_HARD_RULES.oneDirectScoreClaimPerFactor).toBe(true);
+    expect(FACTOR_OWNERSHIP_HARD_RULES.multipleEvidenceEffect).toBe('CONFIDENCE_ONLY');
+    expect(FACTOR_OWNERSHIP_HARD_RULES.shadowSignalDirectScoreWeight).toBe(0);
+  });
+
+  it('has exactly one explicit scoring owner for every registered factor', () => {
+    expect(ATLAS_FACTOR_KEYS.length).toBeGreaterThanOrEqual(20);
+    expect(new Set(ATLAS_FACTOR_KEYS).size).toBe(ATLAS_FACTOR_KEYS.length);
+
+    for (const factor of ATLAS_FACTOR_KEYS) {
+      const entry = FACTOR_OWNERSHIP_LEDGER_OMEGA[factor];
+      expect(entry.scoringOwner).toBe(`E2_SLOT:${factor}`);
+      expect(entry.directScoreClaimsAllowed).toBe(1);
+      expect(entry.evidenceMayIncreaseConfidence).toBe(true);
+      expect(entry.evidenceMayCreateAdditionalScore).toBe(false);
+    }
+  });
+
+  it('accepts one score claim from the canonical factor owner', () => {
+    expect(() =>
+      assertSingleOwnerFactorScoring(
+        ATLAS_FACTOR_KEYS.map((factor, index) => ({
+          factor,
+          claimant: FACTOR_OWNERSHIP_LEDGER_OMEGA[factor].scoringOwner,
+          value: index / 10,
+        })),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a score claim from an evidence contributor', () => {
+    const factor = 'BACKLOG' as const;
+    const contributor = FACTOR_OWNERSHIP_LEDGER_OMEGA[factor].evidenceContributors[0];
+
+    expect(() =>
+      assertSingleOwnerFactorScoring([
+        { factor, claimant: contributor, value: 1 },
+      ]),
+    ).toThrow(/FACTOR_OWNER_VIOLATION:BACKLOG/);
+  });
+
+  it('rejects duplicate points even when both claims use the correct owner', () => {
+    const factor = 'FCF' as const;
+    const owner = FACTOR_OWNERSHIP_LEDGER_OMEGA[factor].scoringOwner;
+
+    expect(() =>
+      assertSingleOwnerFactorScoring([
+        { factor, claimant: owner, value: 0.7 },
+        { factor, claimant: owner, value: 0.8 },
+      ]),
+    ).toThrow('DUPLICATE_FACTOR_SCORE:FCF');
+  });
+
+  it('deduplicates corroborating evidence without manufacturing another score', () => {
+    const evidence = uniqueEvidenceIdsForConfidence([
+      { factor: 'VALUATION', evidenceIds: ['dcf-1', 'cross-check-1', 'dcf-1'] },
+      { factor: 'VALUATION', evidenceIds: ['cross-check-1', 'consensus-1'] },
+    ]);
+
+    expect(evidence.VALUATION).toEqual(['dcf-1', 'cross-check-1', 'consensus-1']);
+    expect(evidence.FCF).toEqual([]);
+  });
+});

--- a/src/atlas/algorithm/factor-ownership-ledger-omega.ts
+++ b/src/atlas/algorithm/factor-ownership-ledger-omega.ts
@@ -1,0 +1,236 @@
+export const FACTOR_OWNERSHIP_LEDGER_OMEGA_VERSION = '2026-09-07-v1.0.0' as const;
+
+export const ATLAS_FACTOR_KEYS = [
+  'BUSINESS_QUALITY',
+  'GROWTH',
+  'EARNINGS_REVISIONS',
+  'PER_SHARE_ECONOMICS',
+  'VALUATION',
+  'EXPECTED_RETURN_3_6Y',
+  'FCF',
+  'MARGINS',
+  'ROIC',
+  'BALANCE_SHEET',
+  'MOAT_DURABILITY',
+  'DISRUPTION_RISK',
+  'CUSTOMER_CONCENTRATION',
+  'BACKLOG',
+  'CAPEX_BOTTLENECK',
+  'MOMENTUM',
+  'MACRO_RISK',
+  'REGULATORY_RISK',
+  'GEOPOLITICAL_RISK',
+  'FINANCING_RISK',
+  'CREDIT_RISK',
+  'AI_VALUE_CAPTURE',
+  'AI_CAPITAL_FORMATION_QUALITY',
+] as const;
+
+export type AtlasFactorKey = (typeof ATLAS_FACTOR_KEYS)[number];
+
+export type FactorOwnershipRecord = Readonly<{
+  scoringOwner: `E2_SLOT:${string}`;
+  evidenceContributors: readonly string[];
+  directScoreClaimsAllowed: 1;
+  evidenceMayIncreaseConfidence: true;
+  evidenceMayCreateAdditionalScore: false;
+}>;
+
+const factor = (
+  key: string,
+  evidenceContributors: readonly string[],
+): FactorOwnershipRecord => ({
+  scoringOwner: `E2_SLOT:${key}`,
+  evidenceContributors,
+  directScoreClaimsAllowed: 1,
+  evidenceMayIncreaseConfidence: true,
+  evidenceMayCreateAdditionalScore: false,
+});
+
+/**
+ * E2 ASSESSMENT Ω factor ownership boundary.
+ *
+ * This is deliberately not a seventh engine. It prevents subordinate engines,
+ * research families and specialized signals from turning corroborating evidence
+ * into duplicate points for the same economic fact.
+ *
+ * Hard rule:
+ *   MULTIPLE_EVIDENCE -> CONFIDENCE
+ *   MULTIPLE_ENGINES  -/-> MULTIPLE_POINTS
+ */
+export const FACTOR_OWNERSHIP_LEDGER_OMEGA: Readonly<
+  Record<AtlasFactorKey, FactorOwnershipRecord>
+> = {
+  BUSINESS_QUALITY: factor('BUSINESS_QUALITY', [
+    'BUSINESS_QUALITY_OMEGA',
+    'PRINCIPAL_OMEGA',
+    'INVESTMENT_DISCIPLINE_COMPOUNDING_OMEGA_V1',
+  ]),
+  GROWTH: factor('GROWTH', [
+    'GROWTH_AND_REVISIONS_OMEGA',
+    'DURABLE_REVISION_GAP_OMEGA_V1',
+  ]),
+  EARNINGS_REVISIONS: factor('EARNINGS_REVISIONS', [
+    'GROWTH_AND_REVISIONS_OMEGA',
+    'DURABLE_REVISION_GAP_OMEGA_V1',
+    'PRE_CONSENSUS_OMEGA_SHADOW',
+  ]),
+  PER_SHARE_ECONOMICS: factor('PER_SHARE_ECONOMICS', [
+    'PER_SHARE_ECONOMICS_OMEGA_V1',
+    'OWNER_ECONOMICS_NORMALIZATION_OMEGA_V1',
+    'CAPITAL_ALLOCATION_QUALITY_OMEGA_V1',
+  ]),
+  VALUATION: factor('VALUATION', [
+    'VALUATION_OMEGA',
+    'VALUATION_METHOD_INTEGRITY_OMEGA_V1',
+    'EXTERNAL_VALUATION_CROSS_CHECK_OMEGA_V1',
+    'EXPECTATION_GAP_OMEGA',
+  ]),
+  EXPECTED_RETURN_3_6Y: factor('EXPECTED_RETURN_3_6Y', [
+    'VALUATION_OMEGA',
+    'EXPECTATION_GAP_OMEGA',
+    'BULL_BASE_BEAR_SENSITIVITY',
+  ]),
+  FCF: factor('FCF', [
+    'BUSINESS_QUALITY_OMEGA',
+    'CAPEX_PRODUCTIVITY_OMEGA',
+    'PER_SHARE_ECONOMICS_OMEGA_V1',
+  ]),
+  MARGINS: factor('MARGINS', [
+    'BUSINESS_QUALITY_OMEGA',
+    'CAPEX_PRODUCTIVITY_OMEGA',
+  ]),
+  ROIC: factor('ROIC', [
+    'BUSINESS_QUALITY_OMEGA',
+    'CAPEX_PRODUCTIVITY_OMEGA',
+    'CAPITAL_ALLOCATION_QUALITY_OMEGA_V1',
+  ]),
+  BALANCE_SHEET: factor('BALANCE_SHEET', [
+    'BUSINESS_QUALITY_OMEGA',
+    'FINANCING_QUALITY_GATE_OMEGA_V1',
+    'RISK_OMEGA',
+  ]),
+  MOAT_DURABILITY: factor('MOAT_DURABILITY', [
+    'MOAT_MIGRATION_OMEGA_V1',
+    'BUSINESS_QUALITY_OMEGA',
+    'AI_VALUE_MIGRATION_OMEGA',
+  ]),
+  DISRUPTION_RISK: factor('DISRUPTION_RISK', [
+    'MOAT_MIGRATION_OMEGA_V1',
+    'RISK_OMEGA',
+    'AI_VALUE_MIGRATION_OMEGA',
+  ]),
+  CUSTOMER_CONCENTRATION: factor('CUSTOMER_CONCENTRATION', [
+    'RHO_COUNTERPARTY_EXPOSURE_OMEGA_V1',
+    'BUSINESS_QUALITY_OMEGA',
+    'AI_DEMAND_PROVENANCE_OMEGA',
+  ]),
+  BACKLOG: factor('BACKLOG', [
+    'T4_QUALITY_ADJUSTED_BACKLOG_OMEGA_V1',
+    'GLOBAL_CAPEX_CHAIN_OMEGA',
+    'POWER_INFRASTRUCTURE_DUELS_OMEGA',
+    'AI_DEMAND_PROVENANCE_OMEGA',
+  ]),
+  CAPEX_BOTTLENECK: factor('CAPEX_BOTTLENECK', [
+    'CAPEX_PRODUCTIVITY_OMEGA',
+    'GLOBAL_CAPEX_CHAIN_OMEGA',
+    'AI_VALUE_MIGRATION_OMEGA',
+    'POWER_INFRASTRUCTURE_DUELS_OMEGA',
+  ]),
+  MOMENTUM: factor('MOMENTUM', [
+    'TAPE_RS_OMEGA',
+    'MONEY_ROTATION_OMEGA',
+    'INSTITUTIONAL_CAPITAL_ROTATION_OMEGA_V1',
+  ]),
+  MACRO_RISK: factor('MACRO_RISK', [
+    'RISK_OMEGA',
+    'MACRO_RISK_GATE_OMEGA',
+    'P3_REGIME_TRANSMISSION_RESEARCH',
+  ]),
+  REGULATORY_RISK: factor('REGULATORY_RISK', [
+    'RISK_OMEGA',
+    'REGULATORY_RESEARCH',
+  ]),
+  GEOPOLITICAL_RISK: factor('GEOPOLITICAL_RISK', [
+    'RISK_OMEGA',
+    'GEOPOLITICAL_RESEARCH',
+  ]),
+  FINANCING_RISK: factor('FINANCING_RISK', [
+    'RISK_OMEGA',
+    'FINANCING_QUALITY_GATE_OMEGA_V1',
+    'AI_CAPITAL_FORMATION_OMEGA',
+  ]),
+  CREDIT_RISK: factor('CREDIT_RISK', [
+    'RISK_OMEGA',
+    'FINANCING_QUALITY_GATE_OMEGA_V1',
+    'CREDIT_RESEARCH',
+  ]),
+  AI_VALUE_CAPTURE: factor('AI_VALUE_CAPTURE', [
+    'AI_VALUE_MIGRATION_OMEGA',
+    'AI_DEMAND_PROVENANCE_OMEGA',
+    'P2_VALUE_CAPTURE_RESEARCH',
+  ]),
+  AI_CAPITAL_FORMATION_QUALITY: factor('AI_CAPITAL_FORMATION_QUALITY', [
+    'AI_CAPITAL_FORMATION_OMEGA',
+    'FINANCING_QUALITY_GATE_OMEGA_V1',
+    'P1_CAPITAL_FLOW_RESEARCH',
+  ]),
+};
+
+export type FactorScoreClaim = Readonly<{
+  factor: AtlasFactorKey;
+  claimant: string;
+  value: number;
+  evidenceIds?: readonly string[];
+}>;
+
+export function assertSingleOwnerFactorScoring(
+  claims: readonly FactorScoreClaim[],
+): void {
+  const scored = new Set<AtlasFactorKey>();
+
+  for (const claim of claims) {
+    const ownership = FACTOR_OWNERSHIP_LEDGER_OMEGA[claim.factor];
+    if (claim.claimant !== ownership.scoringOwner) {
+      throw new Error(
+        `FACTOR_OWNER_VIOLATION:${claim.factor}:expected=${ownership.scoringOwner}:received=${claim.claimant}`,
+      );
+    }
+    if (scored.has(claim.factor)) {
+      throw new Error(`DUPLICATE_FACTOR_SCORE:${claim.factor}`);
+    }
+    if (!Number.isFinite(claim.value)) {
+      throw new Error(`INVALID_FACTOR_SCORE:${claim.factor}`);
+    }
+    scored.add(claim.factor);
+  }
+}
+
+export function uniqueEvidenceIdsForConfidence(
+  claims: readonly Pick<FactorScoreClaim, 'factor' | 'evidenceIds'>[],
+): Readonly<Record<AtlasFactorKey, readonly string[]>> {
+  const result = Object.fromEntries(
+    ATLAS_FACTOR_KEYS.map((factorKey) => [factorKey, [] as string[]]),
+  ) as Record<AtlasFactorKey, string[]>;
+
+  for (const claim of claims) {
+    const seen = new Set(result[claim.factor]);
+    for (const evidenceId of claim.evidenceIds ?? []) {
+      const normalized = evidenceId.trim();
+      if (normalized) seen.add(normalized);
+    }
+    result[claim.factor] = [...seen];
+  }
+
+  return result;
+}
+
+export const FACTOR_OWNERSHIP_HARD_RULES = {
+  canonicalEngine: 'E2_ASSESSMENT_OMEGA',
+  createsNewEngine: false,
+  oneDirectScoreClaimPerFactor: true,
+  nonOwnerScoreClaim: 'REJECT',
+  multipleEvidenceEffect: 'CONFIDENCE_ONLY',
+  shadowSignalDirectScoreWeight: 0,
+  integrationStatus: 'ACTIVE_BOUNDARY_REQUIRES_CALLSITE_AUDIT',
+} as const;


### PR DESCRIPTION
## Closed as superseded by concurrent main implementation

While this PR was being prepared, `main` received `src/atlas/algorithm/atlas-factor-ownership-ledger-omega.ts` plus tests and Phase B CI.

The implementation now on `main` is preferable because it maps actual known runtime modules and deliberately uses `UNRESOLVED_RUNTIME_MAPPING` with fail-closed `ADD_POINTS` behavior rather than inventing scoring ownership where evidence is incomplete.

No code from this PR should be merged. Remaining work is to expand/audit the main ledger and map real scorer callsites.