### PR TITLE
ATLAS AI Ω: executable L0–L4 autonomy + verified post-state

### DIFF
--- a/.github/workflows/architecture-consolidation-ci.yml
+++ b/.github/workflows/architecture-consolidation-ci.yml
@@ -22,9 +22,11 @@ on:
       - 'runtime/agentic_omega/portfolio_finalizer.py'
       - 'runtime/agentic_omega/security_snapshot.py'
       - 'runtime/agentic_omega/point_zero_rebuild.py'
+      - 'runtime/agentic_omega/execution_control.py'
       - 'runtime/agentic_omega/test_universe_competition.py'
       - 'runtime/agentic_omega/test_portfolio_finalizer.py'
       - 'runtime/agentic_omega/test_point_zero_rebuild_pit.py'
+      - 'runtime/agentic_omega/test_execution_control.py'
       - 'api/atlas_core_consolidated.py'
       - 'api/test_atlas_consolidated_boundary.py'
       - 'api/trading212_controlled.py'
@@ -76,7 +78,7 @@ jobs:
           python-version: '3.12'
       - name: Install API test dependencies
         run: pip install -r api/requirements.txt
-      - name: Run public, broker, universe, and runtime Point Zero tests
+      - name: Run public, broker, universe, Point Zero, and execution-control tests
         run: >-
           python -m pytest -q
           api/test_atlas_consolidated_boundary.py
@@ -86,3 +88,4 @@ jobs:
           runtime/agentic_omega/test_universe_competition.py
           runtime/agentic_omega/test_portfolio_finalizer.py
           runtime/agentic_omega/test_point_zero_rebuild_pit.py
+          runtime/agentic_omega/test_execution_control.py

