### PR TITLE
fix: require E5 persist authority on agentic HTTP mutations

### DIFF
--- a/.github/workflows/agentic-runtime-v2.yml
+++ b/.github/workflows/agentic-runtime-v2.yml
@@ -15,6 +15,7 @@ on:
       - "api/test_agentic_evidence_bridge.py"
       - "api/test_agentic_governance.py"
       - "api/test_agent_infrastructure_shadow_memory_firewall.py"
+      - "api/test_agentic_persist_authority_gate.py"
       - "api/test_deployment_contract.py"
       - "api/app.py"
       - "render.yaml"
@@ -32,6 +33,7 @@ on:
       - "api/test_agentic_evidence_bridge.py"
       - "api/test_agentic_governance.py"
       - "api/test_agent_infrastructure_shadow_memory_firewall.py"
+      - "api/test_agentic_persist_authority_gate.py"
       - "api/test_deployment_contract.py"
       - "api/app.py"
       - "render.yaml"
@@ -67,4 +69,5 @@ jobs:
           api/test_agentic_evidence_bridge.py
           api/test_agentic_governance.py
           api/test_agent_infrastructure_shadow_memory_firewall.py
+          api/test_agentic_persist_authority_gate.py
           api/test_deployment_contract.py

--- a/api/app.py
+++ b/api/app.py
@@ -5,6 +5,7 @@ import os
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from api.agent_infrastructure import _control
 from api.agent_infrastructure import router as agent_infrastructure_router
 from api.agentic_evidence_bridge import router as agentic_evidence_bridge_router
 from api.agentic_governance import router as agentic_governance_router
@@ -39,6 +40,44 @@ app.include_router(agentic_governance_router)
 app.include_router(agent_infrastructure_router)
 app.include_router(document_ingestion_router)
 
+_AGENTIC_STATE_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_AGENTIC_PREFIX = "/v1/agentic-omega"
+
+
+@app.middleware("http")
+async def atlas_e5_agentic_control(request: Request, call_next):
+    """Fail closed before any agentic endpoint can mutate durable runtime state.
+
+    Agentic v1/v2 routes append runs, recovery snapshots, predictions, capability
+    evidence and sync receipts to the durable ledger. HTTP reachability is a
+    capability, not PERSIST authority, so every non-read method under the
+    agentic namespace requires the independent ATLAS agent-control token.
+
+    GET health/capability/provenance views stay observable without granting
+    mutation authority.
+    """
+    if (
+        request.method.upper() in _AGENTIC_STATE_MUTATING_METHODS
+        and request.url.path.startswith(_AGENTIC_PREFIX)
+    ):
+        try:
+            _control(request.headers.get("x-atlas-agent-token"))
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={
+                    "detail": exc.detail,
+                    "e5Control": {
+                        "code": "AGENTIC_PERSIST_AUTHORITY_REQUIRED",
+                        "namespace": _AGENTIC_PREFIX,
+                        "method": request.method.upper(),
+                        "architecture": "CAPABILITY != AUTHORITY; WRITE != PERSIST",
+                    },
+                },
+                headers=dict(exc.headers) if exc.headers else None,
+            )
+    return await call_next(request)
+
 
 @app.get("/v1/mobile/deployment", tags=["mobile-v2"])
 async def mobile_deployment_provenance() -> dict[str, object]:
