### PR TITLE
ATLAS Ω P0: enforce SecuritySnapshot + AS_OF at canonical rebuild entrypoint

### DIFF
--- a/.github/workflows/omega-governance-ci.yml
+++ b/.github/workflows/omega-governance-ci.yml
@@ -4,14 +4,22 @@ on:
   pull_request:
     paths:
       - 'src/atlas/governance/**'
+      - 'src/atlas/algorithm/capital-blind-portfolio-selection-omega.ts'
+      - 'src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.ts'
+      - 'src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.test.ts'
       - 'scripts/omega_repository_forensics.py'
+      - 'scripts/point_zero_entrypoint_guard.py'
       - 'CURRENT_CANON/2026-09-07_OMEGA58_102_EXECUTION_CONTRACT.md'
       - '.github/workflows/omega-governance-ci.yml'
   push:
     branches: [main]
     paths:
       - 'src/atlas/governance/**'
+      - 'src/atlas/algorithm/capital-blind-portfolio-selection-omega.ts'
+      - 'src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.ts'
+      - 'src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.test.ts'
       - 'scripts/omega_repository_forensics.py'
+      - 'scripts/point_zero_entrypoint_guard.py'
 
 jobs:
   omega-governance:
@@ -20,10 +28,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run repository forensics
         run: python scripts/omega_repository_forensics.py
-      - name: Run Omega governance tests
+      - name: Enforce canonical Point Zero entrypoint
+        run: python scripts/point_zero_entrypoint_guard.py
+      - name: Run Omega governance and PIT rebuild tests
         run: >-
           npx --yes vitest@3.2.4 run --globals
           src/atlas/governance/omega-governance-core.test.ts
+          src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.test.ts
       - name: Upload repository-forensics evidence
         uses: actions/upload-artifact@v4
         with:

--- a/CURRENT_CANON/2026-09-07_POINT_ZERO_PIT_REBUILD_ENTRYPOINT.md
+++ b/CURRENT_CANON/2026-09-07_POINT_ZERO_PIT_REBUILD_ENTRYPOINT.md
@@ -1,0 +1,43 @@
+# ATLAS Ω — POINT ZERO PIT REBUILD ENTRYPOINT
+
+Status: CANONICAL EXECUTION BOUNDARY
+Date: 2026-09-07
+
+## Law
+
+All canonical clean-selection rebuilds MUST enter through:
+
+`runCanonicalPointZeroRebuildOmega()`
+
+in:
+
+`src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.ts`
+
+Direct production imports of `selectCapitalBlindPortfolioOmega()` are forbidden.
+
+## Required inputs
+
+Every rebuild MUST provide:
+
+- explicit `AS_OF_TIMESTAMP`;
+- one or more versioned `SecuritySnapshot` objects;
+- provenance and confidence on point-in-time values;
+- a deterministic candidate projector that receives only PIT-validated snapshots.
+
+## Fail-closed conditions
+
+The rebuild MUST stop before selection when any consumed input is future-published relative to `AS_OF_TIMESTAMP`, when the snapshot timestamp is in the future, when `lastUpdatedByField` points beyond the as-of boundary, or when required provenance / identity is missing.
+
+`ECONOMIC_PERIOD != PUBLICATION_TIMESTAMP` remains universal. Information is usable only from its publication timestamp.
+
+## Enforcement
+
+`scripts/point_zero_entrypoint_guard.py` fails CI when production code imports the low-level capital-blind selector directly instead of the canonical entrypoint.
+
+`.github/workflows/omega-governance-ci.yml` runs the bypass guard plus PIT boundary tests.
+
+## Scope clarification
+
+This boundary proves temporal/data-contract safety of the inputs that reach clean selection. It does NOT by itself prove empirical alpha, forecast calibration, full provider coverage, or global combinatorial optimality.
+
+Providers that cannot emit a valid `SecuritySnapshot` as-of the requested timestamp are `PIT_UNSAFE` and cannot participate in canonical clean selection until adapted.