--- a/reports/implementation/2026-09-07_ASTRA_AGENTIC_POINT_ZERO_IMPLEMENTATION.md
+++ b/reports/implementation/2026-09-07_ASTRA_AGENTIC_POINT_ZERO_IMPLEMENTATION.md
@@ -1,0 +1,209 @@
+# ATLAS AI Ω — ASTRA AGENTIC UPGRADE / POINT ZERO
+
+**Date:** 2026-09-07  
+**Classification:** `IMPLEMENTATION_EVIDENCE / NON_CANONICAL / NOT_LIVE`  
+**Issue:** #188  
+**PR:** #189  
+**Branch:** `feat/188-agentic-autonomy-verification`  
+**Base main at branch creation:** `c6b5c0ccc84b61b873feafd052e5a2f99bc126a5`
+
+## 1. Point Zero result
+
+The architectural result is **not** to add an `ASTRA ENGINE` or make ATLAS a wrapper around one model.
+
+The current six-engine architecture remains the authority boundary:
+
+`R0 RESEARCH → E1 EVIDENCE → E2 ASSESSMENT → E3 GATE → E4 DECISION → EXECUTION`
+
+with `E5 CONTROL` transversal and `E6 ASSURANCE` independent.
+
+The highest-value non-redundant gap found was below E4: ATLAS had permission policy, durable audit ledgers, capability evidence and decision `OutcomeReceipt`s, but no executable state machine proving that an external action had reached its declared post-state. `READY_FOR_EXECUTION_GATE` correctly meant only that evidence/decision gates had passed.
+
+## 2. Model intelligence vs ATLAS intelligence
+
+### Model intelligence
+
+A replaceable foundation model may provide:
+
+- intent interpretation;
+- research strategy;
+- reasoning and hypothesis generation;
+- planning;
+- tool-argument generation;
+- code/document generation;
+- adaptation to new requirements.
+
+### ATLAS intelligence
+
+ATLAS must own and persist independently of the model:
+
+- authority hierarchy and latest-canon resolution;
+- epistemic labels and provenance;
+- context-retrieval policy;
+- E1–E6 contracts;
+- permissions and autonomy policy;
+- risk/domain classification;
+- human-approval gates;
+- idempotency and execution state;
+- postcondition verification;
+- durable audit/recovery;
+- memory-persistence gates;
+- adversarial evaluation and calibration.
+
+Astra is therefore a candidate model/runtime capability provider underneath ATLAS, never an authority source by itself.
+
+## 3. Target pipeline
+
+`INTENT → AUTHORITY RESOLUTION (CANON + MEMORY CLASS) → CONTEXT RETRIEVAL → EVIDENCE PACKET → E2 ASSESSMENT/REASONING → E3 GATES → E4 DECISION → ACTION PLAN → E5 CAPABILITY + AUTONOMY POLICY → TOOL EXECUTION → E6 POSTCONDITION VERIFICATION → E5 CLOSEOUT/CONTROL → AUDIT LEDGER → MEMORY PROPOSAL → PERSISTENCE GATE`
+
+Important correction to a naive linear agent pipeline: E5 must gate **before** execution, and E6 must independently verify the resulting post-state. Control is not merely a terminal step.
+
+## 4. Executable autonomy ladder added
+
+Subordinate to E5/E6, not a new engine:
+
+- `L0_READ_ONLY` — retrieval and analysis; no external mutation.
+- `L1_PROPOSE` — prepare an action; no execution.
+- `L2_SAFE_WRITE` — reversible low-impact write with explicit compensation plan and postconditions.
+- `L3_CONTROLLED_EXECUTION` — material execution only with verified pre-state, declared postconditions and E5/E6 controls.
+- `L4_HUMAN_APPROVAL_REQUIRED` — high-impact/sovereign action requiring explicit human approval.
+
+Current conservative mandatory-L4 domains:
+
+- external actions;
+- financial actions;
+- legal actions;
+- medical actions;
+- credential changes;
+- production actions.
+
+`MODIFY_CANON` remains outside agentic self-authorization even when approval metadata is present; a separate human governance action is required.
+
+## 5. Evidence / Decision / Execution firewall
+
+New runtime: `runtime/agentic_omega/execution_control.py`.
+
+State machine:
+
+`AUTHORIZED → EXECUTED_UNVERIFIED → VERIFIED_COMPLETE`
+
+with fail-closed branches:
+
+- `BLOCKED`;
+- `UNKNOWN_POSTSTATE`;
+- `ROLLBACK_REQUIRED`.
+
+Invariants:
+
+1. A model/tool claim that an operation succeeded is not completion evidence.
+2. `MODEL_SELF_REPORT` cannot satisfy post-state verification.
+3. Every write/material action declares postconditions before authorization.
+4. Every declared postcondition requires independent readback evidence.
+5. Conflicting post-state evidence produces `UNKNOWN_POSTSTATE`, never success.
+6. Failed reversible writes produce `ROLLBACK_REQUIRED`.
+7. Material actions with stale/unknown or unverified pre-state fail closed.
+8. Action risk can promote autonomy upward; a request/model cannot downgrade the required level.
+9. Idempotency fingerprints block duplicate action attempts.
+10. Authorized/executed state and idempotency bindings are reconstructed from the audit ledger after restart.
+
+## 6. Failure-mode coverage
+
+| Failure | Detection | Gate / mitigation | Verification / recovery |
+|---|---|---|---|
+| Hallucinated completion | no independent postcondition evidence | cannot enter `VERIFIED_COMPLETE` | API/tool/file/system readback; remain unverified |
+| Stale context | pre-state UNKNOWN/unverified | material action blocked | refresh world state before retry |
+| Wrong canon | authority resolution + latest authorized current object | no action from stale authority | reload current canon and context hash |
+| Duplicate action | idempotency fingerprint | duplicate authorization blocked | reconcile ledger/external state |
+| Agent restart | ledger rehydration | preserve prior action state | resume verification, not re-execution |
+| Tool misuse | exact-route capability + E5 permission boundary | fail closed outside allowed route | post-state readback + audit |
+| Destructive/high impact | L4 classification | human approval | post-state verification; recovery/manual rollback |
+| Privilege escalation | autonomy cannot expand component permission | E5 policy remains sovereign | permission/audit ledger |
+| Prompt injection | external content remains evidence candidate only | no authority transfer from content | provenance + E1/E3 checks |
+| Memory contamination | canonical persistence separately gated | no automatic canon/memory promotion | dual persistence/provenance reconciliation |
+| GitHub/Notion contradiction | authority hierarchy + dual-persistence state | incomplete/contradictory state is not completion | reconcile exact identifiers |
+| Correct action, wrong decision | E1→E4 remain upstream of execution | execution controller cannot decide objectives | E6 outcome audit + human gate where material |
+
+## 7. Astra capability delta — evidence rule
+
+Public product claims and benchmark results are not treated as evidence that a capability is available on a particular ATLAS route.
+
+A capability must be separated as:
+
+`ANNOUNCED / AVAILABLE_HERE / TESTED / RELIABLE / NOT_AVAILABLE / UNKNOWN`.
+
+As of 2026-09-07, official OpenAI material supports Astra improvements in coding, research, browsing/computer use, complex multi-step work and creation of documents/spreadsheets/presentations. Work supports longer multi-step deliverables and eligible scheduled/event-triggered work. Rollout is account/surface dependent.
+
+The current implementation therefore depends on **capability evidence for the exact route**, not on the model name. GitHub and Notion routes used in this implementation were actually exercised; generic Astra computer-use/subagent capability was not inferred from announcements.
+
+## 8. External pattern extraction
+
+The useful pattern from CRM/messaging/automation systems is architectural, not vendor-specific:
+
+`TRIGGER / INTENT → IDEMPOTENT COMMAND → ACKNOWLEDGED EXECUTION → ASYNCHRONOUS STATUS OR READBACK → VERIFIED POST-STATE → RECOVERY`
+
+This is superior to the unsafe pattern:
+
+`AGENT SAID DONE → MARK COMPLETE`.
+
+ATLAS should ingest external methods through:
+
+`DISCOVER → VERIFY → EXTRACT PATTERN → GENERALIZE → COMPARE AGAINST ATLAS → IMPLEMENT IF SUPERIOR → TEST → MEASURE`.
+
+No external tool receives architectural authority merely because it is new or popular.
+
+## 9. Implementation ledger
+
+| Change | State |
+|---|---|
+| Issue #188 | OPEN / authoritative work item |
+| Branch `feat/188-agentic-autonomy-verification` | IMPLEMENTED |
+| `runtime/agentic_omega/execution_control.py` | IMPLEMENTED_ON_BRANCH |
+| `runtime/agentic_omega/test_execution_control.py` | TESTED_ON_BRANCH |
+| `src/atlas/algorithm/e5-control-policy-omega.ts` v1.1.0 | IMPLEMENTED_ON_BRANCH |
+| `src/atlas/algorithm/e5-control-policy-omega.test.ts` | TESTED_ON_BRANCH |
+| Architecture Consolidation CI integration | IMPLEMENTED_ON_BRANCH |
+| Restart recovery + durable idempotency reconstruction | IMPLEMENTED_ON_BRANCH / TESTED |
+| PR #189 | OPEN / NOT_MERGED |
+| main | UNCHANGED BY THIS UPGRADE |
+| LIVE production/runtime promotion | NOT_CLAIMED |
+
+Latest CI evidence before this documentation commit, on head `b8aca7114df8d16484182b70f3ee7b5834d32205`:
+
+- `ATLAS Architecture Consolidation CI` run `34136594280` — `SUCCESS`;
+- `ATLAS E5-E6 Control Assurance CI` run `34136594328` — `SUCCESS`;
+- `Agentic Runtime Omega v2 CI` run `34136594345` — `SUCCESS`.
+
+Because this report is itself another PR commit, CI must be checked again on the final PR head before merge. Historical green runs must not be promoted to final-head evidence.
+
+## 10. Remaining gaps
+
+### A. Cross-process atomic action reservation
+
+Restart persistence is implemented, but simultaneous independent processes could still perform a check-then-bind race before the durable ledger append is observed. Required follow-up: an atomic durable action reservation/lease around idempotency authorization.
+
+### B. Live Continuity Binding
+
+Notion records that PR #160 remains blocked because the GitHub repository lacks `NOTION_API_KEY`; the real 10-case Notion continuity smoke was not executed. Unit/runtime PASS is not live-memory evidence.
+
+### C. Shutdown drill
+
+S1–S8 are specified/tested, but the full live external scheduling shutdown drill remains `SPECIFIED_NOT_EXECUTED`.
+
+### D. Generic Astra computer use / delegation
+
+Official product capability is not the same as exact-route ATLAS evidence. Generic GUI computer use and true model-level subagent delegation remain unverified in this implementation environment unless exercised on the exact route.
+
+### E. Human-review gate
+
+PR #189 must still pass the repository contract: review → merge. CI success is not review authority and not production promotion.
+
+## 11. Promotion rule
+
+Do not label this upgrade `MAIN`, `LIVE`, or `PRODUCTION` until:
+
+1. final PR head has green required CI;
+2. human review is complete;
+3. PR #189 is merged according to repository governance;
+4. any runtime deployment has its own post-deploy verification evidence.
+
+> The model may execute work. ATLAS decides whether it was authorized, whether it actually happened, and whether the resulting state is acceptable.