@@ -48,15 +87,30 @@ async def mobile_deployment_provenance() -> dict[str, object]:
     commit = os.getenv("RENDER_GIT_COMMIT", "").strip()
     canonical_repo = "Vicente24051980/atlas_genesis"
     return {
-        "service": "atlas-mobile-deployment",
-        "runtime": "render" if os.getenv("RENDER", "").strip().lower() == "true" else "other",
-        "repoSlug": repo_slug or None,
-        "branch": branch or None,
-        "gitCommit": commit or None,
-        "externalHostname": os.getenv("RENDER_EXTERNAL_HOSTNAME", "").strip() or None,
-        "deployRevision": os.getenv("ATLAS_DEPLOY_REVISION", "").strip() or None,
-        "sourceMatchesCanonical": repo_slug.lower() == canonical_repo.lower() and branch == "main",
-        "secretsExposed": False,
+        "service": "ATLAS Ω API",
+        "status": "online",
+        "version": "0.4.0",
+        "finnhub_configured": bool(os.getenv("FINNHUB_TOKEN", "").strip()),
+        "broker": {
+            "provider": "Trading212",
+            "environment": os.getenv("TRADING212_ENV", "demo").strip().lower(),
+            "configured": bool(
+                os.getenv("TRADING212_API_KEY", "").strip()
+                and os.getenv("TRADING212_API_SECRET", "").strip()
+                and os.getenv("ATLAS_BROKER_CONTROL_TOKEN", "").strip()
+            ),
+        },
+        "deployment": {
+            "service": "atlas-mobile-deployment",
+            "runtime": "render" if os.getenv("RENDER", "").strip().lower() == "true" else "other",
+            "repoSlug": repo_slug or None,
+            "branch": branch or None,
+            "gitCommit": commit or None,
+            "externalHostname": os.getenv("RENDER_EXTERNAL_HOSTNAME", "").strip() or None,
+            "deployRevision": os.getenv("ATLAS_DEPLOY_REVISION", "").strip() or None,
+            "sourceMatchesCanonical": repo_slug.lower() == canonical_repo.lower() and branch == "main",
+            "secretsExposed": False,
+        },
     }
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -46,15 +46,12 @@ _AGENTIC_PREFIX = "/v1/agentic-omega"
 
 @app.middleware("http")
 async def atlas_e5_agentic_control(request: Request, call_next):
-    """Fail closed before any agentic endpoint can mutate durable runtime state.
+    """Fail closed before an agentic HTTP route can mutate durable runtime state.
 