--- a/scripts/point_zero_entrypoint_guard.py
+++ b/scripts/point_zero_entrypoint_guard.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / 'src'
+SELECTOR = 'capital-blind-portfolio-selection-omega'
+ALLOWED = {
+    'src/atlas/algorithm/capital-blind-portfolio-selection-omega.test.ts',
+    'src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.ts',
+    'src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.test.ts',
+}
+PATTERN = re.compile(r"(?:from\s+['\"][^'\"]*capital-blind-portfolio-selection-omega['\"]|require\([^)]*capital-blind-portfolio-selection-omega[^)]*\))")
+
+violations: list[str] = []
+for path in SRC.rglob('*'):
+    if not path.is_file() or path.suffix not in {'.ts', '.tsx', '.js', '.jsx'}:
+        continue
+    rel = path.relative_to(ROOT).as_posix()
+    if rel in ALLOWED:
+        continue
+    text = path.read_text(encoding='utf-8', errors='ignore')
+    if SELECTOR in text and PATTERN.search(text):
+        violations.append(rel)
+
+if violations:
+    print('POINT_ZERO_ENTRYPOINT_BYPASS')
+    for violation in sorted(violations):
+        print(f' - {violation}')
+    print('Production code must call runCanonicalPointZeroRebuildOmega so SecuritySnapshot + AS_OF validation cannot be bypassed.')
+    sys.exit(1)
+
+print('POINT_ZERO_ENTRYPOINT_GUARD_OK')

--- a/src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.test.ts
+++ b/src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { OMEGA_DATA_CONTRACT_VERSION, type SecuritySnapshot } from '../governance/omega-data-integrity';
+import { runCanonicalPointZeroRebuildOmega } from './point-zero-rebuild-entrypoint-omega';
+
+function snapshot(publicationTimestamp = '2026-09-01T10:00:00Z'): SecuritySnapshot {
+  return {
+    schemaVersion: OMEGA_DATA_CONTRACT_VERSION,
+    identity: { issuerId: 'ISSUER-1', securityId: 'SEC-1', tickerAtTime: 'AAA' },
+    timestamp: '2026-09-01T12:00:00Z',
+    reportingCurrency: 'USD',
+    securityCurrency: 'USD',
+    portfolioBaseCurrency: 'EUR',
+    source: 'TEST',
+    valuation: { pe: { value: 20, publicationTimestamp, source: 'TEST', confidence: 1 } },
+    fundamentals: {}, estimates: {}, revisions: {}, priceHistory: [], volatility: {}, balanceSheet: {}, shareCount: {}, sbc: {},
+    corporateActions: [], confidence: 1, missingFields: [], lastUpdatedByField: { valuation: '2026-09-01T12:00:00Z' },
+  };
+}
+
+const projector = (s: any) => ({
+  ticker: s.identity.tickerAtTime,
+  canonicalEntityId: s.identity.issuerId,
+  hardGatesPassed: true,
+  expectedCompoundReturnPct: 15,
+  permanentLossRiskPct: 4,
+  fragilityPenaltyPct: 2,
+});
+
+describe('Canonical Point Zero rebuild Ω — PIT boundary', () => {
+  it('selects only after every snapshot is validated as-of', () => {
+    const result = runCanonicalPointZeroRebuildOmega({
+      asOfTimestamp: '2026-09-02T00:00:00Z', snapshots: [snapshot()], projectCandidate: projector,
+    });
+    expect(result.status).toBe('SELECTED');
+    expect(result.selectedTickers).toEqual(['AAA']);
+    expect(result.pitValidatedSnapshotCount).toBe(1);
+  });
+
+  it('fails closed on future-published fundamentals/valuation', () => {
+    expect(() => runCanonicalPointZeroRebuildOmega({
+      asOfTimestamp: '2026-09-02T00:00:00Z', snapshots: [snapshot('2026-09-03T00:00:00Z')], projectCandidate: projector,
+    })).toThrow('PIT_UNSAFE:valuation.pe');
+  });
+
+  it('fails closed when the snapshot itself is from the future', () => {
+    const s = snapshot(); s.timestamp = '2026-09-05T00:00:00Z';
+    expect(() => runCanonicalPointZeroRebuildOmega({
+      asOfTimestamp: '2026-09-02T00:00:00Z', snapshots: [s], projectCandidate: projector,
+    })).toThrow('PIT_UNSAFE:SNAPSHOT_TIMESTAMP');
+  });
+
+  it('fails closed on future last-update metadata', () => {
+    const s = snapshot(); s.lastUpdatedByField.valuation = '2026-09-04T00:00:00Z';
+    expect(() => runCanonicalPointZeroRebuildOmega({
+      asOfTimestamp: '2026-09-02T00:00:00Z', snapshots: [s], projectCandidate: projector,
+    })).toThrow('PIT_UNSAFE:lastUpdatedByField.valuation');
+  });
+
+  it('requires explicit provenance', () => {
+    const s = snapshot(); s.valuation.pe.source = '';
+    expect(() => runCanonicalPointZeroRebuildOmega({
+      asOfTimestamp: '2026-09-02T00:00:00Z', snapshots: [s], projectCandidate: projector,
+    })).toThrow('MISSING_PROVENANCE:valuation.pe');
+  });
+});

