### PR TITLE
ATLAS Ω: bind Point Zero runtime to PIT SecuritySnapshot

### DIFF
--- a/.github/workflows/architecture-consolidation-ci.yml
+++ b/.github/workflows/architecture-consolidation-ci.yml
@@ -20,8 +20,11 @@ on:
       - 'runtime/agentic_omega/capital_competition.py'
       - 'runtime/agentic_omega/universe_competition.py'
       - 'runtime/agentic_omega/portfolio_finalizer.py'
+      - 'runtime/agentic_omega/security_snapshot.py'
+      - 'runtime/agentic_omega/point_zero_rebuild.py'
       - 'runtime/agentic_omega/test_universe_competition.py'
       - 'runtime/agentic_omega/test_portfolio_finalizer.py'
+      - 'runtime/agentic_omega/test_point_zero_rebuild_pit.py'
       - 'api/atlas_core_consolidated.py'
       - 'api/test_atlas_consolidated_boundary.py'
       - 'api/trading212_controlled.py'
@@ -82,3 +85,4 @@ jobs:
           tests/test_point_zero_universe_integrity.py
           runtime/agentic_omega/test_universe_competition.py
           runtime/agentic_omega/test_portfolio_finalizer.py
+          runtime/agentic_omega/test_point_zero_rebuild_pit.py

--- a/CURRENT_CANON/2026-09-07_POINT_ZERO_PIT_RUNTIME_BINDING.md
+++ b/CURRENT_CANON/2026-09-07_POINT_ZERO_PIT_RUNTIME_BINDING.md
@@ -1,0 +1,61 @@
+# ATLAS Ω — POINT ZERO PIT RUNTIME BINDING
+
+Status: CANONICAL RUNTIME BOUNDARY
+Date: 2026-09-07
+
+## Law
+
+Canonical Point Zero selection MUST enter through:
+
+`runtime.agentic_omega.point_zero_rebuild.run_point_zero_rebuild`
+
+with an explicit `AS_OF_TIMESTAMP` and a collection of versioned `SecuritySnapshot` objects.
+
+`RAW_PROVIDER_OBJECT -> SELECTION` is forbidden.
+
+## Required sequence
+
+`PROVIDER -> SECURITY_SNAPSHOT -> PIT VALIDATION -> ASSESSMENT BINDINGS -> FULL_UNIVERSE_COMPETITION -> CLEAN RANKING`
+
+The runtime fails closed when any of the following is true:
+
+- provider output is not a `SecuritySnapshot`;
+- snapshot schema version is not supported;
+- snapshot timestamp is after `AS_OF_TIMESTAMP`;
+- any consumed publication timestamp is after `AS_OF_TIMESTAMP`;
+- corporate-action publication is after `AS_OF_TIMESTAMP`;
+- confidence is invalid;
+- security identity is unresolved;
+- a required assessment binding is absent or non-numeric.
+
+## Provider authority
+
+Existing provider/capture scripts may continue to produce research evidence, but their raw dictionaries/JSON rows have ZERO direct canonical selection authority. They must be normalized into `SecuritySnapshot` before selection.
+
+In particular, `scripts/point_zero_sec_e1_capture.py` remains an E1 evidence-capture utility. Its output MUST NOT be fed directly into canonical ranking. Historical use is PIT-safe only after publication timestamps have been bounded by the requested `AS_OF_TIMESTAMP`; if that cannot be proven, classify the evidence `PIT_UNSAFE` / `EVIDENCE_PENDING`.
+
+## Required score bindings for current Python runtime
+
+The current bridge expects timestamped values at:
+
+- `fundamentals.fundamental_quality_score`
+- `fundamentals.normalized_economics_score`
+- `fundamentals.evidence_completeness_score`
+- `estimates.expected_return_score`
+- `estimates.regime_compatibility_score`
+- `estimates.normalized_expected_cagr_pct`
+- `valuation.valuation_confidence_pct`
+- `volatility.market_validation_score`
+- `volatility.market_data_age_hours`
+
+These bindings are an adapter contract, not new independent engines or new score authority.
+
+## Selection/execution separation
+
+Broker availability, current holding status, personal capital, cost basis, P/L, replacement hysteresis and transaction/tax frictions remain outside clean Point Zero membership. They may be evaluated only after the clean desired portfolio is frozen.
+
+## CI
+
+`architecture-consolidation-ci.yml` must execute `runtime/agentic_omega/test_point_zero_rebuild_pit.py`.
+
+A green CI proves only the runtime boundary and invariants. It does not prove historical PIT completeness, ER calibration, alpha, or global portfolio optimality.

