### PR TITLE
fix: shadow unvalidated financing-correlation authority

### DIFF
--- a/CURRENT_CANON/2026-09-06_STRUCTURAL_PORTFOLIO_BLOCKER_LEDGER.md
+++ b/CURRENT_CANON/2026-09-06_STRUCTURAL_PORTFOLIO_BLOCKER_LEDGER.md
@@ -40,6 +40,8 @@ No partial candidate set may be presented as a whole-universe structural result.
 
 `PortfolioCandidateV2` currently combines Expected Return percentage points with several untyped numeric risk/fragility/convexity terms.
 
+The same blocker now explicitly covers `fundingSources`: raw categorical funding labels may reveal a genuine common-financing dependency, but Jaccard overlap has no calibrated mapping to loss probability, volatility, drawdown, covariance or another economic risk unit. Therefore `financingCorrelation` remains diagnostic-only and has zero membership authority until the risk-unit contract validates a measured transform.
+
 Authority:
 `src/atlas/algorithm/structural-risk-unit-authority-omega.ts`
 

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
@@ -20,7 +20,7 @@ function c(i:number, er=12, driver=`d${i}`, funding:string[]=[]): PortfolioCandi
   };
 }
 
-describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local selection',()=>{
+describe('Endogenous Portfolio Engine v2.4 — Point Zero / endogenous local selection',()=>{
   it('has no binding ex-ante cardinality floor or ceiling',()=>{
     expect(MIN_PORTFOLIO_POSITIONS_V2).toBe(0);
     expect(MAX_PORTFOLIO_POSITIONS_V2).toBe(Number.POSITIVE_INFINITY);
@@ -67,9 +67,17 @@ describe('Endogenous Portfolio Engine v2.2 — Point Zero / endogenous local sel
     expect(runEndogenousPortfolioEngineV2(xs,{rhoCausalRedundancy:1}).status).toBe('EVIDENCE_PENDING');
   });
 
-  it('detects shared funding-source correlation as risk',()=>{
+  it('measures funding-source overlap diagnostically but gives raw Jaccard overlap zero membership authority',()=>{
     const a=c(1,12,'gpu',['neocloud-x']); const b=c(2,12,'servers',['neocloud-x']); const d=c(3,12,'health',['insurer-y']);
-    expect(evaluatePortfolioSetV2([a,b]).financingCorrelation).toBeGreaterThan(evaluatePortfolioSetV2([a,d]).financingCorrelation);
+    const shared=evaluatePortfolioSetV2([a,b]);
+    const distinct=evaluatePortfolioSetV2([a,d]);
+    expect(shared.financingCorrelation).toBeGreaterThan(distinct.financingCorrelation);
+    expect(shared.utility).toBeCloseTo(distinct.utility,12);
+  });
+
+  it('fails closed if a caller tries to give unvalidated funding-source overlap selection authority',()=>{
+    const xs=Array.from({length:5},(_,i)=>c(i+1,12,`d${i}`,['shared-funder']));
+    expect(runEndogenousPortfolioEngineV2(xs,{etaFinancingCorrelation:0.8}).status).toBe('EVIDENCE_PENDING');
   });
 
   it('rewards scenario offset capacity only through robustness risk reduction',()=>{

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.ts
@@ -1,4 +1,4 @@
-export const ENDOGENOUS_PORTFOLIO_ENGINE_V2_VERSION = '2026-09-07-v2.3.0' as const;
+export const ENDOGENOUS_PORTFOLIO_ENGINE_V2_VERSION = '2026-09-07-v2.4.0' as const;
 
 // Compatibility exports only. They are non-binding sentinels, not portfolio
 // design constraints. Canonical clean selection has no ex-ante floor/ceiling.
@@ -49,7 +49,7 @@ export type PortfolioCandidateV2 = {
   confidence: number; // 0..1, reported separately; never folded into Expected Return.
   individualScore: number;
   causalDrivers: Record<string, number>; // diagnostic exposure map; never a sector/driver quota.
-  fundingSources: string[];
+  fundingSources: string[]; // diagnostic overlap map until B5 risk-unit authority is validated.
   scenarios: Record<ScenarioId, number>; // impact -5..+5
 
   // Personal/current-state fields are accepted only to prove non-authority.
@@ -67,9 +67,9 @@ export type PortfolioEnginePolicyV2 = {
   maxPositions?: number;
   marginalUtilityThreshold?: number;
 
-  // Legacy compatibility fields. Canonical v2.3 fails closed if callers try to
-  // give diversification, causal redundancy or required-driver coverage
-  // independent selection authority.
+  // Legacy compatibility fields. Canonical v2.4 fails closed if callers try to
+  // give diversification, causal redundancy, funding-source label overlap or
+  // required-driver coverage independent selection authority.
   missingDriverRobustnessThreshold?: number;
   requiredStructuralDrivers?: string[];
   alphaDiversification?: number;
@@ -98,9 +98,9 @@ export type PortfolioMetricsV2 = {
   volatilityRisk: number;
   fragility: number;
   convexity: number;
-  causalDiversification: number; // diagnostic only in canonical v2.3
-  causalRedundancy: number; // diagnostic only in canonical v2.3
-  financingCorrelation: number;
+  causalDiversification: number; // diagnostic only in canonical v2.4
+  causalRedundancy: number; // diagnostic only in canonical v2.4
+  financingCorrelation: number; // diagnostic only in canonical v2.4
   robustness: number;
   worstScenarioImpact: number;
   simultaneousAffectedMax: number;
@@ -152,7 +152,12 @@ const DEFAULT_POLICY: NormalizedPolicyV2 = {
   gammaConvexity: 0.35,
   lambdaPermanentLoss: 1.0,
   phiFragility: 0.75,
-  etaFinancingCorrelation: 0.80,
+
+  // B5 fail-closed: raw funding-source labels + Jaccard overlap have no validated
+  // economic/statistical unit yet. Preserve the diagnostic, but give it zero
+  // membership authority until Structural Risk Unit Authority promotes it.
+  etaFinancingCorrelation: 0,
+
   tauTailRisk: 0,
   kappaComplexity: 0.03,
   uncertaintyPenalty: 0.30,
@@ -208,9 +213,15 @@ function normalizePolicy(policy: PortfolioEnginePolicyV2): NormalizedPolicyV2 | 
   if (Math.abs(rw.permanentLoss + rw.tailRisk + rw.volatility - 1) > 1e-9) return null;
 
   // INVIOLABLE MAX RETURN / LOW VOL LAW: no caller may reintroduce a
-  // diversification reward, a causal-redundancy penalty, or mandatory driver
-  // coverage as an independent route into the portfolio.
-  if (p.alphaDiversification !== 0 || p.rhoCausalRedundancy !== 0 || p.requiredStructuralDrivers.length > 0) return null;
+  // diversification reward, causal-redundancy penalty, unvalidated
+  // funding-source-overlap penalty, or mandatory driver coverage as an
+  // independent route into the portfolio.
+  if (
+    p.alphaDiversification !== 0 ||
+    p.rhoCausalRedundancy !== 0 ||
+    p.etaFinancingCorrelation !== 0 ||
+    p.requiredStructuralDrivers.length > 0
+  ) return null;
   return p;
 }
 
@@ -293,9 +304,10 @@ export function evaluatePortfolioSetV2(candidates: PortfolioCandidateV2[], polic
   const causalRedundancy = averagePairwise(candidates, (a, b) => cosineAbs(a.causalDrivers, b.causalDrivers));
   const causalDiversification = 1 - causalRedundancy;
 
-  // Financing correlation remains a research risk input because the same financed
-  // dollar can create common fragility even across different sectors. B5 remains
-  // open: its unit semantics/authority are not canonically validated yet.
+  // Diagnostic only while B5 is open. Shared funding sources can represent a
+  // genuine common fragility, but raw labels/Jaccard have no calibrated unit,
+  // magnitude or causal exposure semantics. They therefore cannot change
+  // selection until validated by Structural Risk Unit Authority.
   const financingCorrelation = averagePairwise(candidates, (a, b) => jaccard(a.fundingSources, b.fundingSources));
 
   const scenarioMeans = CANONICAL_SCENARIOS.map(s => mean(candidates.map(c => c.scenarios[s])));
@@ -319,7 +331,6 @@ export function evaluatePortfolioSetV2(candidates: PortfolioCandidateV2[], polic
     + p.gammaConvexity * convexity
     - p.lambdaPermanentLoss * weightedRisk
     - p.phiFragility * fragility
-    - p.etaFinancingCorrelation * financingCorrelation
     - p.tauTailRisk * tailRisk
     - p.kappaComplexity * complexity
     - p.uncertaintyPenalty * uncertainty;

--- a/src/atlas/algorithm/structural-risk-unit-authority-omega.test.ts
+++ b/src/atlas/algorithm/structural-risk-unit-authority-omega.test.ts
@@ -12,7 +12,8 @@ describe('ATLAS Ω Structural Risk Unit Authority', () => {
     expect(STRUCTURAL_RISK_UNIT_AUTHORITY.tailRiskUnit).toBeNull();
     expect(STRUCTURAL_RISK_UNIT_AUTHORITY.volatilityRiskUnit).toBeNull();
     expect(STRUCTURAL_RISK_UNIT_AUTHORITY.fragilityUnit).toBeNull();
-    expect(STRUCTURAL_RISK_UNIT_AUTHORITY.requirementsToActivate.length).toBeGreaterThanOrEqual(6);
+    expect(STRUCTURAL_RISK_UNIT_AUTHORITY.financingCorrelationUnit).toBeNull();
+    expect(STRUCTURAL_RISK_UNIT_AUTHORITY.requirementsToActivate.length).toBeGreaterThanOrEqual(7);
   });
 
   it('keeps forward expected return explicitly in percentage-point semantics', () => {

--- a/src/atlas/algorithm/structural-risk-unit-authority-omega.ts
+++ b/src/atlas/algorithm/structural-risk-unit-authority-omega.ts
@@ -1,4 +1,4 @@
-export const STRUCTURAL_RISK_UNIT_AUTHORITY_VERSION = '2026-09-06-v0.1.0' as const;
+export const STRUCTURAL_RISK_UNIT_AUTHORITY_VERSION = '2026-09-07-v0.2.0' as const;
 
 /**
  * Fail-closed authority for the units used by the structural portfolio utility.
@@ -8,6 +8,9 @@ export const STRUCTURAL_RISK_UNIT_AUTHORITY_VERSION = '2026-09-06-v0.1.0' as con
  * - permanentLossRisk / tailRisk / volatilityRisk / fragility / convexity are
  *   plain numbers and their common economic unit/normalization is not encoded
  *   in PortfolioCandidateV2.
+ * - fundingSources currently produce only a raw categorical Jaccard-overlap
+ *   diagnostic. That overlap has no calibrated mapping to loss probability,
+ *   volatility, drawdown, common-default exposure or another economic risk unit.
  *
  * Therefore the absolute trade-off between ER and risk is not yet invariant to
  * upstream scoring scale. Canonical optimization must stay blocked until this
@@ -23,8 +26,10 @@ export const STRUCTURAL_RISK_UNIT_AUTHORITY = {
   volatilityRiskUnit: null,
   fragilityUnit: null,
   convexityUnit: null,
+  financingCorrelationUnit: null,
   requirementsToActivate: [
     'Declare an explicit economic/statistical unit or normalized transform for every risk term.',
+    'Replace raw funding-source label overlap with a measured common-financing exposure transform before it can affect membership.',
     'Freeze deterministic transforms from raw evidence into those units.',
     'Prove that equivalent source scales map to identical normalized portfolio inputs.',
     'Calibrate ER-versus-risk trade-offs without using the current portfolio as the target.',


### PR DESCRIPTION
## ASTRA financingCorrelation red team

Repository inspection found a concrete B5 authority contradiction: `financingCorrelation` is computed from raw categorical `fundingSources` via pairwise Jaccard overlap, while B5 explicitly says risk-unit semantics are unresolved. Despite that, v2.3 applied `etaFinancingCorrelation = 0.80` directly to portfolio utility.

That means an uncalibrated label-overlap heuristic could change membership/cardinality inside the research selector even though its mapping to loss probability, volatility, drawdown, common-default exposure or any other economic risk unit is not validated.

## Remediation
- bump Endogenous Portfolio Engine v2 to v2.4.0;
- retain `financingCorrelation` as a diagnostic metric;
- set default `etaFinancingCorrelation = 0`;
- remove financing overlap from utility while B5 remains open;
- fail closed if a caller tries to restore non-zero financing-correlation authority;
- add regression tests proving shared funding labels remain observable but cannot alter utility;
- extend Structural Risk Unit Authority with `financingCorrelationUnit = null` and an explicit activation requirement.

## Promotion condition
Funding correlation can regain utility authority only after a versioned transform maps observed financing exposure into validated economic/statistical risk units and survives calibration/sensitivity/out-of-sample checks under B5.

## Non-goals
- no portfolio change;
- no B5 closure;
- no change to scenario robustness authority;
- no sizing/timing change;
- no change to PR #160;
- no claim that financing commonality is economically irrelevant — only that raw Jaccard label overlap is not yet entitled to direct selection authority.

## Merge gate
Require Endogenous Portfolio Engine v2 CI green on the PR merge candidate.