--- a/src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.ts
+++ b/src/atlas/algorithm/point-zero-rebuild-entrypoint-omega.ts
@@ -1,0 +1,122 @@
+import {
+  publicationIsPitSafe,
+  validConfidence,
+  type ISO8601,
+  type PointInTimeValue,
+  type SecuritySnapshot,
+} from '../governance/omega-data-integrity';
+import {
+  selectCapitalBlindPortfolioOmega,
+  type CapitalBlindCandidate,
+  type CapitalBlindSelectionPolicy,
+  type CapitalBlindSelectionResult,
+} from './capital-blind-portfolio-selection-omega';
+
+export const POINT_ZERO_REBUILD_ENTRYPOINT_VERSION = '2026-09-07-v1.0.0' as const;
+
+export type PitValidatedSnapshot = SecuritySnapshot & { readonly __pitValidated: true };
+
+export type CandidateProjector = (snapshot: PitValidatedSnapshot, asOfTimestamp: ISO8601) => CapitalBlindCandidate;
+
+export type PointZeroRebuildRequest = {
+  asOfTimestamp: ISO8601;
+  snapshots: SecuritySnapshot[];
+  projectCandidate: CandidateProjector;
+  policy?: CapitalBlindSelectionPolicy;
+};
+
+export type PointZeroRebuildResult = CapitalBlindSelectionResult & {
+  asOfTimestamp: ISO8601;
+  snapshotCount: number;
+  pitValidatedSnapshotCount: number;
+  entrypointVersion: typeof POINT_ZERO_REBUILD_ENTRYPOINT_VERSION;
+};
+
+function assertIsoTimestamp(value: string, code: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(code);
+  return parsed;
+}
+
+function validatePitValue<T>(value: PointInTimeValue<T>, asOfTimestamp: ISO8601, field: string): void {
+  if (!value.source?.trim()) throw new Error(`MISSING_PROVENANCE:${field}`);
+  if (!validConfidence(value.confidence)) throw new Error(`INVALID_CONFIDENCE:${field}`);
+  if (!publicationIsPitSafe(value.publicationTimestamp, asOfTimestamp)) {
+    throw new Error(`PIT_UNSAFE:${field}`);
+  }
+  if (value.economicPeriodStart) assertIsoTimestamp(value.economicPeriodStart, `INVALID_ECONOMIC_PERIOD_START:${field}`);
+  if (value.economicPeriodEnd) assertIsoTimestamp(value.economicPeriodEnd, `INVALID_ECONOMIC_PERIOD_END:${field}`);
+}
+
+function validateRecord(
+  record: Record<string, PointInTimeValue<number>>,
+  asOfTimestamp: ISO8601,
+  prefix: string,
+): void {
+  for (const [key, value] of Object.entries(record)) validatePitValue(value, asOfTimestamp, `${prefix}.${key}`);
+}
+
+function validateRevisionRecord(
+  record: Record<string, PointInTimeValue<number>[]>,
+  asOfTimestamp: ISO8601,
+  prefix: string,
+): void {
+  for (const [key, values] of Object.entries(record)) {
+    for (const value of values) validatePitValue(value, asOfTimestamp, `${prefix}.${key}`);
+  }
+}
+
+export function validateSecuritySnapshotAsOf(snapshot: SecuritySnapshot, asOfTimestamp: ISO8601): PitValidatedSnapshot {
+  const asOf = assertIsoTimestamp(asOfTimestamp, 'INVALID_AS_OF_TIMESTAMP');
+  const snapshotTime = assertIsoTimestamp(snapshot.timestamp, 'INVALID_SNAPSHOT_TIMESTAMP');
+  if (snapshotTime > asOf) throw new Error('PIT_UNSAFE:SNAPSHOT_TIMESTAMP');
+
+  if (!snapshot.identity?.issuerId?.trim()) throw new Error('MISSING_ISSUER_ID');
+  if (!snapshot.identity?.securityId?.trim()) throw new Error('MISSING_SECURITY_ID');
+  if (!snapshot.identity?.tickerAtTime?.trim()) throw new Error('MISSING_TICKER_AT_TIME');
+  if (!snapshot.source?.trim()) throw new Error('MISSING_SNAPSHOT_PROVENANCE');
+  if (!validConfidence(snapshot.confidence)) throw new Error('INVALID_SNAPSHOT_CONFIDENCE');
+
+  validateRecord(snapshot.valuation, asOfTimestamp, 'valuation');
+  validateRecord(snapshot.fundamentals, asOfTimestamp, 'fundamentals');
+  validateRecord(snapshot.estimates, asOfTimestamp, 'estimates');
+  validateRevisionRecord(snapshot.revisions, asOfTimestamp, 'revisions');
+  snapshot.priceHistory.forEach((v, i) => validatePitValue(v, asOfTimestamp, `priceHistory.${i}`));
+  validateRecord(snapshot.volatility, asOfTimestamp, 'volatility');
+  validateRecord(snapshot.balanceSheet, asOfTimestamp, 'balanceSheet');
+  validateRecord(snapshot.shareCount, asOfTimestamp, 'shareCount');
+  validateRecord(snapshot.sbc, asOfTimestamp, 'sbc');
+
+  for (const [index, action] of snapshot.corporateActions.entries()) {
+    if (!action.source?.trim()) throw new Error(`MISSING_PROVENANCE:corporateActions.${index}`);
+    if (!publicationIsPitSafe(action.publicationTimestamp, asOfTimestamp)) {
+      throw new Error(`PIT_UNSAFE:corporateActions.${index}`);
+    }
+    assertIsoTimestamp(action.effectiveTimestamp, `INVALID_EFFECTIVE_TIMESTAMP:corporateActions.${index}`);
+  }
+
+  for (const [field, timestamp] of Object.entries(snapshot.lastUpdatedByField)) {
+    const updated = assertIsoTimestamp(timestamp, `INVALID_LAST_UPDATE:${field}`);
+    if (updated > asOf) throw new Error(`PIT_UNSAFE:lastUpdatedByField.${field}`);
+  }
+
+  return Object.assign(snapshot, { __pitValidated: true as const });
+}
+
+export function runCanonicalPointZeroRebuildOmega(request: PointZeroRebuildRequest): PointZeroRebuildResult {
+  assertIsoTimestamp(request.asOfTimestamp, 'INVALID_AS_OF_TIMESTAMP');
+  if (!Array.isArray(request.snapshots) || request.snapshots.length === 0) throw new Error('NO_SECURITY_SNAPSHOTS');
+  if (typeof request.projectCandidate !== 'function') throw new Error('MISSING_CANDIDATE_PROJECTOR');
+
+  const validated = request.snapshots.map(snapshot => validateSecuritySnapshotAsOf(snapshot, request.asOfTimestamp));
+  const candidates = validated.map(snapshot => request.projectCandidate(snapshot, request.asOfTimestamp));
+  const selection = selectCapitalBlindPortfolioOmega(candidates, request.policy ?? {});
+
+  return {
+    ...selection,
+    asOfTimestamp: request.asOfTimestamp,
+    snapshotCount: request.snapshots.length,
+    pitValidatedSnapshotCount: validated.length,
+    entrypointVersion: POINT_ZERO_REBUILD_ENTRYPOINT_VERSION,
+  };
+}


### PR DESCRIPTION
Implements the next P0 after Ω58–Ω102.

Changes:
- adds `runCanonicalPointZeroRebuildOmega()` as the sole canonical clean-selection boundary;
- requires versioned `SecuritySnapshot[]` + explicit `AS_OF_TIMESTAMP`;
- validates snapshot timestamp, publication timestamp, last-update metadata, provenance, confidence and identity before candidate projection;
- candidate projectors receive only PIT-validated snapshots;
- adds CI guard forbidding production imports of the low-level selector, preventing bypass of the PIT boundary;
- extends Omega Governance CI with bypass guard + PIT boundary tests;
- ratifies the execution law in CURRENT_CANON.

Fail-closed semantics: future-published data, future snapshot/update metadata, missing provenance or malformed identity stop the rebuild before selection.

This does not claim full historical PIT coverage or empirical alpha; providers unable to emit valid as-of SecuritySnapshots remain PIT_UNSAFE until adapted.