--- a/runtime/agentic_omega/__init__.py
+++ b/runtime/agentic_omega/__init__.py
@@ -24,6 +24,8 @@ from .capital_competition import Candidate, rank_candidate, competition_for_capi
 from .etf_coverage_gate import CANONICAL_REGIONAL_ETF_BASE, ETFCoverage, OverweightCase, etf_coverage_gate, regional_coverage
 from .universe_competition import UniverseCandidate, audit_candidate, full_universe_competition, green_time_in_portfolio
 from .portfolio_finalizer import FinalCandidate, FinalDecision, GreenTier, CANONICAL_FINALIZER_LAWS, classify, finalize, replacement_allowed
+from .security_snapshot import OMEGA_DATA_CONTRACT_VERSION, CorporateAction, PointInTimeValue, SecurityIdentity, SecuritySnapshot, latest_available, pit_value, validate_snapshot
+from .point_zero_rebuild import PointZeroRebuildResult, run_point_zero_rebuild
 from .market_technical_gates import CryptoConvergenceInput, CryptoConvergenceResult, DurationStressInput, DurationStressRegime, DurationStressResult, SOXTransmissionInput, SOXTransmissionResult, TECHNICAL_GATE_CANONICAL_LAWS, TechnicalGateState, evaluate_crypto_convergence, evaluate_duration_stress, evaluate_sox_transmission
 from .scarcity_absorption import OrganizationalAbsorptionInput, ScarcityMigrationInput, organizational_absorption_omega, scarcity_migration_omega
 from .aime_signal_engines import AIME_CANONICAL_LAWS, ExternalSignalInput, ExternalSignalResult, IntradayBreadthPulseInput, IntradayBreadthPulseResult, OptionsFlowInput, OptionsFlowResult, TechnicalConfirmationInput, TechnicalConfirmationResult, ThemeCrowdingInput, ThemeCrowdingResult, evaluate_external_signal, evaluate_intraday_breadth_pulse, evaluate_options_flow, evaluate_technical_confirmation, evaluate_theme_crowding