--- a/runtime/agentic_omega/execution_control.py
+++ b/runtime/agentic_omega/execution_control.py
@@ -65,6 +65,9 @@ class ActionState(str, Enum):
 
 
 class EventLedger(Protocol):
+    @property
+    def events(self) -> tuple[dict, ...]: ...
+
     def append(self, event_type: str, payload: dict) -> dict: ...
 
 
@@ -184,6 +187,74 @@ class AgenticExecutionController:
         self._receipts: dict[str, ActionReceipt] = {}
         self._idempotency: dict[str, str] = {}
         self._execution_started: set[str] = set()
+        self._hydrate_from_ledger()
+
+    def _request_snapshot(self, request: ActionRequest) -> dict:
+        return {
+            "objective": request.objective,
+            "operation": request.operation.value,
+            "domain": request.domain.value,
+            "tool": request.tool,
+            "target": request.target,
+            "requested_level": int(request.requested_level),
+            "reversible": request.reversible,
+            "compensation_action": request.compensation_action,
+            "expected_postconditions": list(request.expected_postconditions),
+            "pre_state_class": request.pre_state_class.value,
+            "pre_state_verified": request.pre_state_verified,
+            "human_approval_present": bool(request.human_approval_id.strip()),
+            "decision_receipt_id": request.decision_receipt_id,
+        }
+
+    def _hydrate_from_ledger(self) -> None:
+        if self.ledger is None:
+            return
+        events = tuple(getattr(self.ledger, "events", ()) or ())
+        for event in events:
+            payload = event.get("payload", {})
+            action_id = payload.get("action_id")
+            receipt_data = payload.get("receipt")
+            request_data = payload.get("request")
+            if not action_id or not isinstance(receipt_data, dict):
+                continue
+
+            fp = str(receipt_data.get("idempotency_fingerprint", ""))
+            if event.get("event_type") == "ACTION_AUTHORIZED" and request_data and fp:
+                restored = ActionRequest(
+                    objective=str(request_data["objective"]),
+                    operation=ActionOperation(request_data["operation"]),
+                    domain=ActionDomain(request_data["domain"]),
+                    tool=str(request_data["tool"]),
+                    target=str(request_data["target"]),
+                    idempotency_key=f"RESTORED:{fp}",
+                    requested_level=AutonomyLevel(int(request_data["requested_level"])),
+                    reversible=bool(request_data["reversible"]),
+                    compensation_action=str(request_data.get("compensation_action", "")),
+                    expected_postconditions=tuple(request_data.get("expected_postconditions", ())),
+                    pre_state_class=WorldStateClass(request_data["pre_state_class"]),
+                    pre_state_verified=bool(request_data["pre_state_verified"]),
+                    human_approval_id="RESTORED_APPROVAL" if request_data.get("human_approval_present") else "",
+                    decision_receipt_id=str(request_data.get("decision_receipt_id", "")),
+                    action_id=str(action_id),
+                )
+                self._requests[str(action_id)] = restored
+                self._idempotency[fp] = str(action_id)
+
+            if str(action_id) not in self._requests:
+                continue
+            state = ActionState(receipt_data["state"])
+            restored_receipt = ActionReceipt(
+                action_id=str(action_id),
+                state=state,
+                required_level=AutonomyLevel(int(receipt_data["required_level"])),
+                reason=str(receipt_data.get("reason", "")),
+                idempotency_fingerprint=fp,
+                evidence_ids=tuple(receipt_data.get("evidence_ids", ())),
+                emitted_at=str(receipt_data.get("emitted_at", datetime.now(timezone.utc).isoformat())),
+            )
+            self._receipts[str(action_id)] = restored_receipt
+            if state is not ActionState.AUTHORIZED:
+                self._execution_started.add(str(action_id))
 
     def _emit(self, event_type: str, request: ActionRequest, receipt: ActionReceipt) -> ActionReceipt:
         self._receipts[request.action_id] = receipt
@@ -197,6 +268,7 @@ class AgenticExecutionController:
                     "tool": request.tool,
                     "target": request.target,
                     "decision_receipt_id": request.decision_receipt_id,
+                    "request": self._request_snapshot(request),
                     "receipt": {
                         **asdict(receipt),
                         "state": receipt.state.value,

--- a/runtime/agentic_omega/execution_control.py
+++ b/runtime/agentic_omega/execution_control.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum, IntEnum
+from typing import Protocol, Sequence
+
+
+class AutonomyLevel(IntEnum):
+    L0_READ_ONLY = 0
+    L1_PROPOSE = 1
+    L2_SAFE_WRITE = 2
+    L3_CONTROLLED_EXECUTION = 3
+    L4_HUMAN_APPROVAL_REQUIRED = 4
+
+
+class ActionOperation(str, Enum):
+    READ = "READ"
+    PROPOSE = "PROPOSE"
+    WRITE = "WRITE"
+    EXECUTE = "EXECUTE"
+    COMMUNICATE = "COMMUNICATE"
+    SCHEDULE = "SCHEDULE"
+    DELEGATE = "DELEGATE"
+    DELETE = "DELETE"
+    MODIFY_CANON = "MODIFY_CANON"
+
+
+class ActionDomain(str, Enum):
+    INTERNAL = "INTERNAL"
+    EXTERNAL = "EXTERNAL"
+    FINANCIAL = "FINANCIAL"
+    LEGAL = "LEGAL"
+    MEDICAL = "MEDICAL"
+    CREDENTIAL = "CREDENTIAL"
+    PRODUCTION = "PRODUCTION"
+
+
+class WorldStateClass(str, Enum):
+    STABLE = "STABLE"
+    TIME_SENSITIVE = "TIME_SENSITIVE"
+    VOLATILE = "VOLATILE"
+    UNKNOWN = "UNKNOWN"
+
+
+class VerificationSource(str, Enum):
+    TOOL_READBACK = "TOOL_READBACK"
+    API_READBACK = "API_READBACK"
+    FILE_HASH = "FILE_HASH"
+    SYSTEM_OBSERVATION = "SYSTEM_OBSERVATION"
+    HUMAN_CONFIRMATION = "HUMAN_CONFIRMATION"
+    MODEL_SELF_REPORT = "MODEL_SELF_REPORT"
+
+
+class ActionState(str, Enum):
+    PROPOSED = "PROPOSED"
+    AUTHORIZED = "AUTHORIZED"
+    BLOCKED = "BLOCKED"
+    EXECUTED_UNVERIFIED = "EXECUTED_UNVERIFIED"
+    VERIFIED_COMPLETE = "VERIFIED_COMPLETE"
+    UNKNOWN_POSTSTATE = "UNKNOWN_POSTSTATE"
+    ROLLBACK_REQUIRED = "ROLLBACK_REQUIRED"
+
+
+class EventLedger(Protocol):
+    def append(self, event_type: str, payload: dict) -> dict: ...
+
+
+@dataclass(frozen=True)
+class ActionRequest:
+    objective: str
+    operation: ActionOperation
+    domain: ActionDomain
+    tool: str
+    target: str
+    idempotency_key: str
+    requested_level: AutonomyLevel = AutonomyLevel.L0_READ_ONLY
+    reversible: bool = False
+    compensation_action: str = ""
+    expected_postconditions: tuple[str, ...] = ()
+    pre_state_class: WorldStateClass = WorldStateClass.UNKNOWN
+    pre_state_verified: bool = False
+    human_approval_id: str = ""
+    decision_receipt_id: str = ""
+    action_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def __post_init__(self) -> None:
+        for name, value in {
+            "objective": self.objective,
+            "tool": self.tool,
+            "target": self.target,
+            "idempotency_key": self.idempotency_key,
+        }.items():
+            if not value.strip():
+                raise ValueError(f"{name} must be non-empty")
+
+
+@dataclass(frozen=True)
+class PostconditionEvidence:
+    postcondition: str
+    source_kind: VerificationSource
+    source: str
+    observed_at: str
+    matches_expected: bool
+    evidence_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def __post_init__(self) -> None:
+        if not self.postcondition.strip():
+            raise ValueError("postcondition must be non-empty")
+        if not self.source.strip():
+            raise ValueError("source must be non-empty")
+        if not self.observed_at.strip():
+            raise ValueError("observed_at must be non-empty")
+
+
+@dataclass(frozen=True)
+class ActionReceipt:
+    action_id: str
+    state: ActionState
+    required_level: AutonomyLevel
+    reason: str
+    idempotency_fingerprint: str
+    evidence_ids: tuple[str, ...] = ()
+    emitted_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+_OPERATION_FLOOR = {
+    ActionOperation.READ: AutonomyLevel.L0_READ_ONLY,
+    ActionOperation.PROPOSE: AutonomyLevel.L1_PROPOSE,
+    ActionOperation.WRITE: AutonomyLevel.L2_SAFE_WRITE,
+    ActionOperation.EXECUTE: AutonomyLevel.L3_CONTROLLED_EXECUTION,
+    ActionOperation.SCHEDULE: AutonomyLevel.L3_CONTROLLED_EXECUTION,
+    ActionOperation.DELEGATE: AutonomyLevel.L3_CONTROLLED_EXECUTION,
+    ActionOperation.COMMUNICATE: AutonomyLevel.L4_HUMAN_APPROVAL_REQUIRED,
+    ActionOperation.DELETE: AutonomyLevel.L4_HUMAN_APPROVAL_REQUIRED,
+    ActionOperation.MODIFY_CANON: AutonomyLevel.L4_HUMAN_APPROVAL_REQUIRED,
+}
+
+_HUMAN_APPROVAL_DOMAINS = {
+    ActionDomain.EXTERNAL,
+    ActionDomain.FINANCIAL,
+    ActionDomain.LEGAL,
+    ActionDomain.MEDICAL,
+    ActionDomain.CREDENTIAL,
+    ActionDomain.PRODUCTION,
+}
+
+_INDEPENDENT_VERIFICATION_SOURCES = {
+    VerificationSource.TOOL_READBACK,
+    VerificationSource.API_READBACK,
+    VerificationSource.FILE_HASH,
+    VerificationSource.SYSTEM_OBSERVATION,
+    VerificationSource.HUMAN_CONFIRMATION,
+}
+
+
+def autonomy_required(request: ActionRequest) -> AutonomyLevel:
+    required = _OPERATION_FLOOR[request.operation]
+    if request.domain in _HUMAN_APPROVAL_DOMAINS:
+        required = max(required, AutonomyLevel.L4_HUMAN_APPROVAL_REQUIRED)
+    if request.operation is ActionOperation.WRITE and not request.reversible:
+        required = max(required, AutonomyLevel.L3_CONTROLLED_EXECUTION)
+    return AutonomyLevel(max(int(required), int(request.requested_level)))
+
+
+def _fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class AgenticExecutionController:
+    """E5/E6 action state machine.
+
+    This controller never decides *what* ATLAS should do. It only decides
+    whether an already-produced action request may cross the execution
+    boundary and whether the external post-state has been independently
+    verified.
+    """
+
+    def __init__(self, ledger: EventLedger | None = None) -> None:
+        self.ledger = ledger
+        self._requests: dict[str, ActionRequest] = {}
+        self._receipts: dict[str, ActionReceipt] = {}
+        self._idempotency: dict[str, str] = {}
+        self._execution_started: set[str] = set()
+
+    def _emit(self, event_type: str, request: ActionRequest, receipt: ActionReceipt) -> ActionReceipt:
+        self._receipts[request.action_id] = receipt
+        if self.ledger is not None:
+            self.ledger.append(
+                event_type,
+                {
+                    "action_id": request.action_id,
+                    "operation": request.operation.value,
+                    "domain": request.domain.value,
+                    "tool": request.tool,
+                    "target": request.target,
+                    "decision_receipt_id": request.decision_receipt_id,
+                    "receipt": {
+                        **asdict(receipt),
+                        "state": receipt.state.value,
+                        "required_level": int(receipt.required_level),
+                    },
+                },
+            )
+        return receipt
+
+    def authorize(self, request: ActionRequest) -> ActionReceipt:
+        required = autonomy_required(request)
+        fp = _fingerprint(request.idempotency_key)
+
+        existing_action = self._idempotency.get(fp)
+        if existing_action is not None:
+            receipt = ActionReceipt(
+                action_id=request.action_id,
+                state=ActionState.BLOCKED,
+                required_level=required,
+                reason=f"DUPLICATE_ACTION: idempotency key already bound to {existing_action}",
+                idempotency_fingerprint=fp,
+            )
+            return self._emit("ACTION_BLOCKED", request, receipt)
+
+        reason = self._authorization_block_reason(request, required)
+        if reason:
+            receipt = ActionReceipt(
+                action_id=request.action_id,
+                state=ActionState.BLOCKED,
+                required_level=required,
+                reason=reason,
+                idempotency_fingerprint=fp,
+            )
+            return self._emit("ACTION_BLOCKED", request, receipt)
+
+        self._idempotency[fp] = request.action_id
+        self._requests[request.action_id] = request
+        receipt = ActionReceipt(
+            action_id=request.action_id,
+            state=ActionState.AUTHORIZED,
+            required_level=required,
+            reason="E5 authorization conditions satisfied; execution is not yet evidence of completion",
+            idempotency_fingerprint=fp,
+        )
+        return self._emit("ACTION_AUTHORIZED", request, receipt)
+
+    def _authorization_block_reason(
+        self,
+        request: ActionRequest,
+        required: AutonomyLevel,
+    ) -> str:
+        if request.operation is ActionOperation.MODIFY_CANON:
+            return "MODIFY_CANON requires a separate human governance action; agentic execution cannot self-authorize"
+
+        if required >= AutonomyLevel.L2_SAFE_WRITE and not request.expected_postconditions:
+            return "WRITE_OR_EXECUTE_REQUIRES_EXPLICIT_POSTCONDITIONS"
+
+        if required is AutonomyLevel.L2_SAFE_WRITE:
+            if not request.reversible or not request.compensation_action.strip():
+                return "L2_SAFE_WRITE_REQUIRES_REVERSIBILITY_AND_COMPENSATION"
+
+        if required >= AutonomyLevel.L3_CONTROLLED_EXECUTION:
+            if request.pre_state_class is WorldStateClass.UNKNOWN:
+                return "ACTION_BLOCKED_STALE_ASSUMPTION: pre-state UNKNOWN"
+            if not request.pre_state_verified:
+                return "ACTION_BLOCKED_STALE_ASSUMPTION: material pre-state not verified"
+
+        if required is AutonomyLevel.L4_HUMAN_APPROVAL_REQUIRED and not request.human_approval_id.strip():
+            return "HUMAN_APPROVAL_REQUIRED"
+
+        return ""
+
+    def mark_executed(
+        self,
+        action_id: str,
+        *,
+        execution_reference: str,
+        agent_claim: str = "",
+    ) -> ActionReceipt:
+        request = self._require_authorized(action_id)
+        previous = self._receipts[action_id]
+        if action_id in self._execution_started or previous.state is not ActionState.AUTHORIZED:
+            raise RuntimeError("duplicate or invalid execution transition")
+        if not execution_reference.strip():
+            raise ValueError("execution_reference must be non-empty")
+
+        self._execution_started.add(action_id)
+        receipt = ActionReceipt(
+            action_id=action_id,
+            state=ActionState.EXECUTED_UNVERIFIED,
+            required_level=previous.required_level,
+            reason=(
+                "tool/action execution was reported but postconditions are not yet independently verified"
+                + (f"; agent_claim={agent_claim.strip()}" if agent_claim.strip() else "")
+            ),
+            idempotency_fingerprint=previous.idempotency_fingerprint,
+        )
+        return self._emit("ACTION_EXECUTED_UNVERIFIED", request, receipt)
+
+    def verify(
+        self,
+        action_id: str,
+        evidence: Sequence[PostconditionEvidence],
+    ) -> ActionReceipt:
+        request = self._require_authorized(action_id)
+        previous = self._receipts[action_id]
+        if previous.state not in {
+            ActionState.EXECUTED_UNVERIFIED,
+            ActionState.UNKNOWN_POSTSTATE,
+        }:
+            raise RuntimeError("verification requires an executed, unverified action")
+
+        expected = tuple(request.expected_postconditions)
+        by_postcondition: dict[str, list[PostconditionEvidence]] = {item: [] for item in expected}
+        for item in evidence:
+            if item.postcondition in by_postcondition:
+                by_postcondition[item.postcondition].append(item)
+
+        evidence_ids = tuple(item.evidence_id for item in evidence)
+        if any(item.source_kind is VerificationSource.MODEL_SELF_REPORT for item in evidence):
+            receipt = ActionReceipt(
+                action_id=action_id,
+                state=ActionState.EXECUTED_UNVERIFIED,
+                required_level=previous.required_level,
+                reason="MODEL_SELF_REPORT_IS_NOT_POSTSTATE_EVIDENCE",
+                idempotency_fingerprint=previous.idempotency_fingerprint,
+                evidence_ids=evidence_ids,
+            )
+            return self._emit("ACTION_VERIFICATION_INSUFFICIENT", request, receipt)
+
+        missing = [name for name, items in by_postcondition.items() if not items]
+        if missing:
+            receipt = ActionReceipt(
+                action_id=action_id,
+                state=ActionState.EXECUTED_UNVERIFIED,
+                required_level=previous.required_level,
+                reason="MISSING_POSTCONDITION_EVIDENCE: " + ", ".join(missing),
+                idempotency_fingerprint=previous.idempotency_fingerprint,
+                evidence_ids=evidence_ids,
+            )
+            return self._emit("ACTION_VERIFICATION_INSUFFICIENT", request, receipt)
+
+        conflict = any(
+            len({item.matches_expected for item in items}) > 1
+            for items in by_postcondition.values()
+        )
+        if conflict:
+            receipt = ActionReceipt(
+                action_id=action_id,
+                state=ActionState.UNKNOWN_POSTSTATE,
+                required_level=previous.required_level,
+                reason="CONFLICTING_POSTCONDITION_EVIDENCE",
+                idempotency_fingerprint=previous.idempotency_fingerprint,
+                evidence_ids=evidence_ids,
+            )
+            return self._emit("ACTION_POSTSTATE_UNKNOWN", request, receipt)
+
+        failed = [
+            name
+            for name, items in by_postcondition.items()
+            if any(not item.matches_expected for item in items)
+        ]
+        if failed:
+            state = ActionState.ROLLBACK_REQUIRED if request.reversible else ActionState.UNKNOWN_POSTSTATE
+            receipt = ActionReceipt(
+                action_id=action_id,
+                state=state,
+                required_level=previous.required_level,
+                reason="POSTCONDITION_FAILED: " + ", ".join(failed),
+                idempotency_fingerprint=previous.idempotency_fingerprint,
+                evidence_ids=evidence_ids,
+            )
+            event = "ACTION_ROLLBACK_REQUIRED" if state is ActionState.ROLLBACK_REQUIRED else "ACTION_POSTSTATE_UNKNOWN"
+            return self._emit(event, request, receipt)
+
+        if any(item.source_kind not in _INDEPENDENT_VERIFICATION_SOURCES for item in evidence):
+            receipt = ActionReceipt(
+                action_id=action_id,
+                state=ActionState.EXECUTED_UNVERIFIED,
+                required_level=previous.required_level,
+                reason="INDEPENDENT_VERIFICATION_SOURCE_REQUIRED",
+                idempotency_fingerprint=previous.idempotency_fingerprint,
+                evidence_ids=evidence_ids,
+            )
+            return self._emit("ACTION_VERIFICATION_INSUFFICIENT", request, receipt)
+
+        receipt = ActionReceipt(
+            action_id=action_id,
+            state=ActionState.VERIFIED_COMPLETE,
+            required_level=previous.required_level,
+            reason="all declared postconditions independently verified",
+            idempotency_fingerprint=previous.idempotency_fingerprint,
+            evidence_ids=evidence_ids,
+        )
+        return self._emit("ACTION_VERIFIED_COMPLETE", request, receipt)
+
+    def receipt(self, action_id: str) -> ActionReceipt:
+        try:
+            return self._receipts[action_id]
+        except KeyError as exc:
+            raise KeyError(f"unknown action_id: {action_id}") from exc
+
+    def _require_authorized(self, action_id: str) -> ActionRequest:
+        try:
+            return self._requests[action_id]
+        except KeyError as exc:
+            raise RuntimeError("action is not authorized") from exc

--- a/runtime/agentic_omega/test_execution_control.py
+++ b/runtime/agentic_omega/test_execution_control.py
@@ -1,0 +1,194 @@
+from datetime import datetime, timezone
+
+from runtime.agentic_omega.execution_control import (
+    ActionDomain,
+    ActionOperation,
+    ActionRequest,
+    ActionState,
+    AgenticExecutionController,
+    AutonomyLevel,
+    PostconditionEvidence,
+    VerificationSource,
+    WorldStateClass,
+    autonomy_required,
+)
+
+
+NOW = datetime.now(timezone.utc).isoformat()
+
+
+def request(**overrides):
+    base = dict(
+        objective="update reversible internal state",
+        operation=ActionOperation.WRITE,
+        domain=ActionDomain.INTERNAL,
+        tool="notion",
+        target="internal draft",
+        idempotency_key="idem-default",
+        requested_level=AutonomyLevel.L2_SAFE_WRITE,
+        reversible=True,
+        compensation_action="restore previous draft",
+        expected_postconditions=("draft updated",),
+        pre_state_class=WorldStateClass.STABLE,
+        pre_state_verified=True,
+    )
+    base.update(overrides)
+    return ActionRequest(**base)
+
+
+def evidence(postcondition="draft updated", *, matches=True, source_kind=VerificationSource.API_READBACK):
+    return PostconditionEvidence(
+        postcondition=postcondition,
+        source_kind=source_kind,
+        source="readback://target",
+        observed_at=NOW,
+        matches_expected=matches,
+    )
+
+
+def test_autonomy_floor_cannot_be_downgraded_by_request():
+    material = request(
+        operation=ActionOperation.EXECUTE,
+        domain=ActionDomain.FINANCIAL,
+        requested_level=AutonomyLevel.L0_READ_ONLY,
+        idempotency_key="financial-floor",
+    )
+    assert autonomy_required(material) is AutonomyLevel.L4_HUMAN_APPROVAL_REQUIRED
+
+
+def test_nonreversible_write_is_promoted_out_of_l2_safe_write():
+    controller = AgenticExecutionController()
+    unsafe = request(reversible=False, compensation_action="", idempotency_key="unsafe-l2")
+    receipt = controller.authorize(unsafe)
+    assert receipt.state is ActionState.AUTHORIZED
+    assert receipt.required_level is AutonomyLevel.L3_CONTROLLED_EXECUTION
+
+
+def test_l2_reversible_write_requires_compensation_metadata():
+    controller = AgenticExecutionController()
+    action = request(compensation_action="", idempotency_key="missing-compensation")
+    receipt = controller.authorize(action)
+    assert receipt.state is ActionState.BLOCKED
+    assert receipt.reason == "L2_SAFE_WRITE_REQUIRES_REVERSIBILITY_AND_COMPENSATION"
+
+
+def test_l4_material_action_requires_human_approval():
+    controller = AgenticExecutionController()
+    material = request(
+        operation=ActionOperation.EXECUTE,
+        domain=ActionDomain.EXTERNAL,
+        idempotency_key="external-no-approval",
+        human_approval_id="",
+    )
+    receipt = controller.authorize(material)
+    assert receipt.state is ActionState.BLOCKED
+    assert receipt.reason == "HUMAN_APPROVAL_REQUIRED"
+
+
+def test_unknown_or_unverified_pre_state_fails_closed_for_material_action():
+    controller = AgenticExecutionController()
+    material = request(
+        operation=ActionOperation.EXECUTE,
+        requested_level=AutonomyLevel.L3_CONTROLLED_EXECUTION,
+        idempotency_key="stale",
+        pre_state_class=WorldStateClass.UNKNOWN,
+        pre_state_verified=False,
+    )
+    receipt = controller.authorize(material)
+    assert receipt.state is ActionState.BLOCKED
+    assert "ACTION_BLOCKED_STALE_ASSUMPTION" in receipt.reason
+
+
+def test_idempotency_key_blocks_duplicate_action_attempt():
+    controller = AgenticExecutionController()
+    first = request(idempotency_key="same-idem")
+    second = request(idempotency_key="same-idem")
+    assert controller.authorize(first).state is ActionState.AUTHORIZED
+    duplicate = controller.authorize(second)
+    assert duplicate.state is ActionState.BLOCKED
+    assert duplicate.reason.startswith("DUPLICATE_ACTION")
+
+
+def test_execution_claim_never_equals_verified_completion():
+    controller = AgenticExecutionController()
+    action = request(idempotency_key="claim-not-proof")
+    assert controller.authorize(action).state is ActionState.AUTHORIZED
+    receipt = controller.mark_executed(
+        action.action_id,
+        execution_reference="tool-receipt-123",
+        agent_claim="I completed it successfully",
+    )
+    assert receipt.state is ActionState.EXECUTED_UNVERIFIED
+
+
+def test_model_self_report_cannot_verify_poststate():
+    controller = AgenticExecutionController()
+    action = request(idempotency_key="self-report")
+    controller.authorize(action)
+    controller.mark_executed(action.action_id, execution_reference="tool-receipt-124")
+    receipt = controller.verify(
+        action.action_id,
+        [evidence(source_kind=VerificationSource.MODEL_SELF_REPORT)],
+    )
+    assert receipt.state is ActionState.EXECUTED_UNVERIFIED
+    assert receipt.reason == "MODEL_SELF_REPORT_IS_NOT_POSTSTATE_EVIDENCE"
+
+
+def test_all_declared_postconditions_require_independent_readback():
+    controller = AgenticExecutionController()
+    action = request(
+        idempotency_key="two-postconditions",
+        expected_postconditions=("draft updated", "audit row exists"),
+    )
+    controller.authorize(action)
+    controller.mark_executed(action.action_id, execution_reference="tool-receipt-125")
+
+    partial = controller.verify(action.action_id, [evidence("draft updated")])
+    assert partial.state is ActionState.EXECUTED_UNVERIFIED
+    assert "audit row exists" in partial.reason
+
+    complete = controller.verify(
+        action.action_id,
+        [
+            evidence("draft updated"),
+            evidence("audit row exists", source_kind=VerificationSource.SYSTEM_OBSERVATION),
+        ],
+    )
+    assert complete.state is ActionState.VERIFIED_COMPLETE
+
+
+def test_conflicting_postcondition_evidence_produces_unknown_poststate():
+    controller = AgenticExecutionController()
+    action = request(idempotency_key="conflict")
+    controller.authorize(action)
+    controller.mark_executed(action.action_id, execution_reference="tool-receipt-126")
+    receipt = controller.verify(
+        action.action_id,
+        [
+            evidence(matches=True),
+            evidence(matches=False, source_kind=VerificationSource.SYSTEM_OBSERVATION),
+        ],
+    )
+    assert receipt.state is ActionState.UNKNOWN_POSTSTATE
+
+
+def test_failed_postcondition_requires_rollback_when_reversible():
+    controller = AgenticExecutionController()
+    action = request(idempotency_key="rollback")
+    controller.authorize(action)
+    controller.mark_executed(action.action_id, execution_reference="tool-receipt-127")
+    receipt = controller.verify(action.action_id, [evidence(matches=False)])
+    assert receipt.state is ActionState.ROLLBACK_REQUIRED
+
+
+def test_modify_canon_never_self_authorizes_even_with_approval_id():
+    controller = AgenticExecutionController()
+    action = request(
+        operation=ActionOperation.MODIFY_CANON,
+        domain=ActionDomain.INTERNAL,
+        idempotency_key="canon",
+        human_approval_id="human-approval",
+    )
+    receipt = controller.authorize(action)
+    assert receipt.state is ActionState.BLOCKED
+    assert "cannot self-authorize" in receipt.reason

--- a/runtime/agentic_omega/test_execution_control.py
+++ b/runtime/agentic_omega/test_execution_control.py
@@ -17,6 +17,20 @@ from runtime.agentic_omega.execution_control import (
 NOW = datetime.now(timezone.utc).isoformat()
 
 
+class MemoryLedger:
+    def __init__(self):
+        self._events = []
+
+    @property
+    def events(self):
+        return tuple(self._events)
+
+    def append(self, event_type, payload):
+        event = {"event_type": event_type, "payload": payload}
+        self._events.append(event)
+        return event
+
+
 def request(**overrides):
     base = dict(
         objective="update reversible internal state",
@@ -192,3 +206,29 @@ def test_modify_canon_never_self_authorizes_even_with_approval_id():
     receipt = controller.authorize(action)
     assert receipt.state is ActionState.BLOCKED
     assert "cannot self-authorize" in receipt.reason
+
+
+def test_executed_unverified_action_can_be_recovered_and_verified_after_restart():
+    ledger = MemoryLedger()
+    first_process = AgenticExecutionController(ledger)
+    action = request(idempotency_key="restart-continuity")
+    first_process.authorize(action)
+    first_process.mark_executed(action.action_id, execution_reference="tool-receipt-128")
+
+    restarted = AgenticExecutionController(ledger)
+    assert restarted.receipt(action.action_id).state is ActionState.EXECUTED_UNVERIFIED
+    verified = restarted.verify(action.action_id, [evidence()])
+    assert verified.state is ActionState.VERIFIED_COMPLETE
+
+
+def test_idempotency_binding_survives_controller_restart():
+    ledger = MemoryLedger()
+    first_process = AgenticExecutionController(ledger)
+    original = request(idempotency_key="restart-duplicate")
+    assert first_process.authorize(original).state is ActionState.AUTHORIZED
+
+    restarted = AgenticExecutionController(ledger)
+    duplicate = request(idempotency_key="restart-duplicate")
+    receipt = restarted.authorize(duplicate)
+    assert receipt.state is ActionState.BLOCKED
+    assert receipt.reason.startswith("DUPLICATE_ACTION")

--- a/src/atlas/algorithm/e5-control-policy-omega.test.ts
+++ b/src/atlas/algorithm/e5-control-policy-omega.test.ts
@@ -14,6 +14,11 @@ describe('E5 Control Ω policy', () => {
     expect(E5_CONTROL_POLICY_OMEGA.invariants.noPermissionImpliedByAnother).toBe(true);
   });
 
+  it('does not let autonomy level expand component permissions', () => {
+    expect(E5_CONTROL_POLICY_OMEGA.invariants.autonomyLevelCannotExpandComponentPermissions).toBe(true);
+    expect(E5_CONTROL_POLICY_OMEGA.agenticAutonomy.status).toBe('CONTROL_POLICY_DOES_NOT_AUTO_PROMOTE_RUNTIME_AUTONOMY');
+  });
+
   it('requires human approval for scheduling/delegation in E5', () => {
     expect(E5_CONTROL_POLICY_OMEGA.componentPermissions.E5_CONTROL.SCHEDULE).toBe('HUMAN_APPROVAL_REQUIRED');
     expect(E5_CONTROL_POLICY_OMEGA.componentPermissions.E5_CONTROL.DELEGATE).toBe('HUMAN_APPROVAL_REQUIRED');
@@ -21,6 +26,30 @@ describe('E5 Control Ω policy', () => {
 
   it('keeps E4 decision from directly executing', () => {
     expect(E5_CONTROL_POLICY_OMEGA.componentPermissions.E4_DECISION.EXECUTE).toBe('DENY');
+  });
+
+  it('defines L0-L4 without granting automatic L4 authority', () => {
+    expect(Object.keys(E5_CONTROL_POLICY_OMEGA.agenticAutonomy.levels)).toEqual([
+      'L0_READ_ONLY',
+      'L1_PROPOSE',
+      'L2_SAFE_WRITE',
+      'L3_CONTROLLED_EXECUTION',
+      'L4_HUMAN_APPROVAL_REQUIRED',
+    ]);
+    expect(E5_CONTROL_POLICY_OMEGA.agenticAutonomy.levels.L4_HUMAN_APPROVAL_REQUIRED.humanApproval).toBe(true);
+    expect(E5_CONTROL_POLICY_OMEGA.agenticAutonomy.mandatoryL4Domains).toContain('FINANCIAL');
+    expect(E5_CONTROL_POLICY_OMEGA.agenticAutonomy.mandatoryL4Domains).toContain('LEGAL');
+    expect(E5_CONTROL_POLICY_OMEGA.agenticAutonomy.mandatoryL4Domains).toContain('MEDICAL');
+  });
+
+  it('never accepts agent narrative as proof of external completion', () => {
+    const verification = E5_CONTROL_POLICY_OMEGA.agenticAutonomy.verification;
+    expect(verification.executionClaimIsNotCompletionEvidence).toBe(true);
+    expect(verification.verifiedCompleteRequiresDeclaredPostconditions).toBe(true);
+    expect(verification.verifiedCompleteRequiresIndependentReadback).toBe(true);
+    expect(verification.modelSelfReportCannotVerifyCompletion).toBe(true);
+    expect(verification.duplicateExecutionAttemptsFailClosed).toBe(true);
+    expect(verification.unknownPostStateNeverMeansComplete).toBe(true);
   });
 
   it('defines all eight verified shutdown requirements', () => {

--- a/src/atlas/algorithm/e5-control-policy-omega.ts
+++ b/src/atlas/algorithm/e5-control-policy-omega.ts
@@ -1,4 +1,4 @@
-export const E5_CONTROL_POLICY_OMEGA_VERSION = '2026-09-07-v1.0.0' as const;
+export const E5_CONTROL_POLICY_OMEGA_VERSION = '2026-09-07-v1.1.0' as const;
 
 export const ATLAS_PERMISSIONS = [
   'READ',
@@ -27,6 +27,7 @@ export const E5_CONTROL_POLICY_OMEGA = {
     executeDoesNotImplySchedule: true,
     communicateDoesNotImplyDelegate: true,
     predictiveAccuracyCannotExpandPermissions: true,
+    autonomyLevelCannotExpandComponentPermissions: true,
     automaticCanonWriteForbidden: true,
     liveMaterialActionRequiresSpecificHumanApproval: true,
   },
@@ -70,6 +71,57 @@ export const E5_CONTROL_POLICY_OMEGA = {
     MONITOR: {
       READ: 'ALLOW', WRITE: 'ALLOW', EXECUTE: 'ALLOW', COMMUNICATE: 'ALLOW',
       PERSIST: 'ALLOW', SCHEDULE: 'DENY', DELEGATE: 'DENY', ...denyAutomaticCanonWrite,
+    },
+  },
+  agenticAutonomy: {
+    status: 'CONTROL_POLICY_DOES_NOT_AUTO_PROMOTE_RUNTIME_AUTONOMY',
+    runtimeReference: 'runtime/agentic_omega/execution_control.py',
+    levels: {
+      L0_READ_ONLY: {
+        authority: 'READ_ONLY',
+        externalMutation: false,
+        humanApproval: false,
+      },
+      L1_PROPOSE: {
+        authority: 'PREPARE_ACTION_NO_EXECUTION',
+        externalMutation: false,
+        humanApproval: false,
+      },
+      L2_SAFE_WRITE: {
+        authority: 'REVERSIBLE_LOW_IMPACT_WRITE',
+        externalMutation: true,
+        humanApproval: false,
+        requiresCompensationPlan: true,
+      },
+      L3_CONTROLLED_EXECUTION: {
+        authority: 'MATERIAL_EXECUTION_WITH_E5_GATES_AND_E6_VERIFICATION',
+        externalMutation: true,
+        humanApproval: 'POLICY_DEPENDENT',
+      },
+      L4_HUMAN_APPROVAL_REQUIRED: {
+        authority: 'HIGH_IMPACT_OR_SOVEREIGN_ACTION',
+        externalMutation: true,
+        humanApproval: true,
+      },
+    },
+    mandatoryL4Domains: [
+      'EXTERNAL',
+      'FINANCIAL',
+      'LEGAL',
+      'MEDICAL',
+      'CREDENTIAL',
+      'PRODUCTION',
+    ],
+    verification: {
+      executionClaimIsNotCompletionEvidence: true,
+      verifiedCompleteRequiresDeclaredPostconditions: true,
+      verifiedCompleteRequiresIndependentReadback: true,
+      modelSelfReportCannotVerifyCompletion: true,
+      writesRequireIdempotencyKey: true,
+      duplicateExecutionAttemptsFailClosed: true,
+      unknownPostStateNeverMeansComplete: true,
+      reversibleFailureRequiresRollbackState: true,
+      staleOrUnknownMaterialPreStateFailsClosed: true,
     },
   },
   protectedObjects: [


### PR DESCRIPTION
Closes #188.

## Point Zero finding
ATLAS already had E1–E6, E5 permissions, exact-route capability evidence, durable ledgers and decision OutcomeReceipts. The missing non-redundant control was the execution boundary itself: no executable contract prevented a tool/model execution claim from being promoted to completed external state without independent readback.

## Changes
- add `runtime/agentic_omega/execution_control.py` with an E5/E6 action state machine;
- encode L0 READ ONLY → L4 HUMAN APPROVAL REQUIRED in E5 without creating a new engine;
- promote risk upward automatically (model/request cannot downgrade required authority);
- require human approval for external, financial, legal, medical, credential and production domains;
- require idempotency for write/execution paths;
- fail closed on stale/UNKNOWN material pre-state;
- keep `EXECUTED_UNVERIFIED` distinct from `VERIFIED_COMPLETE`;
- forbid `MODEL_SELF_REPORT` as post-state evidence;
- require all declared postconditions to be independently read back;
- surface `UNKNOWN_POSTSTATE` and `ROLLBACK_REQUIRED` recovery states;
- keep `MODIFY_CANON` outside agentic self-authorization;
- add 12 adversarial Python tests and extend E5 contract tests;
- wire the Python suite into Architecture Consolidation CI.

## Evidence status
- local isolated Python suite: 12/12 PASS before push;
- GitHub CI: pending at PR creation;
- main: unchanged;
- LIVE/runtime production: not claimed.

## Architecture boundary
This is E5 CONTROL + E6 ASSURANCE infrastructure. It does not decide what ATLAS should do, does not give E4 execution authority, does not auto-promote autonomy, and does not make Astra part of ATLAS identity.