-    Agentic v1/v2 routes append runs, recovery snapshots, predictions, capability
-    evidence and sync receipts to the durable ledger. HTTP reachability is a
-    capability, not PERSIST authority, so every non-read method under the
-    agentic namespace requires the independent ATLAS agent-control token.
-
-    GET health/capability/provenance views stay observable without granting
-    mutation authority.
+    Agentic v1/v2 endpoints can append runs, recovery snapshots, predictions,
+    capability evidence and synchronization receipts to the durable ledger.
+    Reachability is capability, not PERSIST authority, so non-read methods in
+    this namespace require the independent ATLAS agent-control token.
     """
     if (
         request.method.upper() in _AGENTIC_STATE_MUTATING_METHODS
@@ -87,30 +84,15 @@ async def mobile_deployment_provenance() -> dict[str, object]:
     commit = os.getenv("RENDER_GIT_COMMIT", "").strip()
     canonical_repo = "Vicente24051980/atlas_genesis"
     return {
-        "service": "ATLAS Ω API",
-        "status": "online",
-        "version": "0.4.0",
-        "finnhub_configured": bool(os.getenv("FINNHUB_TOKEN", "").strip()),
-        "broker": {
-            "provider": "Trading212",
-            "environment": os.getenv("TRADING212_ENV", "demo").strip().lower(),
-            "configured": bool(
-                os.getenv("TRADING212_API_KEY", "").strip()
-                and os.getenv("TRADING212_API_SECRET", "").strip()
-                and os.getenv("ATLAS_BROKER_CONTROL_TOKEN", "").strip()
-            ),
-        },
-        "deployment": {
-            "service": "atlas-mobile-deployment",
-            "runtime": "render" if os.getenv("RENDER", "").strip().lower() == "true" else "other",
-            "repoSlug": repo_slug or None,
-            "branch": branch or None,
-            "gitCommit": commit or None,
-            "externalHostname": os.getenv("RENDER_EXTERNAL_HOSTNAME", "").strip() or None,
-            "deployRevision": os.getenv("ATLAS_DEPLOY_REVISION", "").strip() or None,
-            "sourceMatchesCanonical": repo_slug.lower() == canonical_repo.lower() and branch == "main",
-            "secretsExposed": False,
-        },
+        "service": "atlas-mobile-deployment",
+        "runtime": "render" if os.getenv("RENDER", "").strip().lower() == "true" else "other",
+        "repoSlug": repo_slug or None,
+        "branch": branch or None,
+        "gitCommit": commit or None,
+        "externalHostname": os.getenv("RENDER_EXTERNAL_HOSTNAME", "").strip() or None,
+        "deployRevision": os.getenv("ATLAS_DEPLOY_REVISION", "").strip() or None,
+        "sourceMatchesCanonical": repo_slug.lower() == canonical_repo.lower() and branch == "main",
+        "secretsExposed": False,
     }
 
 

--- a/api/test_agentic_persist_authority_gate.py
+++ b/api/test_agentic_persist_authority_gate.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api import agent_infrastructure
+from api.app import app
+
+
+def test_agentic_post_requires_independent_persist_authority(monkeypatch) -> None:
+    monkeypatch.setattr(agent_infrastructure, "ATLAS_AGENT_CONTROL_TOKEN", "test-agent-control")
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agentic-omega/v2/governance/capability-check",
+        json={
+            "route": {"provider": "test-provider"},
+            "capability": "tool_calling",
+            "mode": "boolean_true",
+            "require_fresh": True,
+        },
+    )
+
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["e5Control"]["code"] == "AGENTIC_PERSIST_AUTHORITY_REQUIRED"
+    assert payload["e5Control"]["architecture"] == "CAPABILITY != AUTHORITY; WRITE != PERSIST"
+
+
+def test_agentic_post_reaches_endpoint_with_valid_control_token(monkeypatch) -> None:
+    monkeypatch.setattr(agent_infrastructure, "ATLAS_AGENT_CONTROL_TOKEN", "test-agent-control")
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agentic-omega/v2/governance/capability-check",
+        headers={"x-atlas-agent-token": "test-agent-control"},
+        json={
+            "route": {"provider": "test-provider"},
+            "capability": "tool_calling",
+            "mode": "boolean_true",
+            "require_fresh": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["allowed"] is False
+    assert payload["failClosed"] is True
+
+
+def test_agentic_get_observability_does_not_require_persist_authority(monkeypatch) -> None:
+    monkeypatch.setattr(agent_infrastructure, "ATLAS_AGENT_CONTROL_TOKEN", "test-agent-control")
+    client = TestClient(app)
+
+    response = client.get("/v1/agentic-omega/health")
+
+    assert response.status_code == 200
+    assert response.json()["invariants"]["directTradeExecution"] is False
+
+
+def test_agentic_mutation_fails_closed_when_control_token_not_configured(monkeypatch) -> None:
+    monkeypatch.setattr(agent_infrastructure, "ATLAS_AGENT_CONTROL_TOKEN", "")
+    client = TestClient(app)
+
+    response = client.post(
+        "/v1/agentic-omega/v2/governance/capability-check",
+        json={
+            "route": {"provider": "test-provider"},
+            "capability": "tool_calling",
+            "mode": "boolean_true",
+            "require_fresh": True,
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["e5Control"]["code"] == "AGENTIC_PERSIST_AUTHORITY_REQUIRED"


### PR DESCRIPTION
## ASTRA Master Audit Ω — P0 E5 enforcement

Reconciliation found a concrete gap between the E5 policy and the mounted runtime: multiple `/v1/agentic-omega` POST endpoints append runs, recovery snapshots, calibration records, capability evidence or synchronization receipts to the durable ledger without requiring the independent agent-control token.

### Fix
- add one HTTP boundary in `api/app.py` for the whole `/v1/agentic-omega` namespace;
- `POST/PUT/PATCH/DELETE` now require `ATLAS_AGENT_CONTROL_TOKEN` through the existing `_control()` gate;
- GET health/capability/provenance views remain observable without granting mutation authority;
- missing token fails 401; unconfigured control plane fails 503;
- explicit response metadata states `CAPABILITY != AUTHORITY; WRITE != PERSIST`;
- add TestClient coverage for denied, allowed, observable-GET and unconfigured-token cases;
- wire the new test into Agentic Runtime CI.

### Why middleware
This avoids a fragile endpoint-by-endpoint patch. New mutating routes under the agentic namespace inherit fail-closed E5 control automatically.

No broker behavior, deployment identity contract, canon authority or selection logic is changed.