--- a/runtime/agentic_omega/point_zero_rebuild.py
+++ b/runtime/agentic_omega/point_zero_rebuild.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .security_snapshot import SecuritySnapshot, pit_value, validate_snapshot
+from .universe_competition import UniverseCandidate, full_universe_competition
+
+
+@dataclass(frozen=True)
+class PointZeroRebuildResult:
+    status: str
+    as_of_timestamp: str
+    ranked_rows: tuple[dict, ...]
+    rejected: tuple[dict, ...]
+    snapshot_count: int
+    accepted_snapshot_count: int
+    pit_safe: bool
+
+
+_REQUIRED_BINDINGS = {
+    "fundamental_quality": ("fundamentals", "fundamental_quality_score"),
+    "expected_return": ("estimates", "expected_return_score"),
+    "market_validation": ("volatility", "market_validation_score"),
+    "regime_compatibility": ("estimates", "regime_compatibility_score"),
+    "normalized_economics": ("fundamentals", "normalized_economics_score"),
+    "evidence_completeness": ("fundamentals", "evidence_completeness_score"),
+    "normalized_expected_cagr": ("estimates", "normalized_expected_cagr_pct"),
+    "valuation_confidence": ("valuation", "valuation_confidence_pct"),
+    "market_data_age_hours": ("volatility", "market_data_age_hours"),
+}
+
+
+def _block(snapshot: SecuritySnapshot, name: str):
+    return getattr(snapshot, name)
+
+
+def _candidate_from_snapshot(snapshot: SecuritySnapshot, as_of_timestamp: str) -> tuple[UniverseCandidate | None, tuple[str, ...]]:
+    values: dict[str, float] = {}
+    missing: list[str] = []
+    for target, (block_name, key) in _REQUIRED_BINDINGS.items():
+        raw = pit_value(_block(snapshot, block_name), key, as_of_timestamp)
+        if raw is None:
+            missing.append(f"MISSING_BINDING:{block_name}.{key}")
+            continue
+        try:
+            values[target] = float(raw)
+        except (TypeError, ValueError):
+            missing.append(f"INVALID_BINDING:{block_name}.{key}")
+
+    if missing:
+        return None, tuple(missing)
+
+    candidate = UniverseCandidate(
+        ticker=snapshot.identity.ticker_at_time,
+        fundamental_quality=values["fundamental_quality"],
+        expected_return=values["expected_return"],
+        market_validation=values["market_validation"],
+        regime_compatibility=values["regime_compatibility"],
+        normalized_economics=values["normalized_economics"],
+        evidence_completeness=values["evidence_completeness"],
+        sector="UNKNOWN",
+        normalized_expected_cagr=values["normalized_expected_cagr"],
+        valuation_confidence=values["valuation_confidence"],
+        market_data_age_hours=values["market_data_age_hours"],
+        trading212_available=None,
+        event_gate=False,
+        structural_falsifier=False,
+        incumbent=False,
+    )
+    return candidate, ()
+
+
+def run_point_zero_rebuild(
+    snapshots: Iterable[SecuritySnapshot],
+    *,
+    as_of_timestamp: str,
+) -> PointZeroRebuildResult:
+    """Canonical runtime entrypoint for clean Point-Zero ranking.
+
+    Every security must arrive as a versioned SecuritySnapshot. The function
+    fails closed per security on future publications, invalid timestamps,
+    schema mismatch or absent score bindings. It never consumes incumbent or
+    broker state for clean selection.
+    """
+    materialized = tuple(snapshots)
+    accepted: list[UniverseCandidate] = []
+    rejected: list[dict] = []
+
+    for snapshot in materialized:
+        ok, reasons = validate_snapshot(snapshot, as_of_timestamp)
+        if not ok:
+            rejected.append({
+                "ticker": snapshot.identity.ticker_at_time,
+                "security_id": snapshot.identity.security_id,
+                "reasons": reasons,
+            })
+            continue
+        candidate, binding_reasons = _candidate_from_snapshot(snapshot, as_of_timestamp)
+        if candidate is None:
+            rejected.append({
+                "ticker": snapshot.identity.ticker_at_time,
+                "security_id": snapshot.identity.security_id,
+                "reasons": binding_reasons,
+            })
+            continue
+        accepted.append(candidate)
+
+    rows = tuple(full_universe_competition(accepted))
+    status = "SELECTED" if rows else "EVIDENCE_PENDING"
+    return PointZeroRebuildResult(
+        status=status,
+        as_of_timestamp=as_of_timestamp,
+        ranked_rows=rows,
+        rejected=tuple(rejected),
+        snapshot_count=len(materialized),
+        accepted_snapshot_count=len(accepted),
+        pit_safe=not any(
+            "FUTURE_" in reason or "SNAPSHOT_AFTER_AS_OF" in reason
+            for item in rejected
+            for reason in item["reasons"]
+        ),
+    )

