### PR TITLE
Fail closed on invalid selection inputs; align canon with heuristic cardinality

### DIFF
--- a/CURRENT_CANON/ATLAS_OMEGA_CURRENT_CANON.md
+++ b/CURRENT_CANON/ATLAS_OMEGA_CURRENT_CANON.md
@@ -51,7 +51,7 @@ Nombre canónico: **ATLAS Ω — MASTER UNIVERSE PROMPT**.
 
 Toda autoridad anterior de selección queda `SUPERSEDED_AS_SELECTION_AUTHORITY`, incluyendo prompts maestros previos, amendments, tesis de cartera, Top 10/20/25/30/32/35/37, snapshots, listas incumbentes, reglas de protección de nombres y cualquier otro “mundo” operativo incompatible.
 
-Los documentos previos pueden permanecer en el repositorio como **HISTORICAL / PROVENANCE / RESEARCH ONLY**. No pueden influir por sí mismos en ranking, membership, score, replacement ni `OPTIMAL_N`.
+Los documentos previos pueden permanecer en el repositorio como **HISTORICAL / PROVENANCE / RESEARCH ONLY**. No pueden influir por sí mismos en ranking, membership, score, replacement ni `SELECTED_N`.
 
 ## 2. Point Zero / clean rebuild
 
@@ -87,15 +87,15 @@ La pregunta decisiva no es «¿es buena empresa?», sino:
 
 `Breadth Rotation = 0%` en score/selección canónica. Es `SHADOW_SIGNAL / DISCOVERY_ONLY` hasta promoción formal validada.
 
-## 4. OPTIMAL_N
+## 4. SELECTED_N
 
-`OPTIMAL_N = FULLY_ENDOGENOUS`
+`SELECTED_N = FULLY_ENDOGENOUS`
 
 No existe target, floor ni ceiling canónico de 20, 25, 27, 29, 30, 32, 35, 37, 50 ni de ningún otro número arbitrario.
 
 La cartera comienza desde Point Zero y se expande únicamente mientras la siguiente incorporación mejora materialmente la utilidad retorno/riesgo de la cartera completa. Cuando la siguiente incorporación no mejora esa utilidad, la expansión se detiene.
 
-Las restricciones de cardinalidad sólo pueden existir como límites técnicos transitorios de una implementación y deben declararse `NON_CANONICAL_IMPLEMENTATION_LIMIT`; nunca pueden decidir el `OPTIMAL_N` económico.
+Las restricciones de cardinalidad sólo pueden existir como límites técnicos transitorios de una implementación y deben declararse `NON_CANONICAL_IMPLEMENTATION_LIMIT`; nunca pueden decidir el `SELECTED_N` económico.
 
 ## 5. Pipeline canónico de selección
 
@@ -112,7 +112,7 @@ Las restricciones de cardinalidad sólo pueden existir como límites técnicos t
 11. **Falsifiers** como reglas dentro de E3 · GATE Ω.
 12. Duelos entre empresas económicamente comparables.
 13. **Competition for Capital** mediante duelos cross-sector.
-14. Selección portfolio-level y determinación endógena de `OPTIMAL_N`.
+14. Selección portfolio-level y determinación endógena de `SELECTED_N`.
 15. Auditoría de frontera, concentración oculta, escenarios bull/base/bear y sesgos.
 16. Aplicación de controles de sizing y riesgo, incluido `AI EXPOSURE CONTROL Ω`, sin retrocontaminar el ranking Point Zero.
 
@@ -189,7 +189,9 @@ Si una reconstrucción independiente produce la misma cartera, eso es evidencia 
 ## 12. Campos de salida obligatorios
 
 `UNIVERSE_VERSION`  
-`OPTIMAL_N`  
+`SELECTED_N`
+
+`GLOBAL_OPTIMALITY`
 `SELECTED_PORTFOLIO`  
 `FIRST_10_CHALLENGERS`  
 `DECISIVE_REPLACEMENTS`  
@@ -200,3 +202,11 @@ Si una reconstrucción independiente produce la misma cartera, eso es evidencia 
 `AI_MOMENTUM_OVERRIDE`  
 `CONFIDENCE`  
 `DATA_CUTOFF`
+
+## Corrección de auditoría autorizada · 7-sep-2026 · issue #184
+
+`ENDOGENOUS N ≠ PROVEN GLOBAL OPTIMUM`. La búsqueda heurística informa `SELECTED_N` y `GLOBAL_OPTIMALITY = NOT_PROVEN`. `OPTIMAL_N` queda reservado a una prueba o certificado suficiente de optimalidad global sobre un objetivo, universo y restricciones declarados. Los campos de compatibilidad `optimalN: null` no deben rellenarse con `selectedN`.
+
+La baja volatilidad sólo tiene valor cuando mejora la utilidad económica; no es un objetivo a cualquier precio. La selección no autoriza por sí sola reemplazo ni ejecución.
+
+Estado de implementación: los selectores ya separaban cardinalidad heurística y optimalidad antes de esta corrección documental. Las unidades de riesgo y el sizing estructural siguen `RESEARCH_PENDING`; tests de software no demuestran calibración económica ni rentabilidad.

--- a/docs/canon/ATLAS_OMEGA_MASTER_PROMPT_CANONICAL.md
+++ b/docs/canon/ATLAS_OMEGA_MASTER_PROMPT_CANONICAL.md
@@ -62,7 +62,7 @@ Permite `EXTERNAL_CHALLENGERS` solamente cuando procedan de discovery documentad
 
 No fijes de antemano 20, 25, 30, 32, 35 ni 37 posiciones.
 
-Determina **OPTIMAL_N endógenamente**.
+Determina **SELECTED_N endógenamente**.
 
 Una empresa entra únicamente cuando su contribución marginal mejora la utilidad retorno/riesgo de la cartera completa. Detén la expansión cuando añadir la siguiente empresa empeore esa utilidad.
 
@@ -105,7 +105,7 @@ Busca activamente evidencia que pueda destruir la tesis. Una tesis que no pueda 
 
 **1. Ranking completo de finalistas.** Ticker, empresa, sector/factor, score ATLAS, expected return, riesgo, confianza y estado.
 
-**2. Cartera óptima.** Ranking #1…#N y `OPTIMAL_N`.
+**2. Cartera seleccionada.** Ranking #1…#N y `SELECTED_N`.
 
 **3. Frontera de corte.** Incluye al menos los últimos 5 incumbentes y los primeros 10 challengers para poder observar exactamente dónde está el coste marginal de añadir una posición.
 
@@ -125,12 +125,14 @@ Busca activamente evidencia que pueda destruir la tesis. Una tesis que no pueda 
 
 **No intentes justificar la cartera que ya tenemos. Intenta derrotarla.**
 
-Si la reconstrucción independiente produce la misma cartera, eso constituye evidencia a favor de ella. Si encuentra una cartera superior, reemplázala.
+Si la reconstrucción independiente produce la misma cartera, eso constituye evidencia a favor de ella. Si encuentra una cartera superior, evalúa la transición después de clean selection. REPLACE sólo procede si NET ROTATION ADVANTAGE > 0 con costes, incertidumbre y realidad del broker reconciliada; de lo contrario, BLOCKED / WATCH.
 
 La salida debe terminar con:
 
 `UNIVERSE_VERSION`  
-`OPTIMAL_N`  
+`SELECTED_N`
+
+`GLOBAL_OPTIMALITY`
 `SELECTED_PORTFOLIO`  
 `FIRST_10_CHALLENGERS`  
 `DECISIVE_REPLACEMENTS`  
@@ -146,8 +148,16 @@ No inventes datos ausentes. Marca cualquier variable no verificada como `UNKNOWN
 
 ## Canonical precedence rule
 
-En cualquier conflicto entre este documento y un prompt, tesis, cartera, amendment, motor o snapshot anterior, **prevalece este documento** para discovery final, scoring comparable, ranking, portfolio membership, replacement y `OPTIMAL_N`.
+En cualquier conflicto entre este documento y un prompt, tesis, cartera, amendment, motor o snapshot anterior, **prevalece este documento** para discovery final, scoring comparable, ranking, portfolio membership, replacement y `SELECTED_N`.
 
 `CURRENT_CANON/2026-09-07_ATLAS_AI_EXPOSURE_CONTROL_OMEGA.md` gobierna específicamente el control operativo/sizing de exposición AI y supersede caps AI previos de 14%, 20%, 25% u otros valores históricos.
 
 Los motores sólo conservan autoridad en la medida en que implementen o suministren evidencia compatible con este contrato.
+
+## Corrección de auditoría autorizada · 7-sep-2026 · issue #184
+
+`ENDOGENOUS N ≠ PROVEN GLOBAL OPTIMUM`. La búsqueda heurística informa `SELECTED_N` y `GLOBAL_OPTIMALITY = NOT_PROVEN`. `OPTIMAL_N` queda reservado a una prueba o certificado suficiente de optimalidad global sobre un objetivo, universo y restricciones declarados. Los campos de compatibilidad `optimalN: null` no deben rellenarse con `selectedN`.
+
+La baja volatilidad sólo tiene valor cuando mejora la utilidad económica; no es un objetivo a cualquier precio. La selección no autoriza por sí sola reemplazo ni ejecución.
+
+Estado de implementación: los selectores ya separaban cardinalidad heurística y optimalidad antes de esta corrección documental. Las unidades de riesgo y el sizing estructural siguen `RESEARCH_PENDING`; tests de software no demuestran calibración económica ni rentabilidad.

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.test.ts
@@ -20,6 +20,38 @@ function c(i:number, er=12, driver=`d${i}`, funding:string[]=[]): PortfolioCandi
   };
 }
 
+describe('Audit 184 — malformed inputs must fail closed', () => {
+  it.each([
+    { riskWeights: { permanentLoss: NaN, tailRisk: 0.2, volatility: 0.8 } },
+    { riskWeights: { permanentLoss: -1, tailRisk: 1, volatility: 1 } },
+    { betaRobustness: NaN }, { gammaConvexity: Infinity },
+    { uncertaintyPenalty: -1 }, { replacementThreshold: { GREEN: -100 } },
+    { maxLocalSearchIterations: Infinity }, { maxLocalSearchIterations: 1.5 },
+  ])('rejects invalid numeric policy %j', policy => {
+    expect(runEndogenousPortfolioEngineV2([c(1)], policy).status).toBe('EVIDENCE_PENDING');
+  });
+  it('rejects a truthy non-boolean gate', () => {
+    const candidate = { ...c(1), hardGatesPassed: 'false' } as unknown as PortfolioCandidateV2;
+    expect(runEndogenousPortfolioEngineV2([candidate]).status).toBe('EVIDENCE_PENDING');
+  });
+  it('does not throw on a missing return bridge', () => {
+    const candidate = { ...c(1), expectedReturn: undefined } as unknown as PortfolioCandidateV2;
+    expect(runEndogenousPortfolioEngineV2([candidate]).status).toBe('EVIDENCE_PENDING');
+  });
+  it('rejects one ticker assigned to different economic entities', () => {
+    expect(runEndogenousPortfolioEngineV2([c(1), { ...c(2), ticker: 'T1' }]).status).toBe('EVIDENCE_PENDING');
+  });
+  it('rejects invalid direct metric inputs', () => {
+    expect(() => evaluatePortfolioSetV2([{ ...c(1), confidence: NaN }])).toThrow('INVALID_PORTFOLIO_INPUT');
+  });
+  it('blocks replacing with an entity already held', () => {
+    expect(evaluateReplacementV2([c(1), c(2)], 'T1', c(2, 99), 'GREEN').allowed).toBe(false);
+  });
+  it('blocks malformed challenger evidence', () => {
+    expect(evaluateReplacementV2([c(1)], 'T1', { ...c(2, 99), confidence: 2 }, 'GREEN').allowed).toBe(false);
+  });
+});
+
 describe('Endogenous Portfolio Engine v2.4 — Point Zero / endogenous local selection',()=>{
   it('has no binding ex-ante cardinality floor or ceiling',()=>{
     expect(MIN_PORTFOLIO_POSITIONS_V2).toBe(0);

--- a/src/atlas/algorithm/endogenous-portfolio-engine-v2.ts
+++ b/src/atlas/algorithm/endogenous-portfolio-engine-v2.ts
@@ -1,4 +1,4 @@
-export const ENDOGENOUS_PORTFOLIO_ENGINE_V2_VERSION = '2026-09-07-v2.4.0' as const;
+export const ENDOGENOUS_PORTFOLIO_ENGINE_V2_VERSION = '2026-09-07-v2.4.1' as const;
 
 // Compatibility exports only. They are non-binding sentinels, not portfolio
 // design constraints. Canonical clean selection has no ex-ante floor/ceiling.
@@ -182,13 +182,18 @@ export function expectedReturnPct(c: PortfolioCandidateV2): number {
 }
 
 function validateCandidate(c: PortfolioCandidateV2): boolean {
-  if (!c.ticker?.trim()) return false;
+  if (!c || typeof c.ticker !== 'string' || !c.ticker.trim()) return false;
+  if (c.canonicalEntityId !== undefined && (typeof c.canonicalEntityId !== 'string' || !c.canonicalEntityId.trim())) return false;
+  if (typeof c.hardGatesPassed !== 'boolean' || typeof c.falsifierVetoPassed !== 'boolean') return false;
+  if (!c.expectedReturn || !c.scenarios || !c.causalDrivers || !Array.isArray(c.fundingSources)) return false;
+  if (!c.fundingSources.every(x => typeof x === 'string')) return false;
   const er = c.expectedReturn;
   const numbers = [
     er.fundamentalGrowthPct, er.cashYieldPct, er.capitalReturnsPct, er.multipleNormalizationPct,
     c.permanentLossRisk, c.tailRisk, c.volatilityRisk, c.fragility, c.convexity, c.confidence, c.individualScore,
   ];
   if (!numbers.every(finite)) return false;
+  if (!finite(expectedReturnPct(c))) return false;
   if (c.confidence < 0 || c.confidence > 1) return false;
   for (const s of CANONICAL_SCENARIOS) {
     if (!finite(c.scenarios?.[s]) || c.scenarios[s] < -5 || c.scenarios[s] > 5) return false;
@@ -209,6 +214,13 @@ function normalizePolicy(policy: PortfolioEnginePolicyV2): NormalizedPolicyV2 | 
     requiredStructuralDrivers: policy.requiredStructuralDrivers ?? [],
   };
   const rw = p.riskWeights;
+  // Numeric policy is an input boundary, not a trusted TypeScript assertion.
+  const nonnegative = [p.missingDriverRobustnessThreshold, p.betaRobustness,
+    p.gammaConvexity, p.lambdaPermanentLoss, p.phiFragility, p.tauTailRisk,
+    p.kappaComplexity, p.uncertaintyPenalty, rw.permanentLoss, rw.tailRisk,
+    rw.volatility, ...Object.values(p.replacementThreshold)];
+  if (!nonnegative.every(x => finite(x) && x >= 0)) return null;
+  if (!Number.isSafeInteger(p.maxLocalSearchIterations) || p.maxLocalSearchIterations < 0) return null;
   if (!finite(p.marginalUtilityThreshold) || p.marginalUtilityThreshold < 0) return null;
   if (Math.abs(rw.permanentLoss + rw.tailRisk + rw.volatility - 1) > 1e-9) return null;
 
@@ -249,8 +261,12 @@ function normalizedEvidenceFingerprint(c: PortfolioCandidateV2): string {
 
 function deduplicateEntities(candidates: PortfolioCandidateV2[]): PortfolioCandidateV2[] | null {
   const byEntity = new Map<string, PortfolioCandidateV2>();
+  const tickerEntities = new Map<string, string>();
   for (const candidate of candidates) {
     const key = entityKey(candidate);
+    const ticker = candidate.ticker.trim().toUpperCase();
+    if (tickerEntities.has(ticker) && tickerEntities.get(ticker) !== key) return null;
+    tickerEntities.set(ticker, key);
     const existing = byEntity.get(key);
     if (!existing) {
       byEntity.set(key, candidate);
@@ -289,7 +305,9 @@ function averagePairwise<T>(xs: T[], fn: (a: T, b: T) => number): number {
 
 export function evaluatePortfolioSetV2(candidates: PortfolioCandidateV2[], policy: PortfolioEnginePolicyV2 = {}): PortfolioMetricsV2 {
   const p = normalizePolicy(policy);
-  if (!p || candidates.length === 0) throw new Error('INVALID_PORTFOLIO_INPUT');
+  if (!p || candidates.length === 0 || candidates.some(c => !validateCandidate(c))) throw new Error('INVALID_PORTFOLIO_INPUT');
+  const unique = deduplicateEntities(candidates);
+  if (!unique || unique.length !== candidates.length) throw new Error('INVALID_PORTFOLIO_INPUT');
   const n = candidates.length;
   const w = 1 / n;
   const er = mean(candidates.map(expectedReturnPct));
@@ -512,7 +530,9 @@ export function evaluateReplacementV2(
   incumbentState: IncumbentState, policy: PortfolioEnginePolicyV2 = {},
 ): ReplacementDecisionV2 {
   const p = normalizePolicy(policy);
-  if (!p || !challenger.hardGatesPassed || !challenger.falsifierVetoPassed) return { allowed: false, deltaPortfolioUtility: Number.NEGATIVE_INFINITY, threshold: Infinity, reason: 'Challenger fails policy or hard gates.' };
+  if (!p || !validateCandidate(challenger) || portfolio.some(c => !validateCandidate(c)) || !challenger.hardGatesPassed || !challenger.falsifierVetoPassed || !['GREEN', 'ORANGE', 'RED'].includes(incumbentState)) return { allowed: false, deltaPortfolioUtility: Number.NEGATIVE_INFINITY, threshold: Infinity, reason: 'Challenger fails policy, evidence or hard gates.' };
+  const unique = deduplicateEntities(portfolio);
+  if (!unique || unique.length !== portfolio.length || portfolio.some(c => entityKey(c) === entityKey(challenger) || c.ticker.trim().toUpperCase() === challenger.ticker.trim().toUpperCase())) return { allowed: false, deltaPortfolioUtility: Number.NEGATIVE_INFINITY, threshold: Infinity, reason: 'Duplicate or conflicting portfolio/challenger identity.' };
   const idx = portfolio.findIndex(c => c.ticker === incumbentTicker);
   if (idx < 0) return { allowed: false, deltaPortfolioUtility: Number.NEGATIVE_INFINITY, threshold: Infinity, reason: 'Incumbent not found.' };
   const before = evaluatePortfolioSetV2(portfolio, p).utility;


### PR DESCRIPTION
Closes #184.

The endogenous selector accepted malformed numerical policies (including NaN/negative risk weights), truthy non-boolean gates, conflicting ticker/entity identities and invalid replacement evidence. These could produce SELECTED or allow a duplicate-entity replacement instead of failing closed.

Validates policy values, gate types, return bridge presence, candidate evidence and portfolio identity at selector, metrics and replacement boundaries. Updates current canon and master prompt to SELECTED_N with explicit global-optimality limitations; replaces automatic replacement wording with the net-rotation gate. Notion master mirror has the matching wording correction.

Validation: 14 new regression cases failed on the base; all pass after correction. 82 tests pass across seven TypeScript suites, including E1–E6, clean selection and structural publication. Two universe test functions passed by direct Python invocation; local pytest is unavailable. git diff --check passed. CI execution is pending verification.

Review: inspected the full diff against current contracts. Valid-input ranking and economic weights are unchanged. No broker actions, no new engine, no risk/sizing promotion. Risk units and covariance-aware sizing remain RESEARCH_PENDING; software tests do not validate expected economic returns.