### PR TITLE
ATLAS Ω: implement Ω58–Ω102 forensics, PIT integrity and governance core

### DIFF
--- a/.github/workflows/omega-governance-ci.yml
+++ b/.github/workflows/omega-governance-ci.yml
@@ -1,0 +1,22 @@
+name: ATLAS Omega Governance CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/atlas/governance/**'
+      - 'CURRENT_CANON/2026-09-07_OMEGA58_102_EXECUTION_CONTRACT.md'
+      - '.github/workflows/omega-governance-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/atlas/governance/**'
+
+jobs:
+  omega-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Omega governance tests
+        run: >-
+          npx --yes vitest@3.2.4 run --globals
+          src/atlas/governance/omega-governance-core.test.ts

--- a/.github/workflows/omega-governance-ci.yml
+++ b/.github/workflows/omega-governance-ci.yml
@@ -4,19 +4,28 @@ on:
   pull_request:
     paths:
       - 'src/atlas/governance/**'
+      - 'scripts/omega_repository_forensics.py'
       - 'CURRENT_CANON/2026-09-07_OMEGA58_102_EXECUTION_CONTRACT.md'
       - '.github/workflows/omega-governance-ci.yml'
   push:
     branches: [main]
     paths:
       - 'src/atlas/governance/**'
+      - 'scripts/omega_repository_forensics.py'
 
 jobs:
   omega-governance:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Run repository forensics
+        run: python scripts/omega_repository_forensics.py
       - name: Run Omega governance tests
         run: >-
           npx --yes vitest@3.2.4 run --globals
           src/atlas/governance/omega-governance-core.test.ts
+      - name: Upload repository-forensics evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: omega-repository-forensics
+          path: reports/generated/omega_repository_forensics.json

--- a/CURRENT_CANON/2026-09-07_OMEGA58_102_EXECUTION_CONTRACT.md
+++ b/CURRENT_CANON/2026-09-07_OMEGA58_102_EXECUTION_CONTRACT.md
@@ -1,0 +1,31 @@
+# ATLAS Ω — Ω58–Ω102 EXECUTION CONTRACT
+
+Status: SHADOW-GOVERNANCE until executable tests pass.
+Date: 2026-09-07.
+
+This annex is an implementation specification, not scoring authority.
+
+## Laws
+
+1. Runtime authority is proven by execution/import paths, never inferred from filenames.
+2. Point Zero selection is capital-blind. Current holdings, invested capital, cost basis, P/L and current weights have zero selection authority.
+3. OPTIMAL_N is never a caller preference. A heuristic may return SELECTED_N but must not claim global OPTIMAL_N without a global-search proof.
+4. Narrative-only variables have zero score authority unless definition, scale, observable, provenance, timestamp, reproducibility and falsifier are recorded.
+5. Every backtest must be point-in-time safe. Economic period and publication timestamp are distinct. Information is usable only when publication_timestamp <= AS_OF_TIMESTAMP.
+6. Restatements never overwrite the value actually available at the historical decision time.
+7. Security identity is issuer/instrument based; ticker alone is insufficient.
+8. Corporate actions and FX normalization are centralized concerns, not ad-hoc engine rules.
+9. Company risk and knowledge uncertainty are distinct.
+10. Expected return must expose uncertainty and, where possible, decompose fundamental compounding, capital return and multiple effect.
+11. Portfolio selection must be challenged by dominance, Pareto, alternative-search, local-swap, seed and perturbation tests before optimality language is permitted.
+12. Theoretical Point Zero selection precedes turnover/cost/tax implementation analysis.
+13. Replacement requires economically material net improvement after costs; mathematical epsilon is insufficient.
+14. Decisions, predictions and corrections are append-only. Silent retrospective rewrites are forbidden.
+
+## Fail-closed statuses
+
+ACTIVE_CONFIRMED · DEAD_CODE · GHOST_ACTIVE · DUPLICATE_IMPLEMENTATION · VERSION_CONFLICT · ORPHAN_TEST · ORPHAN_DOC · CAPITAL_BLIND_VIOLATION · NARRATIVE_ONLY · PIT_UNSAFE · SEARCH_UNSTABLE · DOMINATED_SECURITY · BLOCKED_BY_DATA.
+
+## Evidence standard
+
+A checkbox, document or filename is not evidence of implementation. Each Ω control is COMPLETE only when linked to executable code/tests or to an append-only machine-readable registry. Data-dependent controls remain BLOCKED_BY_DATA until suitable point-in-time data exists.

--- a/reports/implementation/2026-09-07_OMEGA58_102_IMPLEMENTATION_STATUS.md
+++ b/reports/implementation/2026-09-07_OMEGA58_102_IMPLEMENTATION_STATUS.md
@@ -1,0 +1,72 @@
+# ASTRA Ω58–Ω102 — IMPLEMENTATION STATUS
+
+Date: 2026-09-07
+Branch: `astra/omega58-102-forensics-governance`
+
+## Executive verdict
+
+The annex is accepted as a governance/test specification. It is **not** accepted as 45 new scoring engines. Controls are consolidated into a small executable layer to avoid authority duplication.
+
+Existing Point Zero selector already rejects fixed-N caller authority, ignores personal portfolio state, removes unmeasured causal-diversification authority and explicitly labels itself a greedy heuristic rather than claiming global `OPTIMAL_N`.
+
+## Implemented now
+
+| Ω | Control | State |
+|---|---|---|
+| 58 | static repository execution/import evidence + file classification | IMPLEMENTED, runtime tracing still required for dynamic paths |
+| 59 | evidence vocabulary for dead/ghost/version/orphan states | CONTRACTED; automatic proof requires runtime/coverage data |
+| 60 | constants/silent-resurrection scanner | IMPLEMENTED |
+| 61 | hidden-prior vocabulary; selector invariance tests already exist in canonical selector | IMPLEMENTED + EXISTING TESTS |
+| 62 | executable narrative-term review scanner + zero-authority law | IMPLEMENTED / REVIEW GATE |
+| 63 | versioned `SecuritySnapshot` data contract | IMPLEMENTED |
+| 64–66 | AS_OF, publication-time and original-value/restatement primitives | IMPLEMENTED |
+| 67–70 | corporate-action vocabulary, security identity, FX and freshness primitives | IMPLEMENTED |
+| 71–72 | confidence propagation and uncertainty separation primitives | IMPLEMENTED; model-specific propagation remains calibration work |
+| 73 | ER calibration | BLOCKED_BY_DATA: requires prospective/PIT forecast history and realized outcomes |
+| 74 | scenario probability law | CONTRACTED: precise probabilities require empirical calibration |
+| 75 | ER fundamental/capital-return/multiple bridge | IMPLEMENTED |
+| 76–84 | owner earnings, allocation, quality decompositions | DATA-CONTRACT TARGETS; company-level computation remains BLOCKED_BY_DATA where normalized histories do not exist |
+| 85 | incremental ROIC primitive | IMPLEMENTED |
+| 86–88 | competition-for-capital law, dominance and Pareto frontier | IMPLEMENTED |
+| 89 | Shapley contribution | SHADOW / NOT IMPLEMENTED until portfolio utility is stable and computational value is demonstrated |
+| 90–92 | adversarial search/local optimum/seed stability | REQUIRED; current canonical selector correctly disclaims global optimality. Full solver comparison remains pending |
+| 93–95 | cut classes, selection frequency contract, robust core | IMPLEMENTED primitives; frequencies require perturbation runner/data |
+| 96 | sizing uncertainty | CONTRACTED; sizing remains separate from selection |
+| 97–99 | after-cost utility, replacement firewall, materiality | IMPLEMENTED primitives; thresholds deliberately not hard-coded as universal canon |
+| 100 | decision-ledger validator | IMPLEMENTED |
+| 101 | explicit revision-record validator / no silent rewrites | IMPLEMENTED |
+| 102 | prediction-registry validator with AS_OF <= prediction time | IMPLEMENTED |
+
+## Files added
+
+- `CURRENT_CANON/2026-09-07_OMEGA58_102_EXECUTION_CONTRACT.md`
+- `scripts/omega_repository_forensics.py`
+- `src/atlas/governance/omega-data-integrity.ts`
+- `src/atlas/governance/omega-governance-core.ts`
+- `src/atlas/governance/omega-governance-core.test.ts`
+- `.github/workflows/omega-governance-ci.yml`
+
+## Architectural decisions
+
+1. **No new scoring authority.** The Ω governance layer validates evidence and decisions; it does not add arbitrary points to ATLAS.
+2. **No false `OPTIMAL_N`.** Greedy/local search cannot publish global-optimum language.
+3. **No arbitrary materiality threshold.** Thresholds are policy inputs and must be economically justified/calibrated before canonization.
+4. **No Shapley theatre.** Shapley stays shadow until utility is stable enough for the computation to mean something.
+5. **No backtest theatre.** Ω73, perturbation frequencies and any prediction-quality claims remain blocked until timestamped PIT records exist.
+6. **Append-only governance.** Decisions, revisions and predictions must carry evidence/timestamps rather than silently rewriting history.
+
+## Remaining P0/P1 work after merge
+
+P0: build a real timestamped `SecuritySnapshot` ingestion path and migrate engines away from arbitrary input objects.
+
+P0: bind `AS_OF_TIMESTAMP` at the canonical rebuild entrypoint and fail closed if any provider cannot prove publication availability.
+
+P1: persist Decision/Revision/Prediction registries as append-only JSONL or database tables.
+
+P1: add an adversarial portfolio solver harness (multiple seeds, 1↔1, 2↔2, add/remove and alternative baselines) before any global optimality claim.
+
+P1: create ER calibration once enough prospective predictions have matured. Historical reconstruction using today's estimates is forbidden.
+
+## Acceptance rule
+
+Merge only if Omega Governance CI passes. A green CI proves the new primitives compile/test and repository-forensics executes; it does **not** by itself prove empirical alpha, global portfolio optimality, PIT completeness of all historical data, or predictive calibration.

--- a/scripts/omega_repository_forensics.py
+++ b/scripts/omega_repository_forensics.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Ω58–Ω62 repository forensics. Emits machine-readable evidence; never infers authority from filenames."""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXECUTABLE_SUFFIXES = {'.py', '.ts', '.tsx', '.js', '.mjs', '.cjs'}
+SKIP_PARTS = {'.git', 'node_modules', 'dist', 'build', '.next'}
+CONSTANT_PATTERNS = {
+    'fixed_n_20_35': re.compile(r'\b(?:MIN|MAX)_PORTFOLIO_POSITIONS\b|\b20\s*[-–]\s*35\b'),
+    'fixed_n_30_32': re.compile(r'\b(?:N\s*=\s*(?:30|32)|OPTIMAL_N\s*=\s*(?:30|32))\b'),
+    'diversification_authority': re.compile(r'\b(?:diversificationBonus|diversification_bonus|sectorCap|sector_cap)\b'),
+    'incumbency_authority': re.compile(r'\b(?:incumbencyBonus|incumbency_bonus|mustKeep|must_keep|protectedTicker)\b'),
+    'personal_state': re.compile(r'\b(?:currentInvestedEur|currentPositionWeight|personalPnLPct|personalAverageCost|isCurrentlyHeld|costBasis|personalExposure)\b'),
+}
+NARRATIVE_TERMS = re.compile(r'\b(?:must own|preferred|elite|founder quality|strategic asset|qualitative conviction|AI narrative)\b', re.I)
+
+
+def files():
+    for path in ROOT.rglob('*'):
+        if not path.is_file() or any(part in SKIP_PARTS for part in path.parts):
+            continue
+        yield path
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def classify(path: Path) -> str:
+    p = rel(path)
+    if p.startswith(('docs/', 'CURRENT_CANON/', 'reports/')) or path.suffix.lower() in {'.md', '.txt'}:
+        return 'DOC_ONLY_OR_RECORD'
+    if p.startswith('tests/') or '.test.' in p or p.endswith('_test.py'):
+        return 'TEST'
+    if p.startswith('scripts/'):
+        return 'SCRIPT'
+    if path.suffix in EXECUTABLE_SUFFIXES:
+        return 'EXECUTABLE_SOURCE'
+    return 'DATA_OR_OTHER'
+
+
+def python_imports(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+    except Exception:
+        return []
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            out.append(node.module)
+    return sorted(set(out))
+
+
+def js_imports(text: str) -> list[str]:
+    patterns = [r'\bfrom\s+[\'\"]([^\'\"]+)[\'\"]', r'\brequire\(\s*[\'\"]([^\'\"]+)[\'\"]\s*\)']
+    return sorted(set(m.group(1) for pattern in patterns for m in re.finditer(pattern, text)))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--out', default='reports/generated/omega_repository_forensics.json')
+    args = ap.parse_args()
+
+    rows, constants, narrative = [], [], []
+    for path in files():
+        p = rel(path)
+        kind = classify(path)
+        text = ''
+        if path.suffix.lower() in EXECUTABLE_SUFFIXES | {'.md', '.json', '.yml', '.yaml'}:
+            try:
+                text = path.read_text(encoding='utf-8')
+            except Exception:
+                text = ''
+        imports = python_imports(path) if path.suffix == '.py' else js_imports(text) if path.suffix in EXECUTABLE_SUFFIXES else []
+        rows.append({'file': p, 'classification': kind, 'imports': imports})
+        for name, pattern in CONSTANT_PATTERNS.items():
+            matches = sorted(set(m.group(0) for m in pattern.finditer(text)))
+            if matches:
+                constants.append({'file': p, 'classification': kind, 'pattern': name, 'matches': matches})
+        if kind in {'EXECUTABLE_SOURCE', 'SCRIPT'} and NARRATIVE_TERMS.search(text):
+            narrative.append({'file': p, 'status': 'REVIEW_REQUIRED', 'reason': 'narrative term appears in executable code'})
+
+    executable_paths = {row['file'] for row in rows if row['classification'] in {'EXECUTABLE_SOURCE', 'SCRIPT'}}
+    inbound = {p: 0 for p in executable_paths}
+    for row in rows:
+        for imported in row['imports']:
+            normalized = imported.replace('.', '/')
+            for target in executable_paths:
+                stem = target.rsplit('.', 1)[0]
+                if normalized.endswith(stem) or normalized.endswith('/' + stem.split('/')[-1]):
+                    inbound[target] += 1
+
+    for row in rows:
+        if row['file'] in inbound:
+            row['inboundImportCount'] = inbound[row['file']]
+            row['runtimeAuthority'] = 'POSSIBLE_ENTRYPOINT' if inbound[row['file']] == 0 else 'IMPORTED_CONFIRMED_STATIC'
+
+    payload = {
+        'schema': 'OMEGA_REPOSITORY_FORENSICS_2026-09-07-v1',
+        'rule': 'STATIC_IMPORT_EVIDENCE_ONLY; filename names confer zero authority',
+        'files': rows,
+        'constantRegistryFindings': constants,
+        'narrativeExecutableFindings': narrative,
+        'limitations': [
+            'dynamic imports/reflection/subprocess entrypoints require runtime tracing',
+            'static detection is evidence, not proof of production invocation',
+            'historical/doc occurrences are retained as provenance and are not automatically violations',
+        ],
+    }
+    out = ROOT / args.out
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + '\n', encoding='utf-8')
+    print(json.dumps({'output': rel(out), 'files': len(rows), 'constant_findings': len(constants), 'narrative_findings': len(narrative)}))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/atlas/governance/omega-data-integrity.ts
+++ b/src/atlas/governance/omega-data-integrity.ts
@@ -1,0 +1,102 @@
+export const OMEGA_DATA_CONTRACT_VERSION = '2026-09-07-v1.0.0' as const;
+export type ISO8601 = string;
+
+export type PointInTimeValue<T> = {
+  value: T;
+  economicPeriodStart?: ISO8601;
+  economicPeriodEnd?: ISO8601;
+  publicationTimestamp: ISO8601;
+  source: string;
+  confidence: number;
+};
+
+export type SecurityIdentity = {
+  issuerId: string;
+  securityId: string;
+  tickerAtTime: string;
+  shareClass?: string;
+  exchange?: string;
+  cusip?: string;
+  isin?: string;
+};
+
+export type CorporateAction = {
+  type: 'SPLIT' | 'REVERSE_SPLIT' | 'SPIN_OFF' | 'MERGER' | 'TICKER_CHANGE' | 'SHARE_CLASS_CONVERSION' | 'RIGHTS' | 'SPECIAL_DIVIDEND' | 'ADR_RATIO_CHANGE' | 'DELISTING';
+  effectiveTimestamp: ISO8601;
+  publicationTimestamp: ISO8601;
+  source: string;
+};
+
+export interface SecuritySnapshot {
+  schemaVersion: typeof OMEGA_DATA_CONTRACT_VERSION;
+  identity: SecurityIdentity;
+  timestamp: ISO8601;
+  reportingCurrency: string;
+  securityCurrency: string;
+  portfolioBaseCurrency: string;
+  source: string;
+  valuation: Record<string, PointInTimeValue<number>>;
+  fundamentals: Record<string, PointInTimeValue<number>>;
+  estimates: Record<string, PointInTimeValue<number>>;
+  revisions: Record<string, PointInTimeValue<number>[]>;
+  priceHistory: PointInTimeValue<number>[];
+  volatility: Record<string, PointInTimeValue<number>>;
+  balanceSheet: Record<string, PointInTimeValue<number>>;
+  shareCount: Record<string, PointInTimeValue<number>>;
+  sbc: Record<string, PointInTimeValue<number>>;
+  corporateActions: CorporateAction[];
+  confidence: number;
+  missingFields: string[];
+  lastUpdatedByField: Record<string, ISO8601>;
+}
+
+export function validConfidence(x: number): boolean {
+  return Number.isFinite(x) && x >= 0 && x <= 1;
+}
+
+export function availableAsOf<T>(values: PointInTimeValue<T>[], asOfTimestamp: ISO8601): PointInTimeValue<T>[] {
+  const asOf = Date.parse(asOfTimestamp);
+  if (!Number.isFinite(asOf)) throw new Error('INVALID_AS_OF_TIMESTAMP');
+  return values.filter(v => {
+    const published = Date.parse(v.publicationTimestamp);
+    return Number.isFinite(published) && published <= asOf;
+  });
+}
+
+export function originalAvailableValue<T>(values: PointInTimeValue<T>[], asOfTimestamp: ISO8601): PointInTimeValue<T> | null {
+  return availableAsOf(values, asOfTimestamp).sort((a, b) => Date.parse(a.publicationTimestamp) - Date.parse(b.publicationTimestamp))[0] ?? null;
+}
+
+export function latestAvailableValue<T>(values: PointInTimeValue<T>[], asOfTimestamp: ISO8601): PointInTimeValue<T> | null {
+  return availableAsOf(values, asOfTimestamp).sort((a, b) => Date.parse(b.publicationTimestamp) - Date.parse(a.publicationTimestamp))[0] ?? null;
+}
+
+export function publicationIsPitSafe(publicationTimestamp: ISO8601, asOfTimestamp: ISO8601): boolean {
+  const publication = Date.parse(publicationTimestamp);
+  const asOf = Date.parse(asOfTimestamp);
+  return Number.isFinite(publication) && Number.isFinite(asOf) && publication <= asOf;
+}
+
+export function freshnessAgeMs(lastUpdate: ISO8601, asOfTimestamp: ISO8601): number {
+  const last = Date.parse(lastUpdate);
+  const asOf = Date.parse(asOfTimestamp);
+  if (!Number.isFinite(last) || !Number.isFinite(asOf)) throw new Error('INVALID_TIMESTAMP');
+  return asOf - last;
+}
+
+export function convertLocalReturnToBase(localReturn: number, fxStart: number, fxEnd: number): number {
+  if (![localReturn, fxStart, fxEnd].every(Number.isFinite) || fxStart <= 0 || fxEnd <= 0) throw new Error('INVALID_FX_INPUT');
+  return (1 + localReturn) * (fxEnd / fxStart) - 1;
+}
+
+export function propagatedConfidence(values: number[]): number {
+  if (values.length === 0 || values.some(v => !validConfidence(v))) return 0;
+  return values.reduce((product, v) => product * v, 1) ** (1 / values.length);
+}
+
+export type UncertainEstimate = { mean: number; standardDeviation: number; confidence: number };
+
+export function conservativeEstimate(x: UncertainEstimate, z = 1): number {
+  if (![x.mean, x.standardDeviation, z].every(Number.isFinite) || x.standardDeviation < 0 || !validConfidence(x.confidence)) throw new Error('INVALID_UNCERTAIN_ESTIMATE');
+  return x.mean - z * x.standardDeviation;
+}

--- a/src/atlas/governance/omega-governance-core.test.ts
+++ b/src/atlas/governance/omega-governance-core.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyCut, dominanceAudit, incrementalRoic, multipleDependence, netDeltaUtility,
+  paretoFrontier, replacementPassesFirewall, robustCore, validateDecisionRecord,
+  validatePrediction, validateRevisionRecord,
+} from './omega-governance-core';
+import {
+  availableAsOf, conservativeEstimate, convertLocalReturnToBase, originalAvailableValue,
+  propagatedConfidence, publicationIsPitSafe,
+} from './omega-data-integrity';
+
+describe('Ω58–Ω102 governance primitives', () => {
+  it('detects strict Pareto dominance', () => {
+    const names = [
+      { ticker: 'A', expectedReturn: 18, risk: 8, fragility: 5 },
+      { ticker: 'B', expectedReturn: 19, risk: 7, fragility: 5 },
+      { ticker: 'C', expectedReturn: 20, risk: 12, fragility: 3 },
+    ];
+    expect(dominanceAudit(names).some(x => x.incumbent === 'A' && x.challenger === 'B' && x.dominated)).toBe(true);
+    expect(paretoFrontier(names).map(x => x.ticker).sort()).toEqual(['B', 'C']);
+  });
+
+  it('classifies ER dependence on terminal multiple', () => {
+    expect(multipleDependence({ fundamentalCompounding: 15, capitalReturn: 2, multipleEffect: 1 })).toBe('FUNDAMENTAL_DRIVEN');
+    expect(multipleDependence({ fundamentalCompounding: 7, capitalReturn: 1, multipleEffect: 8 })).toBe('MULTIPLE_DEPENDENT');
+  });
+
+  it('computes incremental ROIC and fails closed on zero incremental capital', () => {
+    expect(incrementalRoic(20, 100)).toBeCloseTo(0.2);
+    expect(incrementalRoic(20, 0)).toBeNull();
+  });
+
+  it('separates gross utility from after-cost replacement materiality', () => {
+    const replacement = {
+      deltaUtilityBeforeCosts: 2,
+      transactionCosts: 0.3,
+      spreads: 0.1,
+      fxImpact: 0.1,
+      taxEffects: 0.2,
+      operationalComplexity: 0.1,
+      deltaExpectedReturn: 1.5,
+      deltaRisk: -0.5,
+    };
+    expect(netDeltaUtility(replacement)).toBeCloseTo(1.2);
+    expect(replacementPassesFirewall(replacement, { minDeltaUtilityAfterCosts: 1, minDeltaExpectedReturn: 1, maxRiskIncrease: 0 })).toBe(true);
+    expect(replacementPassesFirewall(replacement, { minDeltaUtilityAfterCosts: 1.5 })).toBe(false);
+  });
+
+  it('reports cut uncertainty and robust core from perturbation frequency', () => {
+    expect(classifyCut(0.95)).toBe('HARD_IN');
+    expect(classifyCut(0.52)).toBe('BORDERLINE');
+    expect(robustCore({ AVGO: 0.98, MA: 0.94, X: 0.53 }, 0.8)).toEqual(['AVGO', 'MA']);
+  });
+
+  it('requires evidence, confidence and falsifier in the decision ledger', () => {
+    expect(validateDecisionRecord({
+      date: '2026-09-07T09:00:00+02:00', out: 'A', in: 'B', deltaExpectedReturn: 1,
+      deltaRisk: -1, deltaFragility: -1, deltaUtility: 2, evidence: ['filing'], confidence: 0.8, falsifier: 'ER gap closes',
+    })).toEqual([]);
+    expect(validateDecisionRecord({
+      date: 'bad', out: null, in: null, deltaExpectedReturn: NaN, deltaRisk: 0,
+      deltaFragility: 0, deltaUtility: 0, evidence: [], confidence: 2, falsifier: '',
+    }).length).toBeGreaterThan(0);
+  });
+
+  it('forbids silent rewrites by validating an explicit revision record', () => {
+    expect(validateRevisionRecord({ field: 'ER', oldValue: 18, newValue: 15, reason: 'new filing', timestamp: '2026-09-07T09:00:00+02:00' })).toEqual([]);
+  });
+
+  it('requires prediction AS_OF not to be after prediction time', () => {
+    expect(validatePrediction({ id: 'P1', predictionTimestamp: '2026-09-07T09:00:00Z', asOfTimestamp: '2026-09-07T08:00:00Z', target: 'ER', horizon: '1y', predictedValue: 0.15, confidence: 0.7 })).toEqual([]);
+    expect(validatePrediction({ id: 'P2', predictionTimestamp: '2026-09-07T09:00:00Z', asOfTimestamp: '2026-09-07T10:00:00Z', target: 'ER', horizon: '1y', predictedValue: 0.15, confidence: 0.7 })).toContain('AS_OF_AFTER_PREDICTION');
+  });
+});
+
+describe('Ω63–Ω72 point-in-time data integrity', () => {
+  const history = [
+    { value: 10, publicationTimestamp: '2025-07-15T12:00:00Z', source: 'filing', confidence: 1 },
+    { value: 12, publicationTimestamp: '2025-09-01T12:00:00Z', source: 'restatement', confidence: 1 },
+  ];
+
+  it('does not expose future publications to an earlier AS_OF timestamp', () => {
+    expect(availableAsOf(history, '2025-08-01T00:00:00Z').map(x => x.value)).toEqual([10]);
+    expect(publicationIsPitSafe('2025-09-01T12:00:00Z', '2025-08-01T00:00:00Z')).toBe(false);
+  });
+
+  it('can recover the original value available before a later restatement', () => {
+    expect(originalAvailableValue(history, '2025-12-01T00:00:00Z')?.value).toBe(10);
+  });
+
+  it('keeps FX contribution explicit rather than confusing it with local stock alpha', () => {
+    expect(convertLocalReturnToBase(0.1, 1, 1.05)).toBeCloseTo(0.155);
+  });
+
+  it('propagates confidence and penalizes uncertainty in estimates', () => {
+    expect(propagatedConfidence([0.81, 1])).toBeCloseTo(0.9);
+    expect(conservativeEstimate({ mean: 18, standardDeviation: 15, confidence: 0.6 })).toBe(3);
+  });
+});

--- a/src/atlas/governance/omega-governance-core.ts
+++ b/src/atlas/governance/omega-governance-core.ts
@@ -1,0 +1,169 @@
+export const OMEGA_GOVERNANCE_VERSION = '2026-09-07-v1.0.0' as const;
+
+export type Candidate = {
+  ticker: string;
+  expectedReturn: number;
+  risk: number;
+  fragility: number;
+};
+
+export type DominanceResult = {
+  incumbent: string;
+  challenger: string;
+  dominated: boolean;
+};
+
+export function dominates(challenger: Candidate, incumbent: Candidate): boolean {
+  const weaklyBetter = challenger.expectedReturn >= incumbent.expectedReturn &&
+    challenger.risk <= incumbent.risk && challenger.fragility <= incumbent.fragility;
+  const strictlyBetter = challenger.expectedReturn > incumbent.expectedReturn ||
+    challenger.risk < incumbent.risk || challenger.fragility < incumbent.fragility;
+  return weaklyBetter && strictlyBetter;
+}
+
+export function dominanceAudit(candidates: Candidate[]): DominanceResult[] {
+  const out: DominanceResult[] = [];
+  for (const incumbent of candidates) {
+    for (const challenger of candidates) {
+      if (incumbent.ticker === challenger.ticker) continue;
+      out.push({ incumbent: incumbent.ticker, challenger: challenger.ticker, dominated: dominates(challenger, incumbent) });
+    }
+  }
+  return out;
+}
+
+export function paretoFrontier(candidates: Candidate[]): Candidate[] {
+  return candidates.filter(c => !candidates.some(other => other.ticker !== c.ticker && dominates(other, c)));
+}
+
+export type ExpectedReturnBridge = {
+  fundamentalCompounding: number;
+  capitalReturn: number;
+  multipleEffect: number;
+};
+
+export function totalExpectedReturn(x: ExpectedReturnBridge): number {
+  return x.fundamentalCompounding + x.capitalReturn + x.multipleEffect;
+}
+
+export function multipleDependence(x: ExpectedReturnBridge): 'FUNDAMENTAL_DRIVEN' | 'MIXED' | 'MULTIPLE_DEPENDENT' {
+  const total = Math.abs(totalExpectedReturn(x));
+  if (total === 0) return 'MIXED';
+  const share = Math.abs(x.multipleEffect) / total;
+  return share >= 0.5 ? 'MULTIPLE_DEPENDENT' : share >= 0.2 ? 'MIXED' : 'FUNDAMENTAL_DRIVEN';
+}
+
+export function incrementalRoic(deltaNopat: number, deltaInvestedCapital: number): number | null {
+  if (!Number.isFinite(deltaNopat) || !Number.isFinite(deltaInvestedCapital) || deltaInvestedCapital === 0) return null;
+  return deltaNopat / deltaInvestedCapital;
+}
+
+export type MaterialityPolicy = {
+  minDeltaUtilityAfterCosts: number;
+  minDeltaExpectedReturn?: number;
+  maxRiskIncrease?: number;
+};
+
+export type Replacement = {
+  deltaUtilityBeforeCosts: number;
+  transactionCosts: number;
+  spreads: number;
+  fxImpact: number;
+  taxEffects: number;
+  operationalComplexity: number;
+  deltaExpectedReturn?: number;
+  deltaRisk?: number;
+};
+
+export function netDeltaUtility(x: Replacement): number {
+  return x.deltaUtilityBeforeCosts - x.transactionCosts - x.spreads - x.fxImpact - x.taxEffects - x.operationalComplexity;
+}
+
+export function replacementPassesFirewall(x: Replacement, policy: MaterialityPolicy): boolean {
+  const net = netDeltaUtility(x);
+  if (!(net > policy.minDeltaUtilityAfterCosts)) return false;
+  if (policy.minDeltaExpectedReturn !== undefined && (x.deltaExpectedReturn ?? -Infinity) < policy.minDeltaExpectedReturn) return false;
+  if (policy.maxRiskIncrease !== undefined && (x.deltaRisk ?? Infinity) > policy.maxRiskIncrease) return false;
+  return true;
+}
+
+export type CutClass = 'HARD_IN' | 'SOFT_IN' | 'BORDERLINE' | 'SOFT_OUT' | 'CLEAR_OUT';
+
+export function classifyCut(selectionFrequency: number): CutClass {
+  if (!Number.isFinite(selectionFrequency) || selectionFrequency < 0 || selectionFrequency > 1) throw new Error('INVALID_SELECTION_FREQUENCY');
+  if (selectionFrequency >= 0.9) return 'HARD_IN';
+  if (selectionFrequency >= 0.7) return 'SOFT_IN';
+  if (selectionFrequency >= 0.4) return 'BORDERLINE';
+  if (selectionFrequency >= 0.1) return 'SOFT_OUT';
+  return 'CLEAR_OUT';
+}
+
+export function robustCore(selectionFrequencies: Record<string, number>, threshold = 0.8): string[] {
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) throw new Error('INVALID_ROBUST_CORE_THRESHOLD');
+  return Object.entries(selectionFrequencies)
+    .filter(([, frequency]) => frequency >= threshold)
+    .map(([ticker]) => ticker)
+    .sort();
+}
+
+export type DecisionRecord = {
+  date: string;
+  out: string | null;
+  in: string | null;
+  deltaExpectedReturn: number;
+  deltaRisk: number;
+  deltaFragility: number;
+  deltaUtility: number;
+  evidence: string[];
+  confidence: number;
+  falsifier: string;
+};
+
+export function validateDecisionRecord(record: DecisionRecord): string[] {
+  const errors: string[] = [];
+  if (!Number.isFinite(Date.parse(record.date))) errors.push('INVALID_DATE');
+  if (!record.out && !record.in) errors.push('NO_CHANGE_RECORDED');
+  if (![record.deltaExpectedReturn, record.deltaRisk, record.deltaFragility, record.deltaUtility].every(Number.isFinite)) errors.push('INVALID_METRIC');
+  if (record.evidence.length === 0) errors.push('MISSING_EVIDENCE');
+  if (!Number.isFinite(record.confidence) || record.confidence < 0 || record.confidence > 1) errors.push('INVALID_CONFIDENCE');
+  if (!record.falsifier.trim()) errors.push('MISSING_FALSIFIER');
+  return errors;
+}
+
+export type RevisionRecord<T> = {
+  field: string;
+  oldValue: T;
+  newValue: T;
+  reason: string;
+  timestamp: string;
+};
+
+export function validateRevisionRecord<T>(record: RevisionRecord<T>): string[] {
+  const errors: string[] = [];
+  if (!record.field.trim()) errors.push('MISSING_FIELD');
+  if (!record.reason.trim()) errors.push('MISSING_REASON');
+  if (!Number.isFinite(Date.parse(record.timestamp))) errors.push('INVALID_TIMESTAMP');
+  return errors;
+}
+
+export type PredictionRecord = {
+  id: string;
+  predictionTimestamp: string;
+  asOfTimestamp: string;
+  target: string;
+  horizon: string;
+  predictedValue: number;
+  confidence: number;
+};
+
+export function validatePrediction(record: PredictionRecord): string[] {
+  const errors: string[] = [];
+  const predictionTs = Date.parse(record.predictionTimestamp);
+  const asOfTs = Date.parse(record.asOfTimestamp);
+  if (!Number.isFinite(predictionTs) || !Number.isFinite(asOfTs)) errors.push('INVALID_TIMESTAMP');
+  if (Number.isFinite(predictionTs) && Number.isFinite(asOfTs) && asOfTs > predictionTs) errors.push('AS_OF_AFTER_PREDICTION');
+  if (!record.id.trim() || !record.target.trim() || !record.horizon.trim()) errors.push('MISSING_IDENTITY');
+  if (!Number.isFinite(record.predictedValue)) errors.push('INVALID_PREDICTION');
+  if (!Number.isFinite(record.confidence) || record.confidence < 0 || record.confidence > 1) errors.push('INVALID_CONFIDENCE');
+  return errors;
+}


### PR DESCRIPTION
Implements the Ω58–Ω102 annex as executable governance rather than new scoring authority.

Key changes:
- repository/constants/narrative static forensics with machine-readable evidence;
- versioned SecuritySnapshot + AS_OF/publication/restatement/identity/FX/confidence primitives;
- dominance + Pareto, ER decomposition, incremental ROIC, cut uncertainty, robust core;
- after-cost replacement/materiality firewall;
- decision, revision and prediction registry validators;
- CI gate running forensics + Vitest suite and uploading evidence artifact;
- explicit implementation-status report with BLOCKED_BY_DATA controls kept honest.

Existing Point Zero selector remains sovereign for clean selection and still disclaims global OPTIMAL_N because its current implementation is greedy.

Acceptance: merge only after Omega Governance CI is green. Green CI does not claim empirical alpha, full historical PIT completeness, or global combinatorial optimality.