--- a/runtime/agentic_omega/point_zero_rebuild.py
+++ b/runtime/agentic_omega/point_zero_rebuild.py
@@ -79,15 +79,24 @@ def run_point_zero_rebuild(
     """Canonical runtime entrypoint for clean Point-Zero ranking.
 
     Every security must arrive as a versioned SecuritySnapshot. The function
-    fails closed per security on future publications, invalid timestamps,
-    schema mismatch or absent score bindings. It never consumes incumbent or
-    broker state for clean selection.
+    fails closed per security on raw provider objects, future publications,
+    invalid timestamps, schema mismatch or absent score bindings. It never
+    consumes incumbent or broker state for clean selection.
     """
     materialized = tuple(snapshots)
     accepted: list[UniverseCandidate] = []
     rejected: list[dict] = []
 
-    for snapshot in materialized:
+    for raw in materialized:
+        if not isinstance(raw, SecuritySnapshot):
+            rejected.append({
+                "ticker": None,
+                "security_id": None,
+                "reasons": ("RAW_PROVIDER_OBJECT_FORBIDDEN",),
+            })
+            continue
+
+        snapshot = raw
         ok, reasons = validate_snapshot(snapshot, as_of_timestamp)
         if not ok:
             rejected.append({

--- a/runtime/agentic_omega/security_snapshot.py
+++ b/runtime/agentic_omega/security_snapshot.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+OMEGA_DATA_CONTRACT_VERSION = "2026-09-07-v1.0.0"
+
+
+def _parse_ts(value: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("INVALID_TIMESTAMP")
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError("INVALID_TIMESTAMP") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class PointInTimeValue:
+    value: Any
+    publication_timestamp: str
+    source: str
+    confidence: float
+    economic_period_start: str | None = None
+    economic_period_end: str | None = None
+
+    def available_as_of(self, as_of_timestamp: str) -> bool:
+        return _parse_ts(self.publication_timestamp) <= _parse_ts(as_of_timestamp)
+
+
+@dataclass(frozen=True)
+class SecurityIdentity:
+    issuer_id: str
+    security_id: str
+    ticker_at_time: str
+    share_class: str | None = None
+    exchange: str | None = None
+    cusip: str | None = None
+    isin: str | None = None
+
+
+@dataclass(frozen=True)
+class CorporateAction:
+    type: str
+    effective_timestamp: str
+    publication_timestamp: str
+    source: str
+
+
+@dataclass(frozen=True)
+class SecuritySnapshot:
+    schema_version: str
+    identity: SecurityIdentity
+    timestamp: str
+    reporting_currency: str
+    security_currency: str
+    portfolio_base_currency: str
+    source: str
+    valuation: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    fundamentals: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    estimates: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    revisions: Mapping[str, Sequence[PointInTimeValue]] = field(default_factory=dict)
+    price_history: Sequence[PointInTimeValue] = field(default_factory=tuple)
+    volatility: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    balance_sheet: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    share_count: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    sbc: Mapping[str, PointInTimeValue] = field(default_factory=dict)
+    corporate_actions: Sequence[CorporateAction] = field(default_factory=tuple)
+    confidence: float = 0.0
+    missing_fields: Sequence[str] = field(default_factory=tuple)
+    last_updated_by_field: Mapping[str, str] = field(default_factory=dict)
+
+
+def validate_confidence(value: float) -> bool:
+    return isinstance(value, (int, float)) and 0.0 <= float(value) <= 1.0
+
+
+def latest_available(values: Sequence[PointInTimeValue], as_of_timestamp: str) -> PointInTimeValue | None:
+    available = [v for v in values if v.available_as_of(as_of_timestamp)]
+    if not available:
+        return None
+    return max(available, key=lambda v: _parse_ts(v.publication_timestamp))
+
+
+def _iter_values(snapshot: SecuritySnapshot):
+    for block in (
+        snapshot.valuation,
+        snapshot.fundamentals,
+        snapshot.estimates,
+        snapshot.volatility,
+        snapshot.balance_sheet,
+        snapshot.share_count,
+        snapshot.sbc,
+    ):
+        yield from block.values()
+    for series in snapshot.revisions.values():
+        yield from series
+    yield from snapshot.price_history
+
+
+def validate_snapshot(snapshot: SecuritySnapshot, as_of_timestamp: str) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    try:
+        as_of = _parse_ts(as_of_timestamp)
+        snap_ts = _parse_ts(snapshot.timestamp)
+    except ValueError as exc:
+        return False, (str(exc),)
+
+    if snapshot.schema_version != OMEGA_DATA_CONTRACT_VERSION:
+        reasons.append("UNSUPPORTED_SCHEMA_VERSION")
+    if snap_ts > as_of:
+        reasons.append("SNAPSHOT_AFTER_AS_OF")
+    if not validate_confidence(snapshot.confidence):
+        reasons.append("INVALID_SNAPSHOT_CONFIDENCE")
+    if not snapshot.identity.issuer_id or not snapshot.identity.security_id or not snapshot.identity.ticker_at_time:
+        reasons.append("INVALID_SECURITY_IDENTITY")
+
+    for value in _iter_values(snapshot):
+        if not validate_confidence(value.confidence):
+            reasons.append("INVALID_INPUT_CONFIDENCE")
+            break
+        try:
+            if not value.available_as_of(as_of_timestamp):
+                reasons.append("FUTURE_PUBLICATION_PRESENT")
+                break
+        except ValueError:
+            reasons.append("INVALID_PUBLICATION_TIMESTAMP")
+            break
+
+    for action in snapshot.corporate_actions:
+        try:
+            if _parse_ts(action.publication_timestamp) > as_of:
+                reasons.append("FUTURE_CORPORATE_ACTION_PRESENT")
+                break
+        except ValueError:
+            reasons.append("INVALID_CORPORATE_ACTION_TIMESTAMP")
+            break
+
+    return not reasons, tuple(dict.fromkeys(reasons))
+
+
+def pit_value(block: Mapping[str, PointInTimeValue], key: str, as_of_timestamp: str) -> Any | None:
+    value = block.get(key)
+    if value is None or not value.available_as_of(as_of_timestamp):
+        return None
+    return value.value

--- a/runtime/agentic_omega/test_point_zero_rebuild_pit.py
+++ b/runtime/agentic_omega/test_point_zero_rebuild_pit.py
@@ -78,6 +78,16 @@ def test_missing_required_binding_fails_closed():
     assert "MISSING_BINDING:estimates.normalized_expected_cagr_pct" in result.rejected[0]["reasons"]
 
 
+def test_raw_provider_dict_cannot_bypass_snapshot_contract():
+    result = run_point_zero_rebuild(
+        [{"ticker": "AAA", "expected_return": 999}],
+        as_of_timestamp="2026-09-07T08:00:00+00:00",
+    )
+    assert result.status == "EVIDENCE_PENDING"
+    assert result.accepted_snapshot_count == 0
+    assert result.rejected[0]["reasons"] == ("RAW_PROVIDER_OBJECT_FORBIDDEN",)
+
+
 def test_ranking_cannot_consume_current_holding_state():
     a = snapshot("AAA")
     b = snapshot("BBB")

--- a/runtime/agentic_omega/test_point_zero_rebuild_pit.py
+++ b/runtime/agentic_omega/test_point_zero_rebuild_pit.py
@@ -1,0 +1,85 @@
+from runtime.agentic_omega.point_zero_rebuild import run_point_zero_rebuild
+from runtime.agentic_omega.security_snapshot import (
+    OMEGA_DATA_CONTRACT_VERSION,
+    PointInTimeValue,
+    SecurityIdentity,
+    SecuritySnapshot,
+)
+
+
+def v(value, published="2026-09-06T12:00:00+00:00", confidence=0.95):
+    return PointInTimeValue(value=value, publication_timestamp=published, source="TEST", confidence=confidence)
+
+
+def snapshot(ticker="AAA", *, future=False, omit=None):
+    pub = "2026-09-08T12:00:00+00:00" if future else "2026-09-06T12:00:00+00:00"
+    fundamentals = {
+        "fundamental_quality_score": v(90, pub),
+        "normalized_economics_score": v(95, pub),
+        "evidence_completeness_score": v(92, pub),
+    }
+    estimates = {
+        "expected_return_score": v(88, pub),
+        "regime_compatibility_score": v(80, pub),
+        "normalized_expected_cagr_pct": v(14, pub),
+    }
+    valuation = {"valuation_confidence_pct": v(90, pub)}
+    volatility = {
+        "market_validation_score": v(82, pub),
+        "market_data_age_hours": v(2, pub),
+    }
+    blocks = {
+        "fundamentals": fundamentals,
+        "estimates": estimates,
+        "valuation": valuation,
+        "volatility": volatility,
+    }
+    if omit:
+        block, key = omit
+        blocks[block].pop(key, None)
+
+    return SecuritySnapshot(
+        schema_version=OMEGA_DATA_CONTRACT_VERSION,
+        identity=SecurityIdentity(issuer_id=f"ISSUER:{ticker}", security_id=f"SECURITY:{ticker}", ticker_at_time=ticker),
+        timestamp="2026-09-06T12:05:00+00:00",
+        reporting_currency="USD",
+        security_currency="USD",
+        portfolio_base_currency="EUR",
+        source="TEST",
+        valuation=valuation,
+        fundamentals=fundamentals,
+        estimates=estimates,
+        volatility=volatility,
+        confidence=0.95,
+    )
+
+
+def test_valid_snapshot_enters_clean_ranking():
+    result = run_point_zero_rebuild([snapshot()], as_of_timestamp="2026-09-07T08:00:00+00:00")
+    assert result.status == "SELECTED"
+    assert result.accepted_snapshot_count == 1
+    assert result.ranked_rows[0]["ticker"] == "AAA"
+
+
+def test_future_publication_is_rejected_and_never_ranked():
+    result = run_point_zero_rebuild([snapshot(future=True)], as_of_timestamp="2026-09-07T08:00:00+00:00")
+    assert result.status == "EVIDENCE_PENDING"
+    assert result.accepted_snapshot_count == 0
+    assert result.pit_safe is False
+    assert "FUTURE_PUBLICATION_PRESENT" in result.rejected[0]["reasons"]
+
+
+def test_missing_required_binding_fails_closed():
+    result = run_point_zero_rebuild(
+        [snapshot(omit=("estimates", "normalized_expected_cagr_pct"))],
+        as_of_timestamp="2026-09-07T08:00:00+00:00",
+    )
+    assert result.status == "EVIDENCE_PENDING"
+    assert "MISSING_BINDING:estimates.normalized_expected_cagr_pct" in result.rejected[0]["reasons"]
+
+
+def test_ranking_cannot_consume_current_holding_state():
+    a = snapshot("AAA")
+    b = snapshot("BBB")
+    result = run_point_zero_rebuild([a, b], as_of_timestamp="2026-09-07T08:00:00+00:00")
+    assert all(row["incumbent_state_consumed"] is False for row in result.ranked_rows)


### PR DESCRIPTION
Implements the next P0 after Ω58–Ω102.

Key changes:
- ports the SecuritySnapshot/AS_OF contract into the actual Python agentic runtime;
- adds canonical `run_point_zero_rebuild(..., as_of_timestamp=...)` entrypoint;
- rejects raw provider dictionaries before clean selection;
- fails closed on future publications, future snapshot timestamps, schema mismatch, invalid confidence and missing assessment bindings;
- keeps incumbent/broker/personal-state fields out of clean selection;
- exports the boundary from `runtime.agentic_omega`;
- adds PIT-specific pytest coverage to Architecture Consolidation CI;
- ratifies the runtime binding in CURRENT_CANON.

Important: legacy SEC E1 capture remains research/evidence-only until its observations are demonstrably bounded by AS_OF. This PR prevents such raw rows from bypassing the snapshot boundary; it does not falsely claim historical provider completeness.

Merge only when